### PR TITLE
Wait for weaviate

### DIFF
--- a/test/auth/auth_mock_test.go
+++ b/test/auth/auth_mock_test.go
@@ -73,12 +73,13 @@ func TestAuthMock_NoRefreshToken(t *testing.T) {
 			})
 			s := httptest.NewServer(mux)
 			defer s.Close()
-
-			cfg, err := weaviate.NewConfig(strings.TrimPrefix(s.URL, "http://"), "http", tc.authConfig, nil)
+			cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
+			var err error
+			cfg, err = weaviate.AddAuthClient(cfg, tc.authConfig, 5)
 			assert.Nil(t, err)
 			assert.True(t, strings.Contains(buf.String(), "Auth002"))
 
-			client := weaviate.New(*cfg)
+			client := weaviate.New(cfg)
 			AuthErr := client.Schema().AllDeleter().Do(context.TODO())
 			assert.Nil(t, AuthErr)
 		})
@@ -119,18 +120,19 @@ func TestAuthMock_RefreshCC(t *testing.T) {
 	})
 	s := httptest.NewServer(mux)
 	defer s.Close()
-
-	cfg, err := weaviate.NewConfig(strings.TrimPrefix(s.URL, "http://"), "http", auth.ClientCredentials{ClientSecret: "SecretValue"}, nil)
+	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
+	var err error
+	cfg, err = weaviate.AddAuthClient(cfg, auth.ClientCredentials{ClientSecret: "SecretValue"}, 5)
 	assert.Nil(t, err)
-	client := weaviate.New(*cfg)
+	client := weaviate.New(cfg)
 	AuthErr := client.Schema().AllDeleter().Do(context.TODO())
 	assert.Nil(t, AuthErr)
-	assert.Equal(t, i, 4) // client does 4 initial calls to token endpoint
+	assert.Equal(t, i, 3) // client does 4 initial calls to token endpoint
 
 	time.Sleep(time.Second * 5)
 	// current token expires, so the oauth client needs to get a new one
 	AuthErr2 := client.Schema().AllDeleter().Do(context.TODO())
-	assert.Equal(t, i, 5)
+	assert.Equal(t, i, 4)
 	assert.Nil(t, AuthErr2)
 }
 
@@ -191,10 +193,11 @@ func TestAuthMock_RefreshUserPWAndToken(t *testing.T) {
 			})
 			s := httptest.NewServer(mux)
 			defer s.Close()
-
-			cfg, err := weaviate.NewConfig(strings.TrimPrefix(s.URL, "http://"), "http", tc.authConfig, nil)
+			cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
+			var err error
+			cfg, err = weaviate.AddAuthClient(cfg, tc.authConfig, 5)
 			assert.Nil(t, err)
-			client := weaviate.New(*cfg)
+			client := weaviate.New(cfg)
 			AuthErr := client.Schema().AllDeleter().Do(context.TODO())
 			assert.Nil(t, AuthErr)
 
@@ -228,10 +231,11 @@ func TestAuthMock_CatchAllProxy(t *testing.T) {
 	})
 	s := httptest.NewServer(mux)
 	defer s.Close()
-
-	cfg, err := weaviate.NewConfig(strings.TrimPrefix(s.URL, "http://"), "http", nil, nil)
+	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
+	var err error
+	cfg, err = weaviate.AddAuthClient(cfg, nil, 5)
 	assert.Nil(t, err)
-	client := weaviate.New(*cfg)
+	client := weaviate.New(cfg)
 	AuthErr := client.Schema().AllDeleter().Do(context.TODO())
 	assert.Nil(t, AuthErr)
 }
@@ -273,10 +277,11 @@ func TestAuthMock_CheckDefaultScopes(t *testing.T) {
 	})
 	s := httptest.NewServer(mux)
 	defer s.Close()
-
-	cfg, err := weaviate.NewConfig(strings.TrimPrefix(s.URL, "http://"), "http", auth.ClientCredentials{ClientSecret: "SecretValue"}, nil)
+	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
+	var err error
+	cfg, err = weaviate.AddAuthClient(cfg, auth.ClientCredentials{ClientSecret: "SecretValue"}, 5)
 	assert.Nil(t, err)
-	client := weaviate.New(*cfg)
+	client := weaviate.New(cfg)
 	AuthErr := client.Schema().AllDeleter().Do(context.TODO())
 	assert.Nil(t, AuthErr)
 }

--- a/test/auth/auth_mock_test.go
+++ b/test/auth/auth_mock_test.go
@@ -68,6 +68,9 @@ func TestAuthMock_NoRefreshToken(t *testing.T) {
 			mux.HandleFunc("/v1/schema", func(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte(`{}`))
 			})
+			mux.HandleFunc("/v1/.well-known/ready", func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(`{}`))
+			})
 			s := httptest.NewServer(mux)
 			defer s.Close()
 
@@ -111,6 +114,9 @@ func TestAuthMock_RefreshCC(t *testing.T) {
 	mux.HandleFunc("/v1/schema", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{}`))
 	})
+	mux.HandleFunc("/v1/.well-known/ready", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{}`))
+	})
 	s := httptest.NewServer(mux)
 	defer s.Close()
 
@@ -119,12 +125,12 @@ func TestAuthMock_RefreshCC(t *testing.T) {
 	client := weaviate.New(*cfg)
 	AuthErr := client.Schema().AllDeleter().Do(context.TODO())
 	assert.Nil(t, AuthErr)
-	assert.Equal(t, i, 3) // client does 3 initial calls to token endpoint
+	assert.Equal(t, i, 4) // client does 4 initial calls to token endpoint
 
 	time.Sleep(time.Second * 5)
 	// current token expires, so the oauth client needs to get a new one
 	AuthErr2 := client.Schema().AllDeleter().Do(context.TODO())
-	assert.Equal(t, i, 4)
+	assert.Equal(t, i, 5)
 	assert.Nil(t, AuthErr2)
 }
 
@@ -180,6 +186,9 @@ func TestAuthMock_RefreshUserPWAndToken(t *testing.T) {
 				assert.True(t, time.Now().Sub(tokenRefreshTime).Seconds() < float64(expirationTimeToken))
 				w.Write([]byte(`{}`))
 			})
+			mux.HandleFunc("/v1/.well-known/ready", func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(`{}`))
+			})
 			s := httptest.NewServer(mux)
 			defer s.Close()
 
@@ -212,6 +221,9 @@ func TestAuthMock_CatchAllProxy(t *testing.T) {
 		w.Write([]byte(`NotAValidJsonResponse`))
 	})
 	mux.HandleFunc("/v1/schema", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("/v1/.well-known/ready", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{}`))
 	})
 	s := httptest.NewServer(mux)
@@ -254,6 +266,9 @@ func TestAuthMock_CheckDefaultScopes(t *testing.T) {
 		w.Write([]byte(`{"href": "` + sEndpoints.URL + `/endpoints", "clientId": "DoesNotMatter", "scopes": ["something", "extra"]}`))
 	})
 	mux.HandleFunc("/v1/schema", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("/v1/.well-known/ready", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{}`))
 	})
 	s := httptest.NewServer(mux)

