### PR TITLE
Do not return batch reply if there was an error

### DIFF
--- a/weaviate/connection/grpc.go
+++ b/weaviate/connection/grpc.go
@@ -43,6 +43,9 @@ func (c *GrpcClient) BatchObjects(ctx context.Context, objects []*models.Object,
 		return nil, err
 	}
 	reply, err := c.doBatchObjects(ctx, batchRequest)
+	if err != nil {
+		return nil, fmt.Errorf("batch objects: %w", err)
+	}
 	return c.batch.ParseReply(reply, objects), err
 }
 


### PR DESCRIPTION
If the GRPC connection returned an error the batch-response would still contain "SUCCESFUL" as an answer. Now it is just nil