### PR TITLE
Fix tests for 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/stretchr/testify v1.8.2
-	github.com/weaviate/weaviate v1.19.0-beta.1.0.20230503104113-7d8a670648e4
+	github.com/weaviate/weaviate v1.19.0
 	go.mongodb.org/mongo-driver v1.11.3 // indirect
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094
 )

--- a/go.sum
+++ b/go.sum
@@ -1052,8 +1052,8 @@ github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1
 github.com/weaviate/contextionary v1.2.1/go.mod h1:nIEM3Gq1BzTZLuY+Pl7t8hD3eR6VAU43fRdZTEZ9LRY=
 github.com/weaviate/sroar v0.0.0-20230210105426-26108af5465d h1:bULMGmIS786YSmm/SssAmwu86y4saMoHhvuL0u7pWLc=
 github.com/weaviate/sroar v0.0.0-20230210105426-26108af5465d/go.mod h1:bJUcu8a/7XKOeaCWZtSjuBogUGReUiwJTyGSvcAjDzQ=
-github.com/weaviate/weaviate v1.19.0-beta.1.0.20230503104113-7d8a670648e4 h1:CRlDFTtxmAlNTLomzfRpTZ+1CcgI+1p/RMhYYEgf2ps=
-github.com/weaviate/weaviate v1.19.0-beta.1.0.20230503104113-7d8a670648e4/go.mod h1:hvgLEEiZx0gQNEDLNgPGssk8UQjc/CDxZv2Dd5SYgs8=
+github.com/weaviate/weaviate v1.19.0 h1:JKmScZZ5VWVESCkji37bT1cNFCCRIZrne7ENoRHT1vM=
+github.com/weaviate/weaviate v1.19.0/go.mod h1:hvgLEEiZx0gQNEDLNgPGssk8UQjc/CDxZv2Dd5SYgs8=
 github.com/willf/bitset v1.1.10/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=

--- a/test/classifications/classification_test.go
+++ b/test/classifications/classification_test.go
@@ -83,9 +83,9 @@ func createClassificationClasses(t *testing.T, client *weaviate.Client) {
 		Description: "tag for a pizza",
 		Properties: []*models.Property{
 			{
-				DataType:    []string{"text"},
-				Description: "name",
-				Name:        "name",
+				DataType:     []string{"text"},
+				Description:  "name",
+				Name:         "name",
 				Tokenization: "whitespace",
 			},
 		},

--- a/test/classifications/classification_test.go
+++ b/test/classifications/classification_test.go
@@ -83,9 +83,10 @@ func createClassificationClasses(t *testing.T, client *weaviate.Client) {
 		Description: "tag for a pizza",
 		Properties: []*models.Property{
 			{
-				DataType:    []string{"string"},
+				DataType:    []string{"text"},
 				Description: "name",
 				Name:        "name",
+				Tokenization: "whitespace",
 			},
 		},
 	}

--- a/test/data/data_test.go
+++ b/test/data/data_test.go
@@ -59,12 +59,10 @@ func TestData_uuid(t *testing.T) {
 		createWeaviateTestSchemaUuid(t, client)
 
 		propertySchemaT := map[string]string{
-			"uuid":        "565da3b6-60b3-40e5-ba21-e6bfe5dbba91",
-			
+			"uuid": "565da3b6-60b3-40e5-ba21-e6bfe5dbba91",
 		}
 		propertySchemaA := map[string][]string{
-			"uuidArray":        []string{ "565da3b6-60b3-40e5-ba21-e6bfe5dbba92", "565da3b6-60b3-40e5-ba21-e6bfe5dbba93" },
-			
+			"uuidArray": {"565da3b6-60b3-40e5-ba21-e6bfe5dbba92", "565da3b6-60b3-40e5-ba21-e6bfe5dbba93"},
 		}
 
 		wrapperT, errCreateT := client.Data().Creator().
@@ -82,8 +80,6 @@ func TestData_uuid(t *testing.T) {
 		assert.Nil(t, errCreateA)
 		assert.NotNil(t, wrapperA.Object)
 
-
-
 		objectT, objErrT := client.Data().ObjectsGetter().
 			WithClassName("UserUUIDTest").
 			WithID("abefd256-8574-442b-9293-9205193737ee").
@@ -97,15 +93,13 @@ func TestData_uuid(t *testing.T) {
 
 		assert.Equal(t, "UserUUIDTest", objectT[0].Class)
 		valuesT := objectT[0].Properties.(map[string]interface{})
-		assert.Equal(t,  "565da3b6-60b3-40e5-ba21-e6bfe5dbba91", valuesT["uuid"])
+		assert.Equal(t, "565da3b6-60b3-40e5-ba21-e6bfe5dbba91", valuesT["uuid"])
 		assert.Equal(t, "UserUUIDTest", objectA[0].Class)
 		valuesA := objectA[0].Properties.(map[string]interface{})
 		var compData []interface{}
 		compData = append(compData, "565da3b6-60b3-40e5-ba21-e6bfe5dbba92")
 		compData = append(compData, "565da3b6-60b3-40e5-ba21-e6bfe5dbba93")
 		assert.Equal(t, compData, valuesA["uuidArray"])
-
-
 	})
 
 	t.Run("tear down weaviate", func(t *testing.T) {

--- a/test/docker-compose-azure.yml
+++ b/test/docker-compose-azure.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-group-by-arbitrary-prop-including-ref-return-top-k-per-group-77fe35f
+    image: semitechnologies/weaviate:1.19.0
     ports:
       - 8081:8081
     restart: on-failure:0

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     - '8080'
     - --scheme
     - http
-    image: semitechnologies/weaviate:preview-group-by-arbitrary-prop-including-ref-return-top-k-per-group-77fe35f
+    image: semitechnologies/weaviate:1.19.0
     ports:
     - 8080:8080
     restart: on-failure:0

--- a/test/schema/default_config_test.go
+++ b/test/schema/default_config_test.go
@@ -60,5 +60,5 @@ var defaultVectorIndexConfig = map[string]interface{}{
 }
 
 var defaultReplicationConfig = &models.ReplicationConfig{
-	Factor: 2,
+	Factor: 1,
 }

--- a/test/schema/schema_test.go
+++ b/test/schema/schema_test.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -517,8 +516,9 @@ func TestSchema_integration(t *testing.T) {
 	})
 }
 
-/*
+
 func TestReplication(t *testing.T) {
+	t.Skip("skipping replication tests for now")
 	t.Run("up", func(t *testing.T) {
 		err := testenv.SetupLocalWeaviate()
 		if err != nil {
@@ -589,7 +589,7 @@ func TestReplication(t *testing.T) {
 
 }
 
-*/
+
 
 func TestSchema_errors(t *testing.T) {
 	t.Run("up", func(t *testing.T) {

--- a/test/schema/schema_test.go
+++ b/test/schema/schema_test.go
@@ -2,8 +2,8 @@ package schema
 
 import (
 	"context"
-	"testing"
 	"os"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -515,9 +515,7 @@ func TestSchema_integration(t *testing.T) {
 			t.Fatalf("failed to tear down weaviate: %s", err)
 		}
 	})
-
 }
-
 
 /*
 func TestReplication(t *testing.T) {
@@ -607,7 +605,6 @@ func TestSchema_errors(t *testing.T) {
 		err := client.Schema().ClassCreator().Do(context.Background())
 		assert.NotNil(t, err)
 	})
-
 
 	t.Run("Fail to add property having not supported tokenization", func(t *testing.T) {
 		client := testsuit.CreateTestClient()

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -28,6 +28,9 @@ function main() {
   # Jump to root directory
   cd "$( dirname "${BASH_SOURCE[0]}" )"/.. || exit
 
+  # Start containers to support unit tests
+  ./test/start_containers.sh
+
   if  $run_unit_tests || $run_all_tests
   then
     echo_green "Run all unit tests..."


### PR DESCRIPTION
It appears some unit tests require a running weaviate, this starts the containers before the unit tests.

Also fixes the tests changed by the string->text patch