### PR TITLE
Add schema ClassExistenceChecker

### DIFF
--- a/test/schema/schema_test.go
+++ b/test/schema/schema_test.go
@@ -225,10 +225,12 @@ func TestSchema_integration(t *testing.T) {
 		err := client.Schema().ClassCreator().WithClass(schemaClass).Do(context.Background())
 		assert.Nil(t, err)
 
-		ok := client.Schema().ClassExistenceChecker().WithClassName("Band").Do(context.Background())
+		ok, err := client.Schema().ClassExistenceChecker().WithClassName("Band").Do(context.Background())
+		assert.Nil(t, err)
 		assert.True(t, ok)
 
-		ok = client.Schema().ClassExistenceChecker().WithClassName("NonExistantClass").Do(context.Background())
+		ok, err = client.Schema().ClassExistenceChecker().WithClassName("NonExistantClass").Do(context.Background())
+		assert.Nil(t, err)
 		assert.False(t, ok)
 
 		// Clean up classes

--- a/test/schema/schema_test.go
+++ b/test/schema/schema_test.go
@@ -206,7 +206,7 @@ func TestSchema_integration(t *testing.T) {
 		assert.NotNil(t, bandClass.ModuleConfig)
 		assert.NotNil(t, bandClass.VectorIndexConfig)
 
-		nonExistantClass, getErr := client.Schema().ClassGetter().WithClassName("NonExistantClass").Do(context.Background())
+		nonExistantClass, getErr := client.Schema().ClassGetter().WithClassName("NonExistentClass").Do(context.Background())
 		assert.NotNil(t, getErr)
 		assert.Nil(t, nonExistantClass)
 
@@ -229,7 +229,7 @@ func TestSchema_integration(t *testing.T) {
 		assert.Nil(t, err)
 		assert.True(t, ok)
 
-		ok, err = client.Schema().ClassExistenceChecker().WithClassName("NonExistantClass").Do(context.Background())
+		ok, err = client.Schema().ClassExistenceChecker().WithClassName("NonExistentClass").Do(context.Background())
 		assert.Nil(t, err)
 		assert.False(t, ok)
 

--- a/test/schema/schema_test.go
+++ b/test/schema/schema_test.go
@@ -215,6 +215,27 @@ func TestSchema_integration(t *testing.T) {
 		assert.Nil(t, errRm)
 	})
 
+	t.Run("CHECK /schema/{className}", func(t *testing.T) {
+		client := testsuit.CreateTestClient(8080, nil)
+
+		schemaClass := &models.Class{
+			Class: "Band",
+		}
+
+		err := client.Schema().ClassCreator().WithClass(schemaClass).Do(context.Background())
+		assert.Nil(t, err)
+
+		ok := client.Schema().ClassExistenceChecker().WithClassName("Band").Do(context.Background())
+		assert.True(t, ok)
+
+		ok = client.Schema().ClassExistenceChecker().WithClassName("NonExistantClass").Do(context.Background())
+		assert.False(t, ok)
+
+		// Clean up classes
+		errRm := client.Schema().AllDeleter().Do(context.Background())
+		assert.Nil(t, errRm)
+	})
+
 	t.Run("GET /schema/{className}/shards", func(t *testing.T) {
 		client := testsuit.CreateTestClient(8080, nil)
 

--- a/weaviate/schema/ClassChecker.go
+++ b/weaviate/schema/ClassChecker.go
@@ -5,19 +5,19 @@ import (
 )
 
 // ClassDeleter builder to remove a class from weaviate
-type ClassChecker struct {
+type ClassExistenceChecker struct {
 	schemaAPI *API
 	className string
 }
 
 // WithClassName defines the name of the class that should be checked
-func (cd *ClassChecker) WithClassName(className string) *ClassChecker {
+func (cd *ClassExistenceChecker) WithClassName(className string) *ClassExistenceChecker {
 	cd.className = className
 	return cd
 }
 
 // Do delete the class from the weaviate schema
-func (cd *ClassChecker) Do(ctx context.Context) bool {
-	_, err := cd.schemaAPI.ClassGetter().WithClassName(cd.className).Do(context.Background())
+func (cd *ClassExistenceChecker) Do(ctx context.Context) bool {
+	_, err := cd.schemaAPI.ClassGetter().WithClassName(cd.className).Do(ctx)
 	return err == nil
 }

--- a/weaviate/schema/ClassChecker.go
+++ b/weaviate/schema/ClassChecker.go
@@ -1,0 +1,23 @@
+package schema
+
+import (
+	"context"
+)
+
+// ClassDeleter builder to remove a class from weaviate
+type ClassChecker struct {
+	schemaAPI *API
+	className string
+}
+
+// WithClassName defines the name of the class that should be checked
+func (cd *ClassChecker) WithClassName(className string) *ClassChecker {
+	cd.className = className
+	return cd
+}
+
+// Do delete the class from the weaviate schema
+func (cd *ClassChecker) Do(ctx context.Context) bool {
+	_, err := cd.schemaAPI.ClassGetter().WithClassName(cd.className).Do(context.Background())
+	return err == nil
+}

--- a/weaviate/schema/schema.go
+++ b/weaviate/schema/schema.go
@@ -26,10 +26,10 @@ func (schema *API) ClassGetter() *ClassGetter {
 	}
 }
 
-// ClassChecker builder to check if a class is part of a weaviate schema
+// ClassExistenceChecker builder to check if a class is part of a weaviate schema
 func (schema *API) ClassExistenceChecker() *ClassExistenceChecker {
 	return &ClassExistenceChecker{
-		schemaAPI: schema,
+		connection: schema.connection,
 	}
 }
 

--- a/weaviate/schema/schema.go
+++ b/weaviate/schema/schema.go
@@ -27,8 +27,8 @@ func (schema *API) ClassGetter() *ClassGetter {
 }
 
 // ClassChecker builder to check if a class is part of a weaviate schema
-func (schema *API) ClassChecker() *ClassChecker {
-	return &ClassChecker{
+func (schema *API) ClassExistenceChecker() *ClassExistenceChecker {
+	return &ClassExistenceChecker{
 		schemaAPI: schema,
 	}
 }

--- a/weaviate/schema/schema.go
+++ b/weaviate/schema/schema.go
@@ -26,6 +26,13 @@ func (schema *API) ClassGetter() *ClassGetter {
 	}
 }
 
+// ClassChecker builder to check if a class is part of a weaviate schema
+func (schema *API) ClassChecker() *ClassChecker {
+	return &ClassChecker{
+		schemaAPI: schema,
+	}
+}
+
 // ClassCreator builder to create a weaviate schema class
 func (schema *API) ClassCreator() *ClassCreator {
 	return &ClassCreator{


### PR DESCRIPTION
Closes https://github.com/weaviate/weaviate-go-client/issues/125. Adds a ClassExistenceChecker that returns a boolean to show whether a class exists in a schema or not. 
The signature is: client.Schema().ClassChecker().WithClassName(className string).Do(ctx context.Context) -> bool, error.