### PR TITLE
gql: Support maxVectorDistance parameter in hybrid search

### DIFF
--- a/weaviate/graphql/hybridbuilder.go
+++ b/weaviate/graphql/hybridbuilder.go
@@ -15,15 +15,17 @@ const Ranked FusionType = "rankedFusion"
 const RelativeScore FusionType = "relativeScoreFusion"
 
 type HybridArgumentBuilder struct {
-	query         string
-	vector        []float32
-	withAlpha     bool
-	alpha         float32
-	properties    []string
-	fusionType    FusionType
-	targetVectors []string
-	targets       *MultiTargetArgumentBuilder
-	searches      *HybridSearchesArgumentBuilder
+	query                 string
+	vector                []float32
+	withAlpha             bool
+	alpha                 float32
+	withMaxVectorDistance bool
+	maxVectorDistance     float32
+	properties            []string
+	fusionType            FusionType
+	targetVectors         []string
+	targets               *MultiTargetArgumentBuilder
+	searches              *HybridSearchesArgumentBuilder
 }
 
 // WithQuery the search string
@@ -43,6 +45,13 @@ func (h *HybridArgumentBuilder) WithAlpha(alpha float32) *HybridArgumentBuilder 
 	h.withAlpha = true
 	h.alpha = alpha
 	return h
+}
+
+// WithMaxVectorDistance is the equivalent of 'distance' threshold in vector search.
+func (s *HybridArgumentBuilder) WithMaxVectorDistance(d float32) *HybridArgumentBuilder {
+	s.withMaxVectorDistance = true
+	s.maxVectorDistance = d
+	return s
 }
 
 // WithProperties The properties which are searched. Can be omitted.
@@ -92,6 +101,9 @@ func (h *HybridArgumentBuilder) build() string {
 	if h.withAlpha {
 		clause = append(clause, fmt.Sprintf("alpha: %v", h.alpha))
 	}
+	if h.withMaxVectorDistance {
+		clause = append(clause, fmt.Sprintf("maxVectorDistance: %v", h.maxVectorDistance))
+	}
 
 	if len(h.properties) > 0 {
 		props, err := json.Marshal(h.properties)
@@ -136,13 +148,13 @@ func (s *HybridSearchesArgumentBuilder) WithNearText(nearText *NearTextArgumentB
 	return s
 }
 
-func (h *HybridSearchesArgumentBuilder) build() string {
-	searches := []string{}
-	if h.nearText != nil {
-		searches = append(searches, h.nearText.build())
+func (s *HybridSearchesArgumentBuilder) build() string {
+	var searches []string
+	if s.nearText != nil {
+		searches = append(searches, s.nearText.build())
 	}
-	if h.nearVector != nil {
-		searches = append(searches, h.nearVector.build())
+	if s.nearVector != nil {
+		searches = append(searches, s.nearVector.build())
 	}
 	return strings.Join(searches, " ")
 }

--- a/weaviate/graphql/hybridbuilder_test.go
+++ b/weaviate/graphql/hybridbuilder_test.go
@@ -120,21 +120,6 @@ func TestHybridBuilder_build(t *testing.T) {
 			},
 			want: `hybrid:{query: "I'm a simple string", maxVectorDistance: 0.8, searches:{nearVector:{vector: [0.1,0.2,0.3]}}}`,
 		},
-		{
-			name: "nearText with maxVectorDistance",
-			apply: func(h *HybridArgumentBuilder) {
-				var (
-					text     NearTextArgumentBuilder
-					searches HybridSearchesArgumentBuilder
-				)
-				text.WithConcepts([]string{"concept"})
-				searches.WithNearText(&text)
-				h.WithQuery("I'm a simple string").
-					WithSearches(&searches).
-					WithMaxVectorDistance(0.8)
-			},
-			want: `hybrid:{query: "I'm a simple string", maxVectorDistance: 0.8, searches:{nearText:{concepts: ["concept"]}}}`,
-		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			var hybrid HybridArgumentBuilder

--- a/weaviate/graphql/hybridbuilder_test.go
+++ b/weaviate/graphql/hybridbuilder_test.go
@@ -7,84 +7,111 @@ import (
 )
 
 func TestHybridBuilder_build(t *testing.T) {
-	t.Run("all parameters", func(t *testing.T) {
-		hybrid := HybridArgumentBuilder{}
-		str := hybrid.WithQuery("query").WithVector([]float32{1, 2, 3}).WithAlpha(0.6).WithProperties([]string{"prop1", "prop2"}).build()
-		expected := `hybrid:{query: "query", vector: [1,2,3], alpha: 0.6, properties: ["prop1","prop2"]}`
-		require.Equal(t, expected, str)
-	})
+	for _, tt := range []struct {
+		name  string
+		apply func(h *HybridArgumentBuilder)
+		want  string
+	}{
+		{
+			name: "all parameters",
+			apply: func(h *HybridArgumentBuilder) {
+				h.WithQuery("query").
+					WithVector([]float32{1, 2, 3}).
+					WithAlpha(0.6).
+					WithProperties([]string{"prop1", "prop2"})
+			},
+			want: `hybrid:{query: "query", vector: [1,2,3], alpha: 0.6, properties: ["prop1","prop2"]}`,
+		},
+		{
+			name: "only query",
+			apply: func(h *HybridArgumentBuilder) {
+				h.WithQuery("query")
+			},
+			want: `hybrid:{query: "query"}`,
+		},
+		{
+			name: "query and vector",
+			apply: func(h *HybridArgumentBuilder) {
+				h.WithQuery("query").
+					WithVector([]float32{1, 2, 3})
+			},
+			want: `hybrid:{query: "query", vector: [1,2,3]}`,
+		},
+		{
+			name: "query and alpha",
+			apply: func(h *HybridArgumentBuilder) {
+				h.WithQuery("query").
+					WithAlpha(0.6)
+			},
+			want: `hybrid:{query: "query", alpha: 0.6}`,
+		},
+		{
+			name: "query with escaping and alpha",
+			apply: func(h *HybridArgumentBuilder) {
+				h.WithQuery("\"I'm a complex string\" says the string").
+					WithAlpha(0.6)
+			},
+			want: `hybrid:{query: "\"I'm a complex string\" says the string", alpha: 0.6}`,
+		},
+		{
+			name: "query with fusion type Ranked",
+			apply: func(h *HybridArgumentBuilder) {
+				h.WithQuery("some query").
+					WithFusionType(Ranked)
+			},
+			want: `hybrid:{query: "some query", fusionType: rankedFusion}`,
+		},
+		{
+			name: "query with fusion type Relative Score",
+			apply: func(h *HybridArgumentBuilder) {
+				h.WithQuery("some query").
+					WithFusionType(RelativeScore)
+			},
+			want: `hybrid:{query: "some query", fusionType: relativeScoreFusion}`,
+		},
+		{
+			name: "query and alpha and targetVectors",
+			apply: func(h *HybridArgumentBuilder) {
+				h.WithQuery("query").
+					WithAlpha(0.6).
+					WithTargetVectors("t1")
+			},
+			want: `hybrid:{query: "query", alpha: 0.6, targetVectors: ["t1"]}`,
+		},
+		{
+			name: "query and nearText search",
+			apply: func(h *HybridArgumentBuilder) {
+				var (
+					text     NearTextArgumentBuilder
+					searches HybridSearchesArgumentBuilder
+				)
+				text.WithConcepts([]string{"concept"}).WithCertainty(0.9)
+				searches.WithNearText(&text)
+				h.WithQuery("I'm a simple string").WithSearches(&searches)
+			},
+			want: `hybrid:{query: "I'm a simple string", searches:{nearText:{concepts: ["concept"] certainty: 0.9}}}`,
+		},
+		{
+			name: "query and nearVector search",
+			apply: func(h *HybridArgumentBuilder) {
+				var (
+					vector   NearVectorArgumentBuilder
+					searches HybridSearchesArgumentBuilder
+				)
+				vector.WithVector([]float32{0.1, 0.2, 0.3}).WithCertainty(0.9)
+				searches.WithNearVector(&vector)
+				h.WithQuery("I'm a simple string").WithSearches(&searches)
+			},
+			want: `hybrid:{query: "I'm a simple string", searches:{nearVector:{certainty: 0.9 vector: [0.1,0.2,0.3]}}}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var hybrid HybridArgumentBuilder
+			tt.apply(&hybrid)
 
-	t.Run("only query", func(t *testing.T) {
-		hybrid := HybridArgumentBuilder{}
-		str := hybrid.WithQuery("query").build()
-		expected := `hybrid:{query: "query"}`
-		require.Equal(t, expected, str)
-	})
+			got := hybrid.build()
 
-	t.Run("query and vector", func(t *testing.T) {
-		hybrid := HybridArgumentBuilder{}
-		str := hybrid.WithQuery("query").WithVector([]float32{1, 2, 3}).build()
-		expected := `hybrid:{query: "query", vector: [1,2,3]}`
-		require.Equal(t, expected, str)
-	})
-
-	t.Run("query and alpha", func(t *testing.T) {
-		hybrid := HybridArgumentBuilder{}
-		str := hybrid.WithQuery("query").WithAlpha(0.6).build()
-		expected := `hybrid:{query: "query", alpha: 0.6}`
-		require.Equal(t, expected, str)
-	})
-
-	t.Run("query with escaping and alpha", func(t *testing.T) {
-		hybrid := HybridArgumentBuilder{}
-
-		str := hybrid.WithQuery("\"I'm a complex string\" says the string").WithAlpha(0.6).build()
-		expected := `hybrid:{query: "\"I'm a complex string\" says the string", alpha: 0.6}`
-		require.Equal(t, expected, str)
-	})
-
-	t.Run("query with fusion type Ranked", func(t *testing.T) {
-		hybrid := HybridArgumentBuilder{}
-
-		str := hybrid.WithQuery("some query").WithFusionType(Ranked).build()
-		expected := `hybrid:{query: "some query", fusionType: rankedFusion}`
-		require.Equal(t, expected, str)
-	})
-
-	t.Run("query with fusion type Relative Score", func(t *testing.T) {
-		hybrid := HybridArgumentBuilder{}
-
-		str := hybrid.WithQuery("some query").WithFusionType(RelativeScore).build()
-		expected := `hybrid:{query: "some query", fusionType: relativeScoreFusion}`
-		require.Equal(t, expected, str)
-	})
-
-	t.Run("query and alpha and targetVectors", func(t *testing.T) {
-		hybrid := HybridArgumentBuilder{}
-		str := hybrid.WithQuery("query").WithAlpha(0.6).WithTargetVectors("t1").build()
-		expected := `hybrid:{query: "query", alpha: 0.6, targetVectors: ["t1"]}`
-		require.Equal(t, expected, str)
-	})
-
-	t.Run("query and nearText search", func(t *testing.T) {
-		neartText := &NearTextArgumentBuilder{}
-		neartText.WithConcepts([]string{"concept"}).WithCertainty(0.9)
-		searches := &HybridSearchesArgumentBuilder{}
-		searches.WithNearText(neartText)
-		hybrid := HybridArgumentBuilder{}
-		str := hybrid.WithQuery("I'm a simple string").WithSearches(searches).build()
-		expected := `hybrid:{query: "I'm a simple string", searches:{nearText:{concepts: ["concept"] certainty: 0.9}}}`
-		require.Equal(t, expected, str)
-	})
-
-	t.Run("query and nearVector search", func(t *testing.T) {
-		neartVector := &NearVectorArgumentBuilder{}
-		neartVector.WithVector([]float32{0.1, 0.2, 0.3}).WithCertainty(0.9)
-		searches := &HybridSearchesArgumentBuilder{}
-		searches.WithNearVector(neartVector)
-		hybrid := HybridArgumentBuilder{}
-		str := hybrid.WithQuery("I'm a simple string").WithSearches(searches).build()
-		expected := `hybrid:{query: "I'm a simple string", searches:{nearVector:{certainty: 0.9 vector: [0.1,0.2,0.3]}}}`
-		require.Equal(t, expected, str)
-	})
+			require.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/weaviate/graphql/hybridbuilder_test.go
+++ b/weaviate/graphql/hybridbuilder_test.go
@@ -87,7 +87,8 @@ func TestHybridBuilder_build(t *testing.T) {
 				)
 				text.WithConcepts([]string{"concept"}).WithCertainty(0.9)
 				searches.WithNearText(&text)
-				h.WithQuery("I'm a simple string").WithSearches(&searches)
+				h.WithQuery("I'm a simple string").
+					WithSearches(&searches)
 			},
 			want: `hybrid:{query: "I'm a simple string", searches:{nearText:{concepts: ["concept"] certainty: 0.9}}}`,
 		},
@@ -103,6 +104,36 @@ func TestHybridBuilder_build(t *testing.T) {
 				h.WithQuery("I'm a simple string").WithSearches(&searches)
 			},
 			want: `hybrid:{query: "I'm a simple string", searches:{nearVector:{certainty: 0.9 vector: [0.1,0.2,0.3]}}}`,
+		},
+		{
+			name: "nearVector with maxVectorDistance",
+			apply: func(h *HybridArgumentBuilder) {
+				var (
+					vector   NearVectorArgumentBuilder
+					searches HybridSearchesArgumentBuilder
+				)
+				vector.WithVector([]float32{0.1, 0.2, 0.3})
+				searches.WithNearVector(&vector)
+				h.WithQuery("I'm a simple string").
+					WithSearches(&searches).
+					WithMaxVectorDistance(0.8)
+			},
+			want: `hybrid:{query: "I'm a simple string", maxVectorDistance: 0.8, searches:{nearVector:{vector: [0.1,0.2,0.3]}}}`,
+		},
+		{
+			name: "nearText with maxVectorDistance",
+			apply: func(h *HybridArgumentBuilder) {
+				var (
+					text     NearTextArgumentBuilder
+					searches HybridSearchesArgumentBuilder
+				)
+				text.WithConcepts([]string{"concept"})
+				searches.WithNearText(&text)
+				h.WithQuery("I'm a simple string").
+					WithSearches(&searches).
+					WithMaxVectorDistance(0.8)
+			},
+			want: `hybrid:{query: "I'm a simple string", maxVectorDistance: 0.8, searches:{nearText:{concepts: ["concept"]}}}`,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #242 

## What is changed?
- GraphQL query builder allows specifying `maxVectorDistance` parameter for hybrid search
- Rewrote `hybridbuilder_test.go` tests in the table-driven format

## How is this tested?
- New test case in `hybridbuilder_test.go`
- Local e2e test to check that the query is valid and returns no errors

## Misc
[GraphQL snippet](https://weaviate.io/developers/weaviate/search/hybrid#vector-search-parameters) in the documentation is not valid, fixed in this PR: https://github.com/weaviate/weaviate-io/pull/2672