### PR TITLE
fix: Always include minimumOrTokensMatch in a GraphQL request

### DIFF
--- a/weaviate/graphql/bm25builder_test.go
+++ b/weaviate/graphql/bm25builder_test.go
@@ -46,7 +46,7 @@ func TestBM25Builder_build(t *testing.T) {
 		)
 		operator.WithOperator(BM25SearchOperatorAnd).WithMinimumMatch(4)
 		got := bm25.WithQuery("hello").WithSearchOperator(operator).build()
-		expected := `bm25:{query: "hello", searchOperator:{operator:And}}`
+		expected := `bm25:{query: "hello", searchOperator:{operator:And minimumOrTokensMatch:0}}`
 		require.Equal(t, expected, got)
 	})
 }

--- a/weaviate/graphql/hybridbuilder_test.go
+++ b/weaviate/graphql/hybridbuilder_test.go
@@ -136,7 +136,7 @@ func TestHybridBuilder_build(t *testing.T) {
 				bm25.WithOperator(BM25SearchOperatorAnd)
 				h.WithQuery("hello").WithBM25SearchOperator(bm25)
 			},
-			want: `hybrid:{query: "hello", bm25SearchOperator:{operator:And}}`,
+			want: `hybrid:{query: "hello", bm25SearchOperator:{operator:And minimumOrTokensMatch:0}}`,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/weaviate/graphql/search_operator.go
+++ b/weaviate/graphql/search_operator.go
@@ -19,15 +19,12 @@ func (bm25 *BM25SearchOperatorBuilder) WithOperator(operator string) *BM25Search
 
 // WithMinimumMatch is only relevant for BM25SearchOperatorOr operator.
 func (bm25 *BM25SearchOperatorBuilder) WithMinimumMatch(times int) *BM25SearchOperatorBuilder {
-	bm25.minimumMatch = times
+	if bm25.operator != BM25SearchOperatorAnd {
+		bm25.minimumMatch = times
+	}
 	return bm25
 }
 
 func (bm25 *BM25SearchOperatorBuilder) build() string {
-	query := fmt.Sprintf("{operator:%s", bm25.operator)
-	if bm25.operator != "And" {
-		query += fmt.Sprintf(" minimumOrTokensMatch:%d", bm25.minimumMatch)
-	}
-	query += "}"
-	return query
+	return fmt.Sprintf("{operator:%s minimumOrTokensMatch:%d}", bm25.operator, bm25.minimumMatch)
 }


### PR DESCRIPTION
See this commit in Java's client repo: https://github.com/weaviate/java-client/pull/386/commits/2ee5c73a582ac10a0806539a04ad28dcbede37d1

As of v1.31.0 `minimumOrTokensMatch` is only optional in gRPC API - GraphQL require that it's always supplied even for `And` operator, where it'll be discovered.