### PR TITLE
Adding named vectors to collection

### DIFF
--- a/.github/workflows/workflow-tests.yaml
+++ b/.github/workflows/workflow-tests.yaml
@@ -2,7 +2,7 @@ on:
   workflow_call:
 
 env:
-  WEAVIATE_VERSION: 1.30.0
+  WEAVIATE_VERSION: 1.31.0
 
 jobs:
   auth-tests:

--- a/weaviate/schema/schema.go
+++ b/weaviate/schema/schema.go
@@ -69,6 +69,15 @@ func (schema *API) PropertyCreator() *PropertyCreator {
 	}
 }
 
+// PropertyCreator builder to add a property to an existing schema class
+func (schema *API) VectorAdder() *VectorAdder {
+	return &VectorAdder{
+		connection:   schema.connection,
+		classGetter:  schema.ClassGetter(),
+		classUpdater: schema.ClassUpdater(),
+	}
+}
+
 // ShardsGetter builder to get a weaviate class' shards
 func (schema *API) ShardsGetter() *ShardsGetter {
 	return &ShardsGetter{

--- a/weaviate/schema/vectorAdder.go
+++ b/weaviate/schema/vectorAdder.go
@@ -1,0 +1,46 @@
+package schema
+
+import (
+	"context"
+
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/connection"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// VectorAdder builder to add named vectors to a collection.
+// Named vectors can only be added to collections which already define at least 1 named vector.
+type VectorAdder struct {
+	connection   *connection.Connection
+	className    string
+	addedVectors map[string]models.VectorConfig
+
+	classGetter  *ClassGetter
+	classUpdater *ClassUpdater
+}
+
+// WithClassName sets the collection name for which new vectors will be created.
+func (pc *VectorAdder) WithClassName(className string) *VectorAdder {
+	pc.className = className
+	return pc
+}
+
+// WithVectors accepts configurations to create new named vectors.
+func (pc *VectorAdder) WithVectors(vectors map[string]models.VectorConfig) *VectorAdder {
+	pc.addedVectors = vectors
+	return pc
+}
+
+func (va *VectorAdder) Do(ctx context.Context) error {
+	class, err := va.classGetter.WithClassName(va.className).Do(ctx)
+	if err != nil {
+		return err
+	}
+
+	for name, vector := range va.addedVectors {
+		if _, ok := class.VectorConfig[name]; ok {
+			continue // named vectors are immutable
+		}
+		class.VectorConfig[name] = vector
+	}
+	return va.classUpdater.WithClass(class).Do(ctx)
+}


### PR DESCRIPTION
This PR adds `client.Schema().VectorAdder()` to add new named vectors to existing collections.