### PR TITLE
Token refresh

### DIFF
--- a/test/auth/auth_mock_test.go
+++ b/test/auth/auth_mock_test.go
@@ -158,13 +158,14 @@ func TestAuthMock_RefreshUserPWAndToken(t *testing.T) {
 			muxToken := http.NewServeMux()
 			muxToken.HandleFunc("/auth", func(w http.ResponseWriter, r *http.Request) {
 				// refresh token cannot be expired
+				log.Printf("%v", time.Since(tokenRefreshTime).Seconds())
 				assert.True(t, time.Since(tokenRefreshTime).Seconds() < float64(expirationTimeRefreshToken))
 
 				tokenRefreshTime = time.Now() // update time when the tokens where refreshed the last time
 				w.Header().Set("Content-Type", "application/json")
 				w.Write([]byte(
 					fmt.Sprintf(`{"access_token": "%v", "expires_in": %v, "refresh_token": "%v", "refresh_expires_in" :  %v}`,
-						AccessToken, expirationTimeToken, RefreshToken, expirationTimeRefreshToken)))
+						AccessToken, uint(12), RefreshToken, expirationTimeRefreshToken)))
 			})
 			sToken := httptest.NewServer(muxToken)
 			defer sToken.Close()

--- a/test/auth/auth_mock_test.go
+++ b/test/auth/auth_mock_test.go
@@ -140,6 +140,7 @@ func TestAuthMock_RefreshCC(t *testing.T) {
 func TestAuthMock_RefreshUserPWAndToken(t *testing.T) {
 	expirationTimeRefreshToken := 3
 	initialExpirationTimeToken := uint(2)
+	// higher expiration time to check if the go routine correctly sleeps until the token almost expires
 	expirationTimeToken := uint(12)
 	tests := []struct {
 		name       string

--- a/test/auth/auth_mock_test.go
+++ b/test/auth/auth_mock_test.go
@@ -158,7 +158,7 @@ func TestAuthMock_RefreshUserPWAndToken(t *testing.T) {
 			muxToken := http.NewServeMux()
 			muxToken.HandleFunc("/auth", func(w http.ResponseWriter, r *http.Request) {
 				// refresh token cannot be expired
-				assert.True(t, time.Now().Sub(tokenRefreshTime).Seconds() < float64(expirationTimeRefreshToken))
+				assert.True(t, time.Since(tokenRefreshTime).Seconds() < float64(expirationTimeRefreshToken))
 
 				tokenRefreshTime = time.Now() // update time when the tokens where refreshed the last time
 				w.Header().Set("Content-Type", "application/json")
@@ -184,7 +184,7 @@ func TestAuthMock_RefreshUserPWAndToken(t *testing.T) {
 			})
 			mux.HandleFunc("/v1/schema", func(w http.ResponseWriter, r *http.Request) {
 				// Access Token cannot be expired
-				assert.True(t, time.Now().Sub(tokenRefreshTime).Seconds() < float64(expirationTimeToken))
+				assert.True(t, time.Since(tokenRefreshTime).Seconds() < float64(expirationTimeToken))
 				w.Write([]byte(`{}`))
 			})
 			mux.HandleFunc("/v1/.well-known/ready", func(w http.ResponseWriter, r *http.Request) {
@@ -206,67 +206,6 @@ func TestAuthMock_RefreshUserPWAndToken(t *testing.T) {
 			assert.Nil(t, AuthErr2)
 		})
 	}
-}
-
-func TestAuthMock_RefreshTokenTimeout(t *testing.T) {
-	tokenRefreshTime := time.Now()
-	expirationTimeToken := uint(31)
-	expirationTimeRefreshToken := 2
-	authConfig := auth.BearerToken{AccessToken: AccessToken, ExpiresIn: expirationTimeToken, RefreshToken: RefreshToken}
-	firstTime := true
-	pointerFirstTime := &firstTime
-
-	// endpoint for access tokens
-	muxToken := http.NewServeMux()
-	muxToken.HandleFunc("/auth", func(w http.ResponseWriter, r *http.Request) {
-		if *pointerFirstTime {
-			time.Sleep(6 * time.Second)
-		}
-		*pointerFirstTime = false
-		tokenRefreshTime = time.Now() // update time when the tokens where refreshed the last time
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(
-			fmt.Sprintf(`{"access_token": "%v", "expires_in": %v, "refresh_token": "%v", "refresh_expires_in" :  %v}`,
-				AccessToken, expirationTimeToken, RefreshToken, expirationTimeRefreshToken)))
-	})
-
-	sToken := httptest.NewServer(muxToken)
-	defer sToken.Close()
-
-	// provides all endpoints
-	muxEndpoints := http.NewServeMux()
-	muxEndpoints.HandleFunc("/endpoints", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(fmt.Sprintf(`{"token_endpoint": "` + sToken.URL + `/auth"}`)))
-	})
-	sEndpoints := httptest.NewServer(muxEndpoints)
-	defer sEndpoints.Close()
-
-	// Returns the address of the auth server
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"href": "` + sEndpoints.URL + `/endpoints", "clientId": "DoesNotMatter"}`))
-	})
-	mux.HandleFunc("/v1/schema", func(w http.ResponseWriter, r *http.Request) {
-		assert.True(t, time.Since(tokenRefreshTime).Seconds() < float64(expirationTimeToken))
-		w.Write([]byte(`{}`))
-	})
-	mux.HandleFunc("/v1/.well-known/ready", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{}`))
-	})
-	s := httptest.NewServer(mux)
-	defer s.Close()
-
-	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http", StartupTimeout: 60 * time.Second, AuthConfig: authConfig}
-	client, err := weaviate.NewClient(cfg)
-	assert.Nil(t, err)
-
-	AuthErr := client.Schema().AllDeleter().Do(context.TODO())
-	assert.Nil(t, AuthErr)
-
-	// access and refresh token expired, so the client needs to refresh automatically in the background
-	time.Sleep(time.Second * 30)
-	AuthErr2 := client.Schema().AllDeleter().Do(context.TODO())
-	assert.Nil(t, AuthErr2)
 }
 
 // Test that the client can handle situations in which a proxy returns a catchall page for all requests