--- a/test/auth/auth_mock_test.go
+++ b/test/auth/auth_mock_test.go
@@ -75,7 +75,7 @@ func TestAuthMock_NoRefreshToken(t *testing.T) {
 			defer s.Close()
 			cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
 			var err error
-			cfg, err = weaviate.AddAuthClient(cfg, tc.authConfig, 5)
+			cfg, err = weaviate.AddAuthClient(cfg, tc.authConfig, 60*time.Second)
 			assert.Nil(t, err)
 			assert.True(t, strings.Contains(buf.String(), "Auth002"))
 
@@ -122,7 +122,7 @@ func TestAuthMock_RefreshCC(t *testing.T) {
 	defer s.Close()
 	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
 	var err error
-	cfg, err = weaviate.AddAuthClient(cfg, auth.ClientCredentials{ClientSecret: "SecretValue"}, 5)
+	cfg, err = weaviate.AddAuthClient(cfg, auth.ClientCredentials{ClientSecret: "SecretValue"}, 60*time.Second)
 	assert.Nil(t, err)
 	client := weaviate.New(cfg)
 	AuthErr := client.Schema().AllDeleter().Do(context.TODO())
@@ -195,7 +195,7 @@ func TestAuthMock_RefreshUserPWAndToken(t *testing.T) {
 			defer s.Close()
 			cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
 			var err error
-			cfg, err = weaviate.AddAuthClient(cfg, tc.authConfig, 5)
+			cfg, err = weaviate.AddAuthClient(cfg, tc.authConfig, 60*time.Second)
 			assert.Nil(t, err)
 			client := weaviate.New(cfg)
 			AuthErr := client.Schema().AllDeleter().Do(context.TODO())
@@ -233,7 +233,7 @@ func TestAuthMock_CatchAllProxy(t *testing.T) {
 	defer s.Close()
 	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
 	var err error
-	cfg, err = weaviate.AddAuthClient(cfg, nil, 5)
+	cfg, err = weaviate.AddAuthClient(cfg, nil, 60*time.Second)
 	assert.Nil(t, err)
 	client := weaviate.New(cfg)
 	AuthErr := client.Schema().AllDeleter().Do(context.TODO())
@@ -279,7 +279,7 @@ func TestAuthMock_CheckDefaultScopes(t *testing.T) {
 	defer s.Close()
 	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
 	var err error
-	cfg, err = weaviate.AddAuthClient(cfg, auth.ClientCredentials{ClientSecret: "SecretValue"}, 5)
+	cfg, err = weaviate.AddAuthClient(cfg, auth.ClientCredentials{ClientSecret: "SecretValue"}, 60*time.Second)
 	assert.Nil(t, err)
 	client := weaviate.New(cfg)
 	AuthErr := client.Schema().AllDeleter().Do(context.TODO())

--- a/test/auth/auth_test.go
+++ b/test/auth/auth_test.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,7 +49,7 @@ func TestAuth_clientCredential(t *testing.T) {
 		clientCredentialConf := auth.ClientCredentials{ClientSecret: clientSecret, Scopes: tc.scope}
 		cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", tc.port), Scheme: "http"}
 		var err error
-		cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 60)
+		cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 60*time.Second)
 		assert.Nil(t, err)
 		client := weaviate.New(cfg)
 		AuthErr := client.Schema().AllDeleter().Do(context.TODO())
@@ -76,7 +77,7 @@ func TestAuth_clientCredential_WrongParameters(t *testing.T) {
 			clientCredentialConf := auth.ClientCredentials{ClientSecret: tc.secret, Scopes: tc.scope}
 			cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.OktaCCPort), Scheme: "http"}
 			var err error
-			cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 60)
+			cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 60*time.Second)
 			assert.Nil(t, err)
 			client := weaviate.New(cfg)
 			AuthErr := client.Schema().AllDeleter().Do(context.TODO())
@@ -118,7 +119,7 @@ func TestAuth_UserPW(t *testing.T) {
 				clientCredentialConf := auth.ResourceOwnerPasswordFlow{Username: tc.user, Password: pw, Scopes: tc.scope}
 				cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", tc.port), Scheme: "http"}
 				var err error
-				cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 60)
+				cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 60*time.Second)
 				assert.Nil(t, err)
 				client := weaviate.New(cfg)
 				AuthErr := client.Schema().AllDeleter().Do(context.TODO())
@@ -137,14 +138,14 @@ func TestAuth_UserPW_wrongPW(t *testing.T) {
 	clientCredentialConf := auth.ResourceOwnerPasswordFlow{Username: "SomeUsername", Password: "IamWrong"}
 	cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.WCSPort), Scheme: "http"}
 	var err error
-	_, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 60)
+	_, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 60*time.Second)
 	assert.NotNil(t, err)
 }
 
 func TestNoAuthOnWeaviateWithoutAuth(t *testing.T) {
 	cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.NoAuthPort), Scheme: "http"}
 	var err error
-	cfg, err = weaviate.AddAuthClient(cfg, nil, 60)
+	cfg, err = weaviate.AddAuthClient(cfg, nil, 60*time.Second)
 	assert.Nil(t, err)
 	client := weaviate.New(cfg)
 
@@ -155,7 +156,7 @@ func TestNoAuthOnWeaviateWithoutAuth(t *testing.T) {
 func TestNoAuthOnWeaviateWithAuth(t *testing.T) {
 	cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.WCSPort), Scheme: "http"}
 	var err error
-	cfg, err = weaviate.AddAuthClient(cfg, nil, 60)
+	cfg, err = weaviate.AddAuthClient(cfg, nil, 60*time.Second)
 	assert.Nil(t, err)
 	client := weaviate.New(cfg)
 
@@ -185,7 +186,7 @@ func TestAuthOnWeaviateWithoutAuth(t *testing.T) {
 			}()
 			cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.NoAuthPort), Scheme: "http"}
 			var err error
-			cfg, err = weaviate.AddAuthClient(cfg, tc.authConfig, 60)
+			cfg, err = weaviate.AddAuthClient(cfg, tc.authConfig, 60*time.Second)
 			assert.Nil(t, err)
 			assert.True(t, strings.Contains(buf.String(), "The client was configured to use authentication"))
 
@@ -224,7 +225,7 @@ func TestAuthBearerToken(t *testing.T) {
 			accessToken, refreshToken := getAccessToken(t, url, tc.user, pw)
 			cfg := weaviate.Config{Host: url, Scheme: "http"}
 			var err error
-			cfg, err = weaviate.AddAuthClient(cfg, auth.BearerToken{AccessToken: accessToken, RefreshToken: refreshToken}, 60)
+			cfg, err = weaviate.AddAuthClient(cfg, auth.BearerToken{AccessToken: accessToken, RefreshToken: refreshToken}, 60*time.Second)
 			assert.Nil(t, err)
 
 			client := weaviate.New(cfg)

--- a/test/auth/auth_test.go
+++ b/test/auth/auth_test.go
@@ -199,7 +199,7 @@ func TestAuthOnWeaviateWithoutAuth(t *testing.T) {
 func TestAuthNoWeaviateOnPort(t *testing.T) {
 	cfg := weaviate.Config{Host: "localhost:" + fmt.Sprint(testsuit.NoWeaviatePort), Scheme: "http"}
 	var err error
-	_, err = weaviate.AddAuthClient(cfg, auth.ResourceOwnerPasswordFlow{Username: "SomeUsername", Password: "IamWrong"}, 60)
+	_, err = weaviate.AddAuthClient(cfg, auth.ResourceOwnerPasswordFlow{Username: "SomeUsername", Password: "IamWrong"}, 0)
 	assert.NotNil(t, err)
 }
 

--- a/test/auth/auth_test.go
+++ b/test/auth/auth_test.go
@@ -48,7 +48,7 @@ func TestAuth_clientCredential(t *testing.T) {
 		clientCredentialConf := auth.ClientCredentials{ClientSecret: clientSecret, Scopes: tc.scope}
 		cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", tc.port), Scheme: "http"}
 		var err error
-		cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 20)
+		cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 60)
 		assert.Nil(t, err)
 		client := weaviate.New(cfg)
 		AuthErr := client.Schema().AllDeleter().Do(context.TODO())
@@ -76,7 +76,7 @@ func TestAuth_clientCredential_WrongParameters(t *testing.T) {
 			clientCredentialConf := auth.ClientCredentials{ClientSecret: tc.secret, Scopes: tc.scope}
 			cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.OktaCCPort), Scheme: "http"}
 			var err error
