### PR TITLE
Make WeaviateClientError satisfy the GoStringer interface

### DIFF
--- a/weaviate/fault/error.go
+++ b/weaviate/fault/error.go
@@ -24,3 +24,8 @@ func (uce *WeaviateClientError) Error() string {
 	}
 	return fmt.Sprintf("status code: %v, error: %v", uce.StatusCode, msg)
 }
+
+// GoString makes WeaviateClientError satisfy the GoStringer interface. This allows the correct display when using the formatting %#v, used in assert.Nil().
+func (uce *WeaviateClientError) GoString() string {
+	return uce.Error()
+}


### PR DESCRIPTION
Makes errors display correctly during assertions such as assert.Nil(t,err). This can be archieved by using the GoStringer interface, as  assert.Nil() uses the %#v formatting. 