--- a/weaviate/connection/rest.go
+++ b/weaviate/connection/rest.go
@@ -121,6 +121,11 @@ func (con *Connection) startRefreshGoroutine(transport *oauth2.Transport) {
 	if timeToSleep > 0 {
 		time.Sleep(timeToSleep)
 	}
+
+	_, err = con.RunREST(context.TODO(), "/meta", http.MethodGet, nil)
+	if err == nil {
+		return
+	}
 	ticker := time.NewTicker(time.Second)
 	go func() {
 		for {

--- a/weaviate/connection/rest.go
+++ b/weaviate/connection/rest.go
@@ -130,16 +130,14 @@ func (con *Connection) startRefreshGoroutine(transport *oauth2.Transport) {
 					time.Sleep(timeToSleep)
 				}
 				token, err = transport.Source.Token()
-
-				if time.Until(token.Expiry) < 0 {
-					log.Printf("Requested token was not valid. Stop requesting new access token.")
-					return
-				}
 				if err != nil {
 					log.Printf("Error during token refresh, getting token: %v", err)
 				}
+				if time.Until(token.Expiry) < 0 {
+					log.Printf("Requested token is expired. Stop requesting new access token.")
+					return
+				}
 				time.Sleep(time.Second)
-
 			}
 		}
 	}()

--- a/weaviate/connection/rest.go
+++ b/weaviate/connection/rest.go
@@ -108,7 +108,7 @@ func (con *Connection) startRefreshGoroutine(transport *oauth2.Transport) {
 		return
 	}
 
-	if !token.Valid() {
+	if time.Until(token.Expiry) < 0 {
 		log.Printf("Requested token was not valid")
 		return
 	}
@@ -127,7 +127,7 @@ func (con *Connection) startRefreshGoroutine(transport *oauth2.Transport) {
 			}
 			token, err = transport.Source.Token()
 
-			if !token.Valid() {
+			if time.Until(token.Expiry) < 0 {
 				log.Printf("Requested token was not valid. Stop requesting new access token.")
 				return
 			}

--- a/weaviate/connection/rest.go
+++ b/weaviate/connection/rest.go
@@ -109,7 +109,7 @@ func (con *Connection) startRefreshGoroutine(transport *oauth2.Transport) {
 	}
 
 	if time.Until(token.Expiry) < 0 {
-		log.Printf("Requested token was not valid")
+		log.Printf("Requested token is expired")
 		return
 	}
 


### PR DESCRIPTION
Closes https://github.com/weaviate/weaviate-go-client/issues/137. Allows users with an unstable connection to try refreshing the authentication token several times in order to avoid unauthenticated clients. 