-			cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 20)
+			cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 60)
 			assert.Nil(t, err)
 			client := weaviate.New(cfg)
 			AuthErr := client.Schema().AllDeleter().Do(context.TODO())
@@ -118,7 +118,7 @@ func TestAuth_UserPW(t *testing.T) {
 				clientCredentialConf := auth.ResourceOwnerPasswordFlow{Username: tc.user, Password: pw, Scopes: tc.scope}
 				cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", tc.port), Scheme: "http"}
 				var err error
-				cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 20)
+				cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 60)
 				assert.Nil(t, err)
 				client := weaviate.New(cfg)
 				AuthErr := client.Schema().AllDeleter().Do(context.TODO())
@@ -137,14 +137,14 @@ func TestAuth_UserPW_wrongPW(t *testing.T) {
 	clientCredentialConf := auth.ResourceOwnerPasswordFlow{Username: "SomeUsername", Password: "IamWrong"}
 	cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.WCSPort), Scheme: "http"}
 	var err error
-	_, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 20)
+	_, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 60)
 	assert.NotNil(t, err)
 }
 
 func TestNoAuthOnWeaviateWithoutAuth(t *testing.T) {
 	cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.NoAuthPort), Scheme: "http"}
 	var err error
-	cfg, err = weaviate.AddAuthClient(cfg, nil, 20)
+	cfg, err = weaviate.AddAuthClient(cfg, nil, 60)
 	assert.Nil(t, err)
 	client := weaviate.New(cfg)
 
@@ -155,7 +155,7 @@ func TestNoAuthOnWeaviateWithoutAuth(t *testing.T) {
 func TestNoAuthOnWeaviateWithAuth(t *testing.T) {
 	cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.WCSPort), Scheme: "http"}
 	var err error
-	cfg, err = weaviate.AddAuthClient(cfg, nil, 20)
+	cfg, err = weaviate.AddAuthClient(cfg, nil, 60)
 	assert.Nil(t, err)
 	client := weaviate.New(cfg)
 
@@ -185,7 +185,7 @@ func TestAuthOnWeaviateWithoutAuth(t *testing.T) {
 			}()
 			cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.NoAuthPort), Scheme: "http"}
 			var err error
-			cfg, err = weaviate.AddAuthClient(cfg, tc.authConfig, 20)
+			cfg, err = weaviate.AddAuthClient(cfg, tc.authConfig, 60)
 			assert.Nil(t, err)
 			assert.True(t, strings.Contains(buf.String(), "The client was configured to use authentication"))
 
@@ -199,7 +199,7 @@ func TestAuthOnWeaviateWithoutAuth(t *testing.T) {
 func TestAuthNoWeaviateOnPort(t *testing.T) {
 	cfg := weaviate.Config{Host: "localhost:" + fmt.Sprint(testsuit.NoWeaviatePort), Scheme: "http"}
 	var err error
-	_, err = weaviate.AddAuthClient(cfg, auth.ResourceOwnerPasswordFlow{Username: "SomeUsername", Password: "IamWrong"}, 20)
+	_, err = weaviate.AddAuthClient(cfg, auth.ResourceOwnerPasswordFlow{Username: "SomeUsername", Password: "IamWrong"}, 60)
 	assert.NotNil(t, err)
 }
 
@@ -224,7 +224,7 @@ func TestAuthBearerToken(t *testing.T) {
 			accessToken, refreshToken := getAccessToken(t, url, tc.user, pw)
 			cfg := weaviate.Config{Host: url, Scheme: "http"}
 			var err error
-			cfg, err = weaviate.AddAuthClient(cfg, auth.BearerToken{AccessToken: accessToken, RefreshToken: refreshToken}, 20)
+			cfg, err = weaviate.AddAuthClient(cfg, auth.BearerToken{AccessToken: accessToken, RefreshToken: refreshToken}, 60)
 			assert.Nil(t, err)
 
 			client := weaviate.New(cfg)

--- a/test/auth/auth_test.go
+++ b/test/auth/auth_test.go
@@ -48,7 +48,7 @@ func TestAuth_clientCredential(t *testing.T) {
 		clientCredentialConf := auth.ClientCredentials{ClientSecret: clientSecret, Scopes: tc.scope}
 		cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", tc.port), Scheme: "http"}
 		var err error
-		cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 5)
+		cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 20)
 		assert.Nil(t, err)
 		client := weaviate.New(cfg)
 		AuthErr := client.Schema().AllDeleter().Do(context.TODO())
@@ -76,7 +76,7 @@ func TestAuth_clientCredential_WrongParameters(t *testing.T) {
 			clientCredentialConf := auth.ClientCredentials{ClientSecret: tc.secret, Scopes: tc.scope}
 			cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.OktaCCPort), Scheme: "http"}
 			var err error
-			cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 5)
+			cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 20)
 			assert.Nil(t, err)
 			client := weaviate.New(cfg)
 			AuthErr := client.Schema().AllDeleter().Do(context.TODO())
@@ -118,7 +118,7 @@ func TestAuth_UserPW(t *testing.T) {
 				clientCredentialConf := auth.ResourceOwnerPasswordFlow{Username: tc.user, Password: pw, Scopes: tc.scope}
 				cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", tc.port), Scheme: "http"}
 				var err error
-				cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 5)
+				cfg, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 20)
 				assert.Nil(t, err)
 				client := weaviate.New(cfg)
 				AuthErr := client.Schema().AllDeleter().Do(context.TODO())
@@ -137,14 +137,14 @@ func TestAuth_UserPW_wrongPW(t *testing.T) {
 	clientCredentialConf := auth.ResourceOwnerPasswordFlow{Username: "SomeUsername", Password: "IamWrong"}
 	cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.WCSPort), Scheme: "http"}
 	var err error
-	_, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 5)
+	_, err = weaviate.AddAuthClient(cfg, clientCredentialConf, 20)
 	assert.NotNil(t, err)
 }
 
 func TestNoAuthOnWeaviateWithoutAuth(t *testing.T) {
 	cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.NoAuthPort), Scheme: "http"}
 	var err error
-	cfg, err = weaviate.AddAuthClient(cfg, nil, 5)
+	cfg, err = weaviate.AddAuthClient(cfg, nil, 20)
 	assert.Nil(t, err)
 	client := weaviate.New(cfg)
 
@@ -155,7 +155,7 @@ func TestNoAuthOnWeaviateWithoutAuth(t *testing.T) {
 func TestNoAuthOnWeaviateWithAuth(t *testing.T) {
 	cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.WCSPort), Scheme: "http"}
 	var err error
-	cfg, err = weaviate.AddAuthClient(cfg, nil, 5)
+	cfg, err = weaviate.AddAuthClient(cfg, nil, 20)
 	assert.Nil(t, err)
 	client := weaviate.New(cfg)
 
@@ -185,7 +185,7 @@ func TestAuthOnWeaviateWithoutAuth(t *testing.T) {
 			}()
 			cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.NoAuthPort), Scheme: "http"}
 			var err error
-			cfg, err = weaviate.AddAuthClient(cfg, tc.authConfig, 5)
+			cfg, err = weaviate.AddAuthClient(cfg, tc.authConfig, 20)
 			assert.Nil(t, err)
 			assert.True(t, strings.Contains(buf.String(), "The client was configured to use authentication"))
 
@@ -199,7 +199,7 @@ func TestAuthOnWeaviateWithoutAuth(t *testing.T) {
 func TestAuthNoWeaviateOnPort(t *testing.T) {
 	cfg := weaviate.Config{Host: "localhost:" + fmt.Sprint(testsuit.NoWeaviatePort), Scheme: "http"}
 	var err error
-	_, err = weaviate.AddAuthClient(cfg, auth.ResourceOwnerPasswordFlow{Username: "SomeUsername", Password: "IamWrong"}, 5)
+	_, err = weaviate.AddAuthClient(cfg, auth.ResourceOwnerPasswordFlow{Username: "SomeUsername", Password: "IamWrong"}, 20)
 	assert.NotNil(t, err)
 }
 
@@ -224,7 +224,7 @@ func TestAuthBearerToken(t *testing.T) {
 			accessToken, refreshToken := getAccessToken(t, url, tc.user, pw)
 			cfg := weaviate.Config{Host: url, Scheme: "http"}
 			var err error
-			cfg, err = weaviate.AddAuthClient(cfg, auth.BearerToken{AccessToken: accessToken, RefreshToken: refreshToken}, 5)
+			cfg, err = weaviate.AddAuthClient(cfg, auth.BearerToken{AccessToken: accessToken, RefreshToken: refreshToken}, 20)
 			assert.Nil(t, err)
 
 			client := weaviate.New(cfg)

--- a/test/misc/misc_test.go
+++ b/test/misc/misc_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate-go-client/v4/test/testsuit"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate"
 	"github.com/weaviate/weaviate-go-client/v4/weaviate/testenv"
 )
 
@@ -66,5 +67,33 @@ func TestMisc_integration(t *testing.T) {
 			fmt.Printf(err.Error())
 			t.Fail()
 		}
+	})
+}
+
+func TestMisc_connection_error(t *testing.T) {
+	t.Run("ready", func(t *testing.T) {
+		cfg := weaviate.Config{
+			Host:   "localhorst",
+			Scheme: "http",
+		}
+
+		client := weaviate.New(cfg)
+		isReady, err := client.Misc().ReadyChecker().Do(context.Background())
+
+		assert.NotNil(t, err)
+		assert.False(t, isReady)
+	})
+
+	t.Run("live", func(t *testing.T) {
+		cfg := weaviate.Config{
+			Host:   "localhorst",
+			Scheme: "http",
+		}
+
+		client := weaviate.New(cfg)
+		isReady, err := client.Misc().LiveChecker().Do(context.Background())
+
+		assert.NotNil(t, err)
+		assert.False(t, isReady)
 	})
 }

--- a/test/misc/misc_test.go
+++ b/test/misc/misc_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate-go-client/v4/test/testsuit"
-	"github.com/weaviate/weaviate-go-client/v4/weaviate"
 	"github.com/weaviate/weaviate-go-client/v4/weaviate/testenv"
 )
 
@@ -67,33 +66,5 @@ func TestMisc_integration(t *testing.T) {
 			fmt.Printf(err.Error())
 			t.Fail()
 		}
-	})
-}
-
-func TestMisc_connection_error(t *testing.T) {
-	t.Run("ready", func(t *testing.T) {
-		cfg := weaviate.Config{
-			Host:   "localhorst",
-			Scheme: "http",
-		}
-
-		client := weaviate.New(cfg)
-		isReady, err := client.Misc().ReadyChecker().Do(context.Background())
-
-		assert.NotNil(t, err)
-		assert.False(t, isReady)
-	})
-
-	t.Run("live", func(t *testing.T) {
-		cfg := weaviate.Config{
-			Host:   "localhorst",
-			Scheme: "http",
-		}
-
-		client := weaviate.New(cfg)
-		isReady, err := client.Misc().LiveChecker().Do(context.Background())
-
-		assert.NotNil(t, err)
-		assert.False(t, isReady)
 	})
 }

--- a/test/misc/misc_version_check_test.go
+++ b/test/misc/misc_version_check_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate-go-client/v4/test/testsuit"
@@ -33,7 +34,7 @@ func TestMisc_version_check(t *testing.T) {
 			t.Fail()
 		}
 	})
-	client.WaitForWeavaite(60)
+	client.WaitForWeavaite(time.Second * 60)
 	t.Run("Weaviate is live, perform ready check", func(t *testing.T) {
 		isReady, err := client.Misc().ReadyChecker().Do(context.Background())
 		assert.Nil(t, err)
@@ -98,7 +99,7 @@ func TestMisc_empty_version_check(t *testing.T) {
 			t.Fail()
 		}
 	})
-	client.WaitForWeavaite(60)
+	client.WaitForWeavaite(60 * time.Second)
 	t.Run("Create sample schema food, try to perform queries using /v1/objects?class={className}", func(t *testing.T) {
 		testsuit.CreateWeaviateTestSchemaFood(t, client)
 

--- a/test/misc/misc_version_check_test.go
+++ b/test/misc/misc_version_check_test.go
@@ -11,15 +11,6 @@ import (
 )
 
 func TestMisc_version_check(t *testing.T) {
-	// needs to be the same client for the whole test
-	client := testsuit.CreateTestClient(8080, nil)
-
-	t.Run("Weaviate is not live, perform live check", func(t *testing.T) {
-		isReady, err := client.Misc().ReadyChecker().Do(context.Background())
-		assert.NotNil(t, err)
-		assert.False(t, isReady)
-	})
-
 	t.Run("Start Weaviate", func(t *testing.T) {
 		err := testenv.SetupLocalWeaviate()
 		if err != nil {
@@ -27,6 +18,9 @@ func TestMisc_version_check(t *testing.T) {
 			t.Fail()
 		}
 	})
+
+	// needs to be the same client for the whole test
+	client := testsuit.CreateTestClient(8080, nil)
 
 	t.Run("Weaviate is live, perform ready check", func(t *testing.T) {
 		isReady, err := client.Misc().ReadyChecker().Do(context.Background())
@@ -70,15 +64,6 @@ func TestMisc_version_check(t *testing.T) {
 }
 
 func TestMisc_empty_version_check(t *testing.T) {
-	// needs to be the same client for the whole test
-	client := testsuit.CreateTestClient(8080, nil)
-
-	t.Run("Weaviate is not live, perform live check", func(t *testing.T) {
-		isReady, err := client.Misc().ReadyChecker().Do(context.Background())
-		assert.NotNil(t, err)
-		assert.False(t, isReady)
-	})
-
 	t.Run("Start Weaviate", func(t *testing.T) {
 		err := testenv.SetupLocalWeaviate()
 		if err != nil {
@@ -86,6 +71,9 @@ func TestMisc_empty_version_check(t *testing.T) {
 			t.Fail()
 		}
 	})
+
+	// needs to be the same client for the whole test
+	client := testsuit.CreateTestClient(8080, nil)
 
 	t.Run("Create sample schema food, try to perform queries using /v1/objects?class={className}", func(t *testing.T) {
 		testsuit.CreateWeaviateTestSchemaFood(t, client)

--- a/test/misc/misc_version_check_test.go
+++ b/test/misc/misc_version_check_test.go
@@ -7,10 +7,25 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate-go-client/v4/test/testsuit"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate"
 	"github.com/weaviate/weaviate-go-client/v4/weaviate/testenv"
 )
 
 func TestMisc_version_check(t *testing.T) {
+	cfg := &weaviate.Config{
+		Host:    "localhost:8080",
+		Scheme:  "http",
+		Headers: map[string]string{},
+	}
+
+	client := weaviate.New(*cfg)
+
+	t.Run("Weaviate is not live, perform live check", func(t *testing.T) {
+		isReady, err := client.Misc().ReadyChecker().Do(context.Background())
+		assert.NotNil(t, err)
+		assert.False(t, isReady)
+	})
+
 	t.Run("Start Weaviate", func(t *testing.T) {
 		err := testenv.SetupLocalWeaviate()
 		if err != nil {
@@ -18,10 +33,7 @@ func TestMisc_version_check(t *testing.T) {
 			t.Fail()
 		}
 	})
-
-	// needs to be the same client for the whole test
-	client := testsuit.CreateTestClient(8080, nil)
-
+	client.WaitForWeavaite(60)
 	t.Run("Weaviate is live, perform ready check", func(t *testing.T) {
 		isReady, err := client.Misc().ReadyChecker().Do(context.Background())
 		assert.Nil(t, err)
@@ -64,6 +76,21 @@ func TestMisc_version_check(t *testing.T) {
 }
 
 func TestMisc_empty_version_check(t *testing.T) {
+	// needs to be the same client for the whole test
+	cfg := &weaviate.Config{
+		Host:    "localhost:8080",
+		Scheme:  "http",
+		Headers: map[string]string{},
+	}
+
+	client := weaviate.New(*cfg)
+
+	t.Run("Weaviate is not live, perform live check", func(t *testing.T) {
+		isReady, err := client.Misc().ReadyChecker().Do(context.Background())
+		assert.NotNil(t, err)
+		assert.False(t, isReady)
+	})
+
 	t.Run("Start Weaviate", func(t *testing.T) {
 		err := testenv.SetupLocalWeaviate()
 		if err != nil {
@@ -71,10 +98,7 @@ func TestMisc_empty_version_check(t *testing.T) {
 			t.Fail()
 		}
 	})
-
-	// needs to be the same client for the whole test
-	client := testsuit.CreateTestClient(8080, nil)
-
+	client.WaitForWeavaite(60)
 	t.Run("Create sample schema food, try to perform queries using /v1/objects?class={className}", func(t *testing.T) {
 		testsuit.CreateWeaviateTestSchemaFood(t, client)
 

--- a/test/mock/wait_for_weaviate_test.go
+++ b/test/mock/wait_for_weaviate_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate-go-client/v4/weaviate"
@@ -21,7 +22,7 @@ func TestWaitForWeaviate(t *testing.T) {
 
 	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
 	client := weaviate.New(cfg)
-	err := client.WaitForWeavaite(60)
+	err := client.WaitForWeavaite(60 * time.Second)
 	assert.Nil(t, err)
 }
 
@@ -33,6 +34,6 @@ func TestWaitForWeaviate_NoConnection(t *testing.T) {
 
 	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
 	client := weaviate.New(cfg)
-	err := client.WaitForWeavaite(5)
+	err := client.WaitForWeavaite(5 * time.Second)
 	assert.NotNil(t, err)
 }

--- a/test/mock/wait_for_weaviate_test.go
+++ b/test/mock/wait_for_weaviate_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestWaitForWeaviate(t *testing.T) {
-	// Returns the address of the auth server
+	// Tests the WaitForWeaviate function if a connection can be established
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/.well-known/ready", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{}`))
@@ -26,7 +26,7 @@ func TestWaitForWeaviate(t *testing.T) {
 }
 
 func TestWaitForWeaviate_NoConnection(t *testing.T) {
-	// Returns the address of the auth server
+	// Tests the WaitForWeaviate function if no connection can be established
 	mux := http.NewServeMux()
 	s := httptest.NewServer(mux)
 	defer s.Close()

--- a/test/mock/wait_for_weaviate_test.go
+++ b/test/mock/wait_for_weaviate_test.go
@@ -21,7 +21,7 @@ func TestWaitForWeaviate(t *testing.T) {
 
 	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
 	client := weaviate.New(cfg)
-	err := client.WaitForWeavaite(5)
+	err := client.WaitForWeavaite(60)
 	assert.Nil(t, err)
 }
 

--- a/test/mock/wait_for_weaviate_test.go
+++ b/test/mock/wait_for_weaviate_test.go
@@ -1,0 +1,38 @@
+package connection
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate"
+)
+
+func TestWaitForWeaviate(t *testing.T) {
+	// Returns the address of the auth server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/.well-known/ready", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{}`))
+	})
+	s := httptest.NewServer(mux)
+	defer s.Close()
+
+	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
+	client := weaviate.New(cfg)
+	err := client.WaitForWeavaite(5)
+	assert.Nil(t, err)
+}
+
+func TestWaitForWeaviate_NoConnection(t *testing.T) {
+	// Returns the address of the auth server
+	mux := http.NewServeMux()
+	s := httptest.NewServer(mux)
+	defer s.Close()
+
+	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
+	client := weaviate.New(cfg)
+	err := client.WaitForWeavaite(5)
+	assert.NotNil(t, err)
+}

--- a/test/testsuit/generics.go
+++ b/test/testsuit/generics.go
@@ -179,6 +179,7 @@ func CreateTestClient(port int, connectionClient *http.Client) *weaviate.Client 
 		}
 	}
 	client := weaviate.New(*cfg)
+	client.WaitForWeavaite(20)
 	return client
 }
 

--- a/test/testsuit/generics.go
+++ b/test/testsuit/generics.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
@@ -179,7 +180,7 @@ func CreateTestClient(port int, connectionClient *http.Client) *weaviate.Client 
 		}
 	}
 	client := weaviate.New(*cfg)
-	client.WaitForWeavaite(60)
+	client.WaitForWeavaite(60 * time.Second)
 	return client
 }
 

--- a/test/testsuit/generics.go
+++ b/test/testsuit/generics.go
@@ -179,7 +179,7 @@ func CreateTestClient(port int, connectionClient *http.Client) *weaviate.Client 
 		}
 	}
 	client := weaviate.New(*cfg)
-	client.WaitForWeavaite(20)
+	client.WaitForWeavaite(60)
 	return client
 }
 

--- a/weaviate/connection/rest.go
+++ b/weaviate/connection/rest.go
@@ -55,14 +55,13 @@ func NewConnection(scheme string, host string, httpClient *http.Client, headers 
 }
 
 // WaitForWeaviate waits until weaviate is started up and ready
-// expects weaviat at localhost:8080
 func (con *Connection) WaitForWeaviate(startup_period int) error {
 	if startup_period < 0 {
 		return errors.New("'startup_period' needs to be an integer larger than zero")
 	}
 
 	for i := 0; i < startup_period; i++ {
-		ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second*3)
+		ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second)
 		response, err := con.RunREST(ctx, "/.well-known/ready", http.MethodGet, nil)
 		var isReady bool
 		switch {

--- a/weaviate/connection/rest.go
+++ b/weaviate/connection/rest.go
@@ -58,10 +58,9 @@ func NewConnection(scheme string, host string, httpClient *http.Client, headers 
 // expects weaviat at localhost:8080
 func (con *Connection) WaitForWeaviate(startup_period int) error {
 	if startup_period < 0 {
-		return errors.New("startup_period needs to be an integer larger than zero")
+		return errors.New("'startup_period' needs to be an integer larger than zero")
 	}
 
-	var err error
 	for i := 0; i < startup_period; i++ {
 		ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second*3)
 		response, err := con.RunREST(ctx, "/.well-known/ready", http.MethodGet, nil)
@@ -73,6 +72,7 @@ func (con *Connection) WaitForWeaviate(startup_period int) error {
 			isReady = true
 		default:
 			isReady = false
+
 		}
 
 		cancelFunc()
@@ -82,7 +82,8 @@ func (con *Connection) WaitForWeaviate(startup_period int) error {
 		fmt.Printf("Weaviate not yet up waiting another second. Iteration: %v\n", i)
 		time.Sleep(time.Second)
 	}
-	return err
+
+	return fmt.Errorf("weaviate did not start up in %d seconds. Either the Weaviate URL %s is wrong or Weaviate did not start up in the interval given in 'startup_period'", startup_period, con.basePath)
 }
 
 // startRefreshGoroutine starts a background goroutine that periodically refreshes the auth token.

--- a/weaviate/connection/rest.go
+++ b/weaviate/connection/rest.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -44,13 +45,39 @@ func NewConnection(scheme string, host string, httpClient *http.Client, headers 
 
 	// shutdown goroutine when connections is cleaned up
 	runtime.SetFinalizer(connection, finalizer)
-
+	connection.WaitForWeaviate()
 	transport, ok := connection.httpClient.Transport.(*oauth2.Transport)
 	if ok {
 		connection.startRefreshGoroutine(transport)
 	}
 
 	return connection
+}
+
+// WaitForWeaviate waits until weaviate is started up and ready
+// expects weaviat at localhost:8080
+func (con *Connection) WaitForWeaviate() error {
+	for i := 0; i < 20; i++ {
+		ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second*3)
+		response, err := con.RunREST(ctx, "/.well-known/ready", http.MethodGet, nil)
+		var isReady bool
+		switch {
+		case err != nil:
+			isReady = false
+		case response.StatusCode == 200:
+			isReady = true
+		default:
+			isReady = false
+		}
+
+		cancelFunc()
+		if isReady {
+			return nil
+		}
+		fmt.Printf("Weaviate not yet up waiting another 3 seconds. Iteration: %v\n", i)
+		time.Sleep(time.Second * 3)
+	}
+	return fmt.Errorf("Weaviate did not start in time")
 }
 
 // startRefreshGoroutine starts a background goroutine that periodically refreshes the auth token.

--- a/weaviate/connection/rest.go
+++ b/weaviate/connection/rest.go
@@ -56,34 +56,47 @@ func NewConnection(scheme string, host string, httpClient *http.Client, headers 
 
 // WaitForWeaviate waits until weaviate is started up and ready
 func (con *Connection) WaitForWeaviate(startupTimeout time.Duration) error {
-	if startupTimeout < 0 {
-		return errors.New("'startupTimeout' needs to be a time.Duration larger than zero")
-	}
-	ticker := time.NewTicker(time.Second)
-	startTime := time.Now()
-	for {
-		t := <-ticker.C
+	switch {
+	case startupTimeout < 0:
+		return errors.New("'startupTimeout' can not be smaller than zero")
+	case startupTimeout == 0:
+		return nil
+	default:
 		ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second)
 		response, err := con.RunREST(ctx, "/.well-known/ready", http.MethodGet, nil)
-		var isReady bool
-		switch {
-		case err != nil:
-			isReady = false
-		case response.StatusCode == 200:
-			isReady = true
-		default:
-			isReady = false
-
-		}
-
 		cancelFunc()
-		if isReady {
-			return nil
+		if err == nil {
+			if response.StatusCode == 200 {
+				return nil
+			}
 		}
-		if t.After(startTime.Add(startupTimeout)) {
-			return fmt.Errorf("weaviate did not start up in %d seconds. Either the Weaviate URL %q is wrong or Weaviate did not start up in the interval given in 'startupTimeout'", startupTimeout, con.basePath)
+		ticker := time.NewTicker(time.Second)
+		startTime := time.Now()
+		for {
+			t := <-ticker.C
+			ctx, cancelFunc = context.WithTimeout(context.Background(), time.Second)
+			response, err = con.RunREST(ctx, "/.well-known/ready", http.MethodGet, nil)
+			var isReady bool
+			switch {
+			case err != nil:
+				isReady = false
+			case response.StatusCode == 200:
+				isReady = true
+			default:
+				isReady = false
+
+			}
+
+			cancelFunc()
+			if isReady {
+				return nil
+			}
+			if t.After(startTime.Add(startupTimeout)) {
+				return fmt.Errorf("weaviate did not start up in %s. Either the Weaviate URL %q is wrong or Weaviate did not start up in the interval given in 'startupTimeout'", startupTimeout.String(), con.basePath)
+			}
+			log.Printf("Weaviate not yet up. Waiting for another second.")
 		}
-		log.Printf("Weaviate not yet up. Waiting for another second.")
+
 	}
 }
 

--- a/weaviate/connection/rest.go
+++ b/weaviate/connection/rest.go
@@ -56,47 +56,45 @@ func NewConnection(scheme string, host string, httpClient *http.Client, headers 
 
 // WaitForWeaviate waits until weaviate is started up and ready
 func (con *Connection) WaitForWeaviate(startupTimeout time.Duration) error {
-	switch {
-	case startupTimeout < 0:
+	if startupTimeout < 0 {
 		return errors.New("'startupTimeout' can not be smaller than zero")
-	case startupTimeout == 0:
+	} else if startupTimeout == 0 {
 		return nil
-	default:
-		ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second)
-		response, err := con.RunREST(ctx, "/.well-known/ready", http.MethodGet, nil)
+	}
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second)
+	response, err := con.RunREST(ctx, "/.well-known/ready", http.MethodGet, nil)
+	cancelFunc()
+	if err == nil {
+		if response.StatusCode == 200 {
+			return nil
+		}
+	}
+	ticker := time.NewTicker(time.Second)
+	startTime := time.Now()
+	for {
+		t := <-ticker.C
+		ctx, cancelFunc = context.WithTimeout(context.Background(), time.Second)
+		response, err = con.RunREST(ctx, "/.well-known/ready", http.MethodGet, nil)
+		var isReady bool
+		switch {
+		case err != nil:
+			isReady = false
+		case response.StatusCode == 200:
+			isReady = true
+		default:
+			isReady = false
+
+		}
+
 		cancelFunc()
-		if err == nil {
-			if response.StatusCode == 200 {
-				return nil
-			}
+		if isReady {
+			return nil
 		}
-		ticker := time.NewTicker(time.Second)
-		startTime := time.Now()
-		for {
-			t := <-ticker.C
-			ctx, cancelFunc = context.WithTimeout(context.Background(), time.Second)
-			response, err = con.RunREST(ctx, "/.well-known/ready", http.MethodGet, nil)
-			var isReady bool
-			switch {
-			case err != nil:
-				isReady = false
-			case response.StatusCode == 200:
-				isReady = true
-			default:
-				isReady = false
-
-			}
-
-			cancelFunc()
-			if isReady {
-				return nil
-			}
-			if t.After(startTime.Add(startupTimeout)) {
-				return fmt.Errorf("weaviate did not start up in %s. Either the Weaviate URL %q is wrong or Weaviate did not start up in the interval given in 'startupTimeout'", startupTimeout.String(), con.basePath)
-			}
-			log.Printf("Weaviate not yet up. Waiting for another second.")
+		if t.After(startTime.Add(startupTimeout)) {
+			return fmt.Errorf("weaviate did not start up in %s. Either the Weaviate URL %q is wrong or Weaviate did not start up in the interval given in 'startupTimeout'", startupTimeout.String(), con.basePath)
 		}
-
+		log.Printf("Weaviate not yet up. Waiting for another second.")
 	}
 }
 

--- a/weaviate/connection/rest.go
+++ b/weaviate/connection/rest.go
@@ -80,7 +80,7 @@ func (con *Connection) WaitForWeaviate(startupTimeout time.Duration) error {
 		if isReady {
 			return nil
 		}
-		if t.After(startTime.Add(startupTimeout)) {
+		if t.After(startTime.Add(startupTimeout * time.Second)) {
 			return fmt.Errorf("weaviate did not start up in %d seconds. Either the Weaviate URL %q is wrong or Weaviate did not start up in the interval given in 'startupTimeout'", startupTimeout, con.basePath)
 		}
 		log.Printf("Weaviate not yet up. Waiting for another second.")

--- a/weaviate/connection/rest.go
+++ b/weaviate/connection/rest.go
@@ -57,7 +57,7 @@ func NewConnection(scheme string, host string, httpClient *http.Client, headers 
 // WaitForWeaviate waits until weaviate is started up and ready
 func (con *Connection) WaitForWeaviate(startupTimeout time.Duration) error {
 	if startupTimeout < 0 {
-		return errors.New("'startupTimeout' needs to be an integer larger than zero")
+		return errors.New("'startupTimeout' needs to be a time.Duration larger than zero")
 	}
 	ticker := time.NewTicker(time.Second)
 	startTime := time.Now()
@@ -80,7 +80,7 @@ func (con *Connection) WaitForWeaviate(startupTimeout time.Duration) error {
 		if isReady {
 			return nil
 		}
-		if t.After(startTime.Add(startupTimeout * time.Second)) {
+		if t.After(startTime.Add(startupTimeout)) {
 			return fmt.Errorf("weaviate did not start up in %d seconds. Either the Weaviate URL %q is wrong or Weaviate did not start up in the interval given in 'startupTimeout'", startupTimeout, con.basePath)
 		}
 		log.Printf("Weaviate not yet up. Waiting for another second.")

--- a/weaviate/connection/rest.go
+++ b/weaviate/connection/rest.go
@@ -55,12 +55,12 @@ func NewConnection(scheme string, host string, httpClient *http.Client, headers 
 }
 
 // WaitForWeaviate waits until weaviate is started up and ready
-func (con *Connection) WaitForWeaviate(startup_period int) error {
-	if startup_period < 0 {
-		return errors.New("'startup_period' needs to be an integer larger than zero")
+func (con *Connection) WaitForWeaviate(startupTimeout time.Duration) error {
+	if startupTimeout < 0 {
+		return errors.New("'startupTimeout' needs to be an integer larger than zero")
 	}
 	ticker := time.NewTicker(time.Second)
-	start_time := time.Now()
+	startTime := time.Now()
 	for {
 		t := <-ticker.C
 		ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second)
@@ -80,10 +80,10 @@ func (con *Connection) WaitForWeaviate(startup_period int) error {
 		if isReady {
 			return nil
 		}
-		if t.After(start_time.Add(time.Duration(startup_period) * time.Second)) {
-			return fmt.Errorf("weaviate did not start up in %d seconds. Either the Weaviate URL %s is wrong or Weaviate did not start up in the interval given in 'startup_period'", startup_period, con.basePath)
+		if t.After(startTime.Add(startupTimeout * time.Second)) {
+			return fmt.Errorf("weaviate did not start up in %d seconds. Either the Weaviate URL %q is wrong or Weaviate did not start up in the interval given in 'startupTimeout'", startupTimeout, con.basePath)
 		}
-		fmt.Printf("Weaviate not yet up waiting another second. Current time: %v\n", t)
+		log.Printf("Weaviate not yet up. Waiting for another second.")
 	}
 }
 

--- a/weaviate/connection/rest.go
+++ b/weaviate/connection/rest.go
@@ -80,7 +80,7 @@ func (con *Connection) WaitForWeaviate(startupTimeout time.Duration) error {
 		if isReady {
 			return nil
 		}
-		if t.After(startTime.Add(startupTimeout * time.Second)) {
+		if t.After(startTime.Add(startupTimeout)) {
 			return fmt.Errorf("weaviate did not start up in %d seconds. Either the Weaviate URL %q is wrong or Weaviate did not start up in the interval given in 'startupTimeout'", startupTimeout, con.basePath)
 		}
 		log.Printf("Weaviate not yet up. Waiting for another second.")

--- a/weaviate/testenv/environment.go
+++ b/weaviate/testenv/environment.go
@@ -17,8 +17,7 @@ import (
 //	due to syncing issues and speeds up the process
 func SetupLocalWeaviate() error {
 	if !isExternalWeaviateRunning() {
-		err := test.SetupWeaviate()
-		return err
+		return test.SetupWeaviate()
 	}
 	return nil
 }
@@ -32,8 +31,7 @@ func SetupLocalWeaviate() error {
 //	due to syncing issues and speeds up the process
 func SetupLocalWeaviateDeprecated() error {
 	if !isExternalWeaviateRunning() {
-		err := test.SetupWeaviateDeprecated()
-		return err
+		return test.SetupWeaviateDeprecated()
 	}
 	return nil
 }

--- a/weaviate/testenv/environment.go
+++ b/weaviate/testenv/environment.go
@@ -1,14 +1,12 @@
 package testenv
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/weaviate/weaviate-go-client/v4/test"
-	"github.com/weaviate/weaviate-go-client/v4/weaviate"
 )
 
 // SetupLocalWeaviate creates a local weaviate running on 8080 using docker compose
@@ -20,11 +18,9 @@ import (
 func SetupLocalWeaviate() error {
 	if !isExternalWeaviateRunning() {
 		err := test.SetupWeaviate()
-		if err != nil {
-			return err
-		}
+		return err
 	}
-	return WaitForWeaviate()
+	return nil
 }
 
 // SetupLocalWeaviateDeprecated creates a local weaviate running on 8080 using docker compose
@@ -37,11 +33,9 @@ func SetupLocalWeaviate() error {
 func SetupLocalWeaviateDeprecated() error {
 	if !isExternalWeaviateRunning() {
 		err := test.SetupWeaviateDeprecated()
-		if err != nil {
-			return err
-		}
+		return err
 	}
-	return WaitForWeaviate()
+	return nil
 }
 
 func isExternalWeaviateRunning() bool {
@@ -49,28 +43,6 @@ func isExternalWeaviateRunning() bool {
 	val = strings.ToLower(val)
 	fmt.Printf("\nEXTERNAL_WEAVIATE_RUNNING: %v\n", val)
 	return val == "true"
-}
-
-// WaitForWeaviate waits until weaviate is started up and ready
-// expects weaviat at localhost:8080
-func WaitForWeaviate() error {
-	cfg := weaviate.Config{
-		Host:   "localhost:8080",
-		Scheme: "http",
-	}
-	client := weaviate.New(cfg)
-
-	for i := 0; i < 20; i++ {
-		ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second*3)
-		isReady, _ := client.Misc().ReadyChecker().Do(ctx)
-		cancelFunc()
-		if isReady {
-			return nil
-		}
-		fmt.Printf("Weaviate not yet up waiting another 3 seconds. Iteration: %v\n", i)
-		time.Sleep(time.Second * 3)
-	}
-	return fmt.Errorf("Weaviate did not start in time")
 }
 
 // TearDownLocalWeaviate shuts down the locally started weaviate docker compose

--- a/weaviate/weaviate_client.go
+++ b/weaviate/weaviate_client.go
@@ -39,7 +39,10 @@ func NewConfig(host string, scheme string, authConfig auth.Config, headers map[s
 	var client *http.Client
 	var err error
 	if authConfig != nil {
-		tmpCon := connection.NewConnection(scheme, host, nil, headers)
+		tmpCon, ok := connection.NewConnection(scheme, host, nil, headers)
+		if ok != nil {
+			return nil, ok
+		}
 		client, err = authConfig.GetAuthClient(tmpCon)
 		if err != nil {
 			return nil, err
@@ -72,7 +75,7 @@ type Client struct {
 // The client uses the original data models as provided by weaviate itself.
 // All these models are provided in the sub module "github.com/weaviate/weaviate/entities/models"
 func New(config Config) *Client {
-	con := connection.NewConnection(config.Scheme, config.Host, config.ConnectionClient, config.Headers)
+	con, _ := connection.NewConnection(config.Scheme, config.Host, config.ConnectionClient, config.Headers)
 
 	// some endpoints now require a className namespace.
 	// to determine if this new convention is to be used,

--- a/weaviate/weaviate_client.go
+++ b/weaviate/weaviate_client.go
@@ -51,13 +51,13 @@ func NewConfig(host string, scheme string, authConfig auth.Config, headers map[s
 	return &Config{Host: host, Scheme: scheme, Headers: headers, ConnectionClient: client}, nil
 }
 
-func AddAuthClient(cfg Config, authConfig auth.Config, startupTimeout int) (Config, error) {
+func AddAuthClient(cfg Config, authConfig auth.Config, startupTimeout time.Duration) (Config, error) {
 	if authConfig == nil {
 		return cfg, nil
 	}
 
 	tmpCon := connection.NewConnection(cfg.Scheme, cfg.Host, nil, cfg.Headers)
-	err := tmpCon.WaitForWeaviate(time.Duration(startupTimeout))
+	err := tmpCon.WaitForWeaviate(startupTimeout)
 	if err != nil {
 		return cfg, err
 	}
@@ -127,8 +127,8 @@ func New(config Config) *Client {
 }
 
 // Waits for Weaviate to start.
-func (c *Client) WaitForWeavaite(startupTimeout int) error {
-	return c.connection.WaitForWeaviate(time.Duration(startupTimeout))
+func (c *Client) WaitForWeavaite(startupTimeout time.Duration) error {
+	return c.connection.WaitForWeaviate(startupTimeout)
 }
 
 // Misc collection group for .well_known and root level API commands

--- a/weaviate/weaviate_client.go
+++ b/weaviate/weaviate_client.go
@@ -3,6 +3,7 @@ package weaviate
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/weaviate/weaviate-go-client/v4/weaviate/auth"
 	"github.com/weaviate/weaviate-go-client/v4/weaviate/backup"
@@ -50,13 +51,13 @@ func NewConfig(host string, scheme string, authConfig auth.Config, headers map[s
 	return &Config{Host: host, Scheme: scheme, Headers: headers, ConnectionClient: client}, nil
 }
 
-func AddAuthClient(cfg Config, authConfig auth.Config, startup_period int) (Config, error) {
+func AddAuthClient(cfg Config, authConfig auth.Config, startupTimeout int) (Config, error) {
 	if authConfig == nil {
 		return cfg, nil
 	}
 
 	tmpCon := connection.NewConnection(cfg.Scheme, cfg.Host, nil, cfg.Headers)
-	err := tmpCon.WaitForWeaviate(startup_period)
+	err := tmpCon.WaitForWeaviate(time.Duration(startupTimeout))
 	if err != nil {
 		return cfg, err
 	}
@@ -126,8 +127,8 @@ func New(config Config) *Client {
 }
 
 // Waits for Weaviate to start.
-func (c *Client) WaitForWeavaite(startup_period int) error {
-	return c.connection.WaitForWeaviate(startup_period)
+func (c *Client) WaitForWeavaite(startupTimeout int) error {
+	return c.connection.WaitForWeaviate(time.Duration(startupTimeout))
 }
 
 // Misc collection group for .well_known and root level API commands

--- a/weaviate/weaviate_client.go
+++ b/weaviate/weaviate_client.go
@@ -37,11 +37,10 @@ type Config struct {
 
 func NewConfig(host string, scheme string, authConfig auth.Config, headers map[string]string) (*Config, error) {
 	var client *http.Client
-	var err error
 	if authConfig != nil {
-		tmpCon, ok := connection.NewConnection(scheme, host, nil, headers)
-		if ok != nil {
-			return nil, ok
+		tmpCon, err := connection.NewConnection(scheme, host, nil, headers)
+		if err != nil {
+			return nil, err
 		}
 		client, err = authConfig.GetAuthClient(tmpCon)
 		if err != nil {


### PR DESCRIPTION
Closes https://github.com/weaviate/weaviate-go-client/issues/112. 

Implements the WaitForWeaviate function which automatically waits for weaviate to start before initializing the client. 

Due to the existing architecture of the client, there are two places where a first connection to weaviate happens:
1) When creating the config with authentication: Here the weaviate OIDC config is queried before the client is created.
2) After creating the client, before a user makes the first connection.

Due to this I added the WaitForWeaviate in two places:
1) In a new function AddAuthClient, that creates the correct http-client
2) In a member function of the client, eg client.WaitForWeavaite(time) that users can call after creating the client