### PR TITLE
Hybrid properties

### DIFF
--- a/test/graphql/graphql_test.go
+++ b/test/graphql/graphql_test.go
@@ -1038,7 +1038,6 @@ func TestGraphQL_integration(t *testing.T) {
 		{name: "hybridProperties2", properties: []string{}, num_results: 1},
 		{name: "hybridProperties3", properties: []string{"name"}, num_results: 0},
 		{name: "hybridProperties4", properties: []string{"name", "description"}, num_results: 1},
-		{name: "hybridProperties5", properties: []string{"best_before"}, num_results: 0},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/graphql/graphql_test.go
+++ b/test/graphql/graphql_test.go
@@ -1034,10 +1034,10 @@ func TestGraphQL_integration(t *testing.T) {
 		properties  []string
 		num_results int
 	}{
-		{name: "hybridProperties1", properties: nil, num_results: 1},
-		{name: "hybridProperties2", properties: []string{}, num_results: 1},
-		{name: "hybridProperties3", properties: []string{"name"}, num_results: 0},
-		{name: "hybridProperties4", properties: []string{"name", "description"}, num_results: 1},
+		{name: "Get hybrid Properties nil", properties: nil, num_results: 1},
+		{name: "Get hybrid Properties empty", properties: []string{}, num_results: 1},
+		{name: "Get hybrid Properties name", properties: []string{"name"}, num_results: 0},
+		{name: "Get hybrid Properties name,description", properties: []string{"name", "description"}, num_results: 1},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/weaviate/graphql/hybridbuilder.go
+++ b/weaviate/graphql/hybridbuilder.go
@@ -7,10 +7,11 @@ import (
 )
 
 type HybridArgumentBuilder struct {
-	query     string
-	vector    []float32
-	withAlpha bool
-	alpha     float32
+	query      string
+	vector     []float32
+	withAlpha  bool
+	alpha      float32
+	properties []string
 }
 
 // WithQuery the search string
@@ -32,6 +33,11 @@ func (h *HybridArgumentBuilder) WithAlpha(alpha float32) *HybridArgumentBuilder 
 	return h
 }
 
+func (h *HybridArgumentBuilder) WithProperties(properties []string) *HybridArgumentBuilder {
+	h.properties = properties
+	return h
+}
+
 // Build build the given clause
 func (h *HybridArgumentBuilder) build() string {
 	clause := []string{}
@@ -47,6 +53,14 @@ func (h *HybridArgumentBuilder) build() string {
 	}
 	if h.withAlpha {
 		clause = append(clause, fmt.Sprintf("alpha: %v", h.alpha))
+	}
+
+	if len(h.properties) > 0 {
+		props, err := json.Marshal(h.properties)
+		if err != nil {
+			panic(fmt.Errorf("failed to unmarshal hybrid properties: %s", err))
+		}
+		clause = append(clause, fmt.Sprintf("properties: %v", string(props)))
 	}
 	return fmt.Sprintf("hybrid:{%v}", strings.Join(clause, ", "))
 }

--- a/weaviate/graphql/hybridbuilder.go
+++ b/weaviate/graphql/hybridbuilder.go
@@ -33,6 +33,7 @@ func (h *HybridArgumentBuilder) WithAlpha(alpha float32) *HybridArgumentBuilder 
 	return h
 }
 
+// WithProperties. The properties which are searched. Can be omitted.
 func (h *HybridArgumentBuilder) WithProperties(properties []string) *HybridArgumentBuilder {
 	h.properties = properties
 	return h

--- a/weaviate/graphql/hybridbuilder_test.go
+++ b/weaviate/graphql/hybridbuilder_test.go
@@ -9,8 +9,8 @@ import (
 func TestHybridBuilder_build(t *testing.T) {
 	t.Run("all parameters", func(t *testing.T) {
 		hybrid := HybridArgumentBuilder{}
-		str := hybrid.WithQuery("query").WithVector([]float32{1, 2, 3}).WithAlpha(0.6).build()
-		expected := `hybrid:{query: "query", vector: [1,2,3], alpha: 0.6}`
+		str := hybrid.WithQuery("query").WithVector([]float32{1, 2, 3}).WithAlpha(0.6).WithProperties([]string{"prop1", "prop2"}).build()
+		expected := `hybrid:{query: "query", vector: [1,2,3], alpha: 0.6, properties: ["prop1","prop2"]}`
 		require.Equal(t, expected, str)
 	})
 


### PR DESCRIPTION
Closes https://github.com/weaviate/weaviate-go-client/issues/159. Adds an additional parameter "properties" to the hybrid search which allows users to only search through the given properties.