### PR TITLE
Add Experimental gRPC search functionality

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,10 @@ issues:
       text: 'SA1019' # TODO: remove this once deprecated gRPC fields are removed from API
     - linters:
         - staticcheck
+      path: weaviate/graphql/search_result.go
+      text: 'SA1019' # TODO: remove this once deprecated gRPC fields are removed from API
+    - linters:
+        - staticcheck
       text: "SA1029:"
     - linters:
         - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,10 @@ issues:
       text: 'SA1019' # TODO: remove this once deprecated gRPC fields are removed from API
     - linters:
         - staticcheck
+      path: weaviate/graphql/search.go
+      text: 'SA1019' # TODO: remove this once deprecated gRPC fields are removed from API
+    - linters:
+        - staticcheck
       text: "SA1029:"
     - linters:
         - staticcheck

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/weaviate/weaviate-go-client/v5
 
 go 1.24
 
-toolchain go1.24.3
-
 require (
 	github.com/docker/go-connections v0.5.0
 	github.com/go-openapi/strfmt v0.23.0

--- a/test/search/grpc_search_test.go
+++ b/test/search/grpc_search_test.go
@@ -90,7 +90,7 @@ func TestSearch_all_properties(t *testing.T) {
 					"color", "colors", "author", "authors", "number", "numbers", "int", "ints",
 					"uuid", "uuids", "date", "dates", "bool", "bools",
 				}
-				results, err := client.Search().
+				results, err := client.Experimental().Search().
 					WithCollection(className).
 					WithProperties(props...).
 					Do(ctx)
@@ -111,7 +111,7 @@ func TestSearch_all_properties(t *testing.T) {
 					"uuid", "uuids", "date", "dates", "bool", "bools",
 				}
 
-				results, err := client.Search().
+				results, err := client.Experimental().Search().
 					WithCollection(className).
 					WithProperties(props...).
 					WithReferences(&graphql.Reference{
@@ -147,7 +147,7 @@ func TestSearch_all_properties(t *testing.T) {
 					"color", "colors", "author", "authors", "number", "numbers", "int", "ints",
 					"uuid", "uuids", "date", "dates", "bool", "bools",
 				}
-				results, err := client.Search().
+				results, err := client.Experimental().Search().
 					WithCollection(className).
 					WithProperties(props...).
 					WithMetadata(&graphql.Metadata{
@@ -181,7 +181,7 @@ func TestSearch_all_properties(t *testing.T) {
 					WithConcepts([]string{"Jenny"}).
 					WithTargetVectors("author_and_colors").
 					WithCertainty(0.8)
-				results, err := client.Search().
+				results, err := client.Experimental().Search().
 					WithNearText(nearText).
 					WithCollection(className).
 					WithProperties(props...).
@@ -221,7 +221,7 @@ func TestSearch_all_properties(t *testing.T) {
 					WithProperties([]string{"author"}).
 					WithTargetVectors("author_and_colors")
 
-				results, err := client.Search().
+				results, err := client.Experimental().Search().
 					WithHybrid(hybrid).
 					WithCollection(className).
 					WithProperties(props...).
@@ -339,7 +339,7 @@ func TestSearch_all_properties(t *testing.T) {
 		})
 		t.Run("search", func(t *testing.T) {
 			bm25 := client.GraphQL().Bm25ArgBuilder().WithQuery("name 1").WithProperties("name")
-			results, err := client.Search().
+			results, err := client.Experimental().Search().
 				WithBM25(bm25).
 				WithCollection(noVectorizerClass).
 				WithMetadata(&graphql.Metadata{
@@ -365,7 +365,7 @@ func TestSearch_all_properties(t *testing.T) {
 					"regular": {[]float32{1, 2}},
 					"colbert": {[][]float32{{0.09, 0.11}, {0.22, 0.33}, {0.33, 0.44}}},
 				})
-			results, err := client.Search().
+			results, err := client.Experimental().Search().
 				WithNearVector(nearVector).
 				WithCollection(noVectorizerClass).
 				WithMetadata(&graphql.Metadata{

--- a/test/search/search_all_properties_test.go
+++ b/test/search/search_all_properties_test.go
@@ -1,0 +1,364 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v5/test/testsuit"
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/graphql"
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/testenv"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func TestSearch_all_properties(t *testing.T) {
+	ctx := context.Background()
+
+	err := testenv.SetupLocalWeaviate()
+	if err != nil {
+		require.Nil(t, err, "failed to start weaviate")
+	}
+	client := testsuit.CreateTestClient(true)
+
+	t.Run("clean DB", func(t *testing.T) {
+		err := client.Schema().AllDeleter().Do(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("search with all properties", func(t *testing.T) {
+		className := "AllPropertiesWithCrossRefsAndMultipleVectorizers"
+		t.Run("gRPC batch import", func(t *testing.T) {
+			tests := []struct {
+				name                string
+				className           string
+				properties          []map[string]interface{}
+				withCrossRefs       bool
+				withMultipleVectors bool
+			}{
+				{
+					name:                "all primitive properties with cross references (single and multi ref types) with nested with nested array objects and with multiple vectorizers configuration",
+					className:           className,
+					properties:          testsuit.AllPropertiesDataWithCrossReferencesWithNestedArrayObjectsAsMap(),
+					withCrossRefs:       true,
+					withMultipleVectors: true,
+				},
+			}
+			for _, tt := range tests {
+				className := tt.className
+				objects := testsuit.AllPropertiesObjectsWithData(className, tt.properties)
+				data := tt.properties
+
+				testsuit.AllPropertiesSchemaCreate(t, client, className, tt.withCrossRefs, tt.withMultipleVectors)
+
+				batchResultSlice, batchErrSlice := client.Batch().ObjectsBatcher().WithObjects(objects...).Do(ctx)
+				assert.Nil(t, batchErrSlice)
+				assert.NotNil(t, batchResultSlice)
+				assert.Equal(t, 3, len(batchResultSlice))
+
+				for i := range objects {
+					objs, err := client.Data().ObjectsGetter().
+						WithID(objects[i].ID.String()).
+						WithClassName(objects[i].Class).
+						WithVector().
+						Do(ctx)
+					require.NoError(t, err)
+					require.Len(t, objs, 1)
+					obj := objs[0]
+					assert.Equal(t, className, obj.Class)
+					props, ok := obj.Properties.(map[string]interface{})
+					require.True(t, ok)
+					require.NotNil(t, props)
+					properties := data[i]
+					require.Equal(t, len(props), len(properties))
+					for propName := range properties {
+						assert.NotNil(t, props[propName])
+					}
+					if tt.withMultipleVectors {
+						assert.Len(t, obj.Vectors, 2)
+					}
+				}
+			}
+		})
+
+		t.Run("search", func(t *testing.T) {
+			t.Run("find all primitive and array types", func(t *testing.T) {
+				props := []string{
+					"color", "colors", "author", "authors", "number", "numbers", "int", "ints",
+					"uuid", "uuids", "date", "dates", "bool", "bools",
+				}
+				results, err := client.Search().
+					WithCollection(className).
+					WithProperties(props...).
+					Do(ctx)
+				require.NoError(t, err)
+				assert.Len(t, results, 3)
+				for _, res := range results {
+					assert.NotEmpty(t, res.ID)
+					assert.Equal(t, className, res.Collection)
+					require.Len(t, res.Properties, len(props))
+					for _, prop := range props {
+						assert.NotNil(t, res.Properties[prop])
+					}
+				}
+			})
+			t.Run("find all primitive and array and reference types", func(t *testing.T) {
+				props := []string{
+					"color", "colors", "author", "authors", "number", "numbers", "int", "ints",
+					"uuid", "uuids", "date", "dates", "bool", "bools",
+				}
+
+				results, err := client.Search().
+					WithCollection(className).
+					WithProperties(props...).
+					WithReferences(&graphql.Reference{
+						ReferenceProperty: "hasRefClass",
+						TargetCollection:  "RefClass",
+						Properties:        []string{"category"},
+						Metadata:          &graphql.Metadata{ID: true},
+					}).
+					Do(ctx)
+				require.NoError(t, err)
+				assert.Len(t, results, 3)
+				for _, res := range results {
+					assert.NotEmpty(t, res.ID)
+					assert.Equal(t, className, res.Collection)
+					require.Len(t, res.Properties, len(props))
+					for _, prop := range props {
+						assert.NotNil(t, res.Properties[prop])
+					}
+					require.NotEmpty(t, res.References)
+					for _, ref := range res.References {
+						assert.Equal(t, "hasRefClass", ref.Name)
+						require.Len(t, ref.ReferenceProperties, 1)
+						for _, refProps := range ref.ReferenceProperties {
+							require.Len(t, refProps.Properties, 1)
+							assert.NotNil(t, refProps.Properties["category"])
+							assert.NotEmpty(t, refProps.Metadata.ID)
+						}
+					}
+				}
+			})
+			t.Run("find all primitive and array types along with metadata", func(t *testing.T) {
+				props := []string{
+					"color", "colors", "author", "authors", "number", "numbers", "int", "ints",
+					"uuid", "uuids", "date", "dates", "bool", "bools",
+				}
+				results, err := client.Search().
+					WithCollection(className).
+					WithProperties(props...).
+					WithMetadata(&graphql.Metadata{
+						ID: true, CreationTimeUnix: true, LastUpdateTimeUnix: true, Vector: true, Vectors: []string{"author_and_colors"},
+					}).
+					Do(ctx)
+				require.NoError(t, err)
+				assert.Len(t, results, 3)
+				for _, res := range results {
+					assert.NotEmpty(t, res.ID)
+					assert.Equal(t, className, res.Collection)
+					require.Len(t, res.Properties, len(props))
+					for _, prop := range props {
+						assert.NotNil(t, res.Properties[prop])
+					}
+					assert.True(t, res.Metadata.CreationTimeUnix > 0)
+					assert.True(t, res.Metadata.LastUpdateTimeUnix > 0)
+					assert.Empty(t, res.Vector)
+					require.NotEmpty(t, res.Vectors)
+					require.NotNil(t, res.Vectors["author_and_colors"])
+					assert.NotEmpty(t, res.Vectors["author_and_colors"].GetVector())
+				}
+			})
+
+			t.Run("find all primitive and array types along with metadata with nearText", func(t *testing.T) {
+				props := []string{
+					"color", "colors", "author", "authors", "number", "numbers", "int", "ints",
+					"uuid", "uuids", "date", "dates", "bool", "bools",
+				}
+				nearText := client.GraphQL().NearTextArgBuilder().
+					WithConcepts([]string{"Jenny"}).
+					WithTargetVectors("author_and_colors").
+					WithCertainty(0.8)
+				results, err := client.Search().
+					WithNearText(nearText).
+					WithCollection(className).
+					WithProperties(props...).
+					WithMetadata(&graphql.Metadata{
+						ID: true, Certainty: true, CreationTimeUnix: true, LastUpdateTimeUnix: true, Vector: true, Vectors: []string{"author_and_colors"},
+					}).
+					Do(ctx)
+				require.NoError(t, err)
+				assert.Len(t, results, 1)
+				for _, res := range results {
+					assert.NotEmpty(t, res.ID)
+					assert.Equal(t, className, res.Collection)
+					require.Len(t, res.Properties, len(props))
+					for _, prop := range props {
+						assert.NotNil(t, res.Properties[prop])
+					}
+					assert.True(t, res.Metadata.CreationTimeUnix > 0)
+					assert.True(t, res.Metadata.LastUpdateTimeUnix > 0)
+					assert.True(t, res.Metadata.Certainty > 0.8)
+					assert.Empty(t, res.Vector)
+					require.NotEmpty(t, res.Vectors)
+					assert.NotNil(t, res.Vectors["author_and_colors"])
+				}
+			})
+			t.Run("find all primitive and array types along with metadata with hybrid", func(t *testing.T) {
+				t.Skip("it fails needs investigation")
+				props := []string{
+					"color", "colors", "author", "authors", "number", "numbers", "int", "ints",
+					"uuid", "uuids", "date", "dates", "bool", "bools",
+				}
+
+				nearText := client.GraphQL().NearTextArgBuilder().WithConcepts([]string{"Jenny"})
+				searches := client.GraphQL().HybridSearchesArgumentBuilder().WithNearText(nearText)
+				hybrid := client.GraphQL().HybridArgumentBuilder().
+					WithQuery("Jenny").
+					WithSearches(searches).
+					WithProperties([]string{"author"}).
+					WithTargetVectors("author_and_colors")
+
+				results, err := client.Search().
+					WithHybrid(hybrid).
+					WithCollection(className).
+					WithProperties(props...).
+					WithMetadata(&graphql.Metadata{
+						ID: true, Score: true, ExplainScore: true, Vectors: []string{"author_and_colors"},
+					}).
+					Do(ctx)
+				require.NoError(t, err)
+				assert.Len(t, results, 3)
+				for i, res := range results {
+					assert.NotEmpty(t, res.ID)
+					assert.Equal(t, className, res.Collection)
+					require.Len(t, res.Properties, len(props))
+					for _, prop := range props {
+						assert.NotNil(t, res.Properties[prop])
+					}
+					if i == 0 {
+						assert.Equal(t, res.Metadata.Score, 1)
+					}
+					if i == 1 {
+						assert.True(t, res.Metadata.Score > 0)
+					}
+					if i == 2 {
+						assert.Equal(t, res.Metadata.Score, 0)
+					}
+					assert.NotEmpty(t, res.Metadata.ExplainScore)
+					assert.Empty(t, res.Vector)
+					require.NotEmpty(t, res.Vectors)
+					assert.NotNil(t, res.Vectors["author_and_colors"])
+				}
+			})
+		})
+	})
+
+	t.Run("multivectors", func(t *testing.T) {
+		noVectorizerClass := "NoVectorizerWithMultiVectors"
+		t.Run("create class", func(t *testing.T) {
+			class := &models.Class{
+				Class: noVectorizerClass,
+				Properties: []*models.Property{
+					{
+						Name:     "name",
+						DataType: []string{schema.DataTypeText.String()},
+					},
+				},
+				VectorConfig: map[string]models.VectorConfig{
+					"regular": {
+						Vectorizer: map[string]interface{}{
+							"none": nil,
+						},
+						VectorIndexType: "hnsw",
+					},
+					"colbert": {
+						Vectorizer: map[string]interface{}{
+							"none": nil,
+						},
+						VectorIndexConfig: map[string]interface{}{
+							"multivector": map[string]interface{}{
+								"enabled": true,
+							},
+						},
+						VectorIndexType: "hnsw",
+					},
+				},
+			}
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.NoError(t, err)
+		})
+		t.Run("import data", func(t *testing.T) {
+			vectors := []models.Vectors{
+				{
+					"regular": []float32{1, 2},
+					"colbert": [][]float32{{0.09, 0.11}, {0.22, 0.33}, {0.33, 0.44}},
+				},
+				{
+					"regular": []float32{3, 4},
+					"colbert": [][]float32{{0.19, 0.21}, {0.333, 0.33}, {0.33, 0.33333}},
+				},
+				{
+					"regular": []float32{1, 1},
+					"colbert": [][]float32{{0.1111111, 0.1}, {0.1, 0.1}, {0.1, 0.1}},
+				},
+			}
+			objs := make([]*models.Object, len(vectors))
+			for i, v := range vectors {
+				id := strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-00000000000%v", i))
+				objs[i] = &models.Object{
+					ID:    id,
+					Class: noVectorizerClass,
+					Properties: map[string]any{
+						"name": fmt.Sprintf("name %v", i),
+					},
+					Vectors: v,
+				}
+			}
+			batchResponse, err := client.Batch().ObjectsBatcher().WithObjects(objs...).Do(ctx)
+			require.NoError(t, err)
+			assert.NotNil(t, batchResponse)
+			assert.Equal(t, len(objs), len(batchResponse))
+			// get object
+			for i := range vectors {
+				id := fmt.Sprintf("00000000-0000-0000-0000-00000000000%v", i)
+				res, err := client.Data().ObjectsGetter().
+					WithClassName(noVectorizerClass).WithID(id).
+					WithVector().
+					Do(ctx)
+				require.NoError(t, err)
+				require.NotEmpty(t, res)
+				require.Len(t, res, 1)
+				assert.Equal(t, id, res[0].ID.String())
+				require.Len(t, res[0].Vectors, 2)
+				assert.NotNil(t, res[0].Vectors["regular"])
+				assert.NotNil(t, res[0].Vectors["colbert"])
+			}
+		})
+		t.Run("search", func(t *testing.T) {
+			bm25 := client.GraphQL().Bm25ArgBuilder().WithQuery("name 1").WithProperties("name")
+			results, err := client.Search().
+				WithBM25(bm25).
+				WithCollection(noVectorizerClass).
+				WithMetadata(&graphql.Metadata{
+					ID: true, Vectors: []string{"regular", "colbert"},
+				}).
+				Do(ctx)
+			require.NoError(t, err)
+			assert.Len(t, results, 3)
+			for _, res := range results {
+				assert.NotEmpty(t, res.ID)
+				assert.Equal(t, noVectorizerClass, res.Collection)
+				require.Len(t, res.Vectors, 2)
+				assert.NotNil(t, res.Vectors["regular"].Vector)
+				assert.NotNil(t, res.Vectors["regular"].GetVector())
+				assert.NotNil(t, res.Vectors["colbert"].Vector)
+				assert.NotNil(t, res.Vectors["colbert"].GetMultiVector())
+			}
+		})
+	})
+
+	require.Nil(t, testenv.TearDownLocalWeaviate(), "failed to tear down weaviate")
+}

--- a/weaviate/connection/grpc.go
+++ b/weaviate/connection/grpc.go
@@ -35,6 +35,13 @@ func NewGrpcClient(host string, secured bool, headers map[string]string,
 	return &GrpcClient{client, headers, timeout, grpcbatch.New(gRPCVersionSupport)}, nil
 }
 
+func (c *GrpcClient) Search(ctx context.Context, req *pb.SearchRequest) (*pb.SearchReply, error) {
+	ctxWithTimeoutAndHeaders, cancel := c.ctxWithTimeoutWithHeaders(ctx)
+	defer cancel()
+
+	return c.client.Search(ctxWithTimeoutAndHeaders, req, c.getOptions()...)
+}
+
 func (c *GrpcClient) BatchObjects(ctx context.Context, objects []*models.Object,
 	consistencyLevel string,
 ) ([]models.ObjectsGetResponse, error) {

--- a/weaviate/crossref/beacon.go
+++ b/weaviate/crossref/beacon.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/db"
+	"github.com/weaviate/weaviate/entities/schema/crossref"
 )
 
 func BuildBeacon(id, className string, dbVersion *db.VersionSupport) string {
@@ -17,4 +18,11 @@ func BuildBeacon(id, className string, dbVersion *db.VersionSupport) string {
 		dbVersion.WarnUsageOfNotSupportedClassNamespacedEndpointsForBeacons()
 	}
 	return fmt.Sprintf("weaviate://localhost/%v", id)
+}
+
+func ExtractID(beacon string) string {
+	if ref, err := crossref.Parse(beacon); err == nil {
+		return ref.TargetID.String()
+	}
+	return ""
 }

--- a/weaviate/graphql/bm25builder.go
+++ b/weaviate/graphql/bm25builder.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
 
 type BM25ArgumentBuilder struct {
@@ -46,4 +48,12 @@ func (b *BM25ArgumentBuilder) build() string {
 		clause = append(clause, fmt.Sprintf("searchOperator:%s", b.searchOperator.build()))
 	}
 	return fmt.Sprintf("bm25:{%v}", strings.Join(clause, ", "))
+}
+
+func (b *BM25ArgumentBuilder) togrpc() *pb.BM25 {
+	bm25 := &pb.BM25{
+		Query:      b.query,
+		Properties: b.properties,
+	}
+	return bm25
 }

--- a/weaviate/graphql/hybridbuilder.go
+++ b/weaviate/graphql/hybridbuilder.go
@@ -173,10 +173,11 @@ func (h *HybridArgumentBuilder) togrpc() *pb.Hybrid {
 	if !h.isVectorEmpty(h.vector) {
 		hybrid.Vectors = []*pb.Vectors{common.GetVector("", h.vector)}
 	}
+	if h.targets != nil {
+		hybrid.Targets = h.targets.togrpc()
+	}
 	if len(h.targetVectors) > 0 && h.targets == nil {
-		hybrid.Targets = &pb.Targets{
-			TargetVectors: h.targetVectors,
-		}
+		hybrid.Targets = &pb.Targets{TargetVectors: h.targetVectors}
 	}
 	switch h.fusionType {
 	case Ranked:
@@ -193,6 +194,9 @@ func (h *HybridArgumentBuilder) togrpc() *pb.Hybrid {
 		if h.searches.nearVector != nil {
 			hybrid.NearVector = h.searches.nearVector.togrpc()
 		}
+	}
+	if h.bm25SearchOperator != nil {
+		hybrid.Bm25SearchOperator = h.bm25SearchOperator.togrpc()
 	}
 	return hybrid
 }

--- a/weaviate/graphql/multitargetbuilder_test.go
+++ b/weaviate/graphql/multitargetbuilder_test.go
@@ -116,16 +116,9 @@ func TestMultiTargetArgumentBuilder(t *testing.T) {
 		assert.Len(t, targets.TargetVectors, 3)
 		assert.Contains(t, targets.TargetVectors, "one", "two")
 		assert.Len(t, targets.WeightsForTargets, 3)
-		for i, w := range targets.WeightsForTargets {
+		for _, w := range targets.WeightsForTargets {
 			if w.Target == "one" {
 				assert.Equal(t, w.Weight, float32(1))
-			}
-			if w.Target == "two" {
-				if i == 1 {
-					assert.Equal(t, w.Weight, float32(2))
-				} else {
-					assert.Equal(t, w.Weight, float32(3))
-				}
 			}
 		}
 	})

--- a/weaviate/graphql/nearaudiobuilder.go
+++ b/weaviate/graphql/nearaudiobuilder.go
@@ -2,6 +2,8 @@ package graphql
 
 import (
 	"io"
+
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
 
 type NearAudioArgumentBuilder struct {
@@ -73,4 +75,24 @@ func (b *NearAudioArgumentBuilder) build() string {
 	}
 	builder.withTargets(b.targets)
 	return builder.build()
+}
+
+func (b *NearAudioArgumentBuilder) togrpc() *pb.NearAudioSearch {
+	builder := &nearMediaArgumentBuilder{
+		data:       b.audio,
+		dataReader: b.audioReader,
+	}
+	nearAudio := &pb.NearAudioSearch{
+		Audio:         builder.getContent(),
+		TargetVectors: b.targetVectors,
+	}
+	if b.hasCertainty {
+		certainty := float64(b.certainty)
+		nearAudio.Certainty = &certainty
+	}
+	if b.hasDistance {
+		distance := float64(b.distance)
+		nearAudio.Distance = &distance
+	}
+	return nearAudio
 }

--- a/weaviate/graphql/nearaudiobuilder.go
+++ b/weaviate/graphql/nearaudiobuilder.go
@@ -83,8 +83,7 @@ func (b *NearAudioArgumentBuilder) togrpc() *pb.NearAudioSearch {
 		dataReader: b.audioReader,
 	}
 	nearAudio := &pb.NearAudioSearch{
-		Audio:         builder.getContent(),
-		TargetVectors: b.targetVectors,
+		Audio: builder.getContent(),
 	}
 	if b.hasCertainty {
 		certainty := float64(b.certainty)
@@ -93,6 +92,12 @@ func (b *NearAudioArgumentBuilder) togrpc() *pb.NearAudioSearch {
 	if b.hasDistance {
 		distance := float64(b.distance)
 		nearAudio.Distance = &distance
+	}
+	if b.targets != nil {
+		nearAudio.Targets = b.targets.togrpc()
+	}
+	if len(b.targetVectors) > 0 && b.targets == nil {
+		nearAudio.Targets = &pb.Targets{TargetVectors: b.targetVectors}
 	}
 	return nearAudio
 }

--- a/weaviate/graphql/neardepthbuilder.go
+++ b/weaviate/graphql/neardepthbuilder.go
@@ -83,8 +83,7 @@ func (b *NearDepthArgumentBuilder) togrpc() *pb.NearDepthSearch {
 		dataReader: b.depthReader,
 	}
 	nearDepth := &pb.NearDepthSearch{
-		Depth:         builder.getContent(),
-		TargetVectors: b.targetVectors,
+		Depth: builder.getContent(),
 	}
 	if b.hasCertainty {
 		certainty := float64(b.certainty)
@@ -93,6 +92,12 @@ func (b *NearDepthArgumentBuilder) togrpc() *pb.NearDepthSearch {
 	if b.hasDistance {
 		distance := float64(b.distance)
 		nearDepth.Distance = &distance
+	}
+	if b.targets != nil {
+		nearDepth.Targets = b.targets.togrpc()
+	}
+	if len(b.targetVectors) > 0 && b.targets == nil {
+		nearDepth.Targets = &pb.Targets{TargetVectors: b.targetVectors}
 	}
 	return nearDepth
 }

--- a/weaviate/graphql/neardepthbuilder.go
+++ b/weaviate/graphql/neardepthbuilder.go
@@ -95,8 +95,7 @@ func (b *NearDepthArgumentBuilder) togrpc() *pb.NearDepthSearch {
 	}
 	if b.targets != nil {
 		nearDepth.Targets = b.targets.togrpc()
-	}
-	if len(b.targetVectors) > 0 && b.targets == nil {
+	} else if len(b.targetVectors) > 0 {
 		nearDepth.Targets = &pb.Targets{TargetVectors: b.targetVectors}
 	}
 	return nearDepth

--- a/weaviate/graphql/neardepthbuilder.go
+++ b/weaviate/graphql/neardepthbuilder.go
@@ -2,6 +2,8 @@ package graphql
 
 import (
 	"io"
+
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
 
 type NearDepthArgumentBuilder struct {
@@ -73,4 +75,24 @@ func (b *NearDepthArgumentBuilder) build() string {
 	}
 	builder.withTargets(b.targets)
 	return builder.build()
+}
+
+func (b *NearDepthArgumentBuilder) togrpc() *pb.NearDepthSearch {
+	builder := &nearMediaArgumentBuilder{
+		data:       b.depth,
+		dataReader: b.depthReader,
+	}
+	nearDepth := &pb.NearDepthSearch{
+		Depth:         builder.getContent(),
+		TargetVectors: b.targetVectors,
+	}
+	if b.hasCertainty {
+		certainty := float64(b.certainty)
+		nearDepth.Certainty = &certainty
+	}
+	if b.hasDistance {
+		distance := float64(b.distance)
+		nearDepth.Distance = &distance
+	}
+	return nearDepth
 }

--- a/weaviate/graphql/nearimagebuilder.go
+++ b/weaviate/graphql/nearimagebuilder.go
@@ -2,6 +2,8 @@ package graphql
 
 import (
 	"io"
+
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
 
 type NearImageArgumentBuilder struct {
@@ -73,4 +75,24 @@ func (b *NearImageArgumentBuilder) build() string {
 	}
 	builder.withTargets(b.targets)
 	return builder.build()
+}
+
+func (b *NearImageArgumentBuilder) togrpc() *pb.NearImageSearch {
+	builder := &nearMediaArgumentBuilder{
+		data:       b.image,
+		dataReader: b.imageReader,
+	}
+	nearImage := &pb.NearImageSearch{
+		Image:         builder.getContent(),
+		TargetVectors: b.targetVectors,
+	}
+	if b.hasCertainty {
+		certainty := float64(b.certainty)
+		nearImage.Certainty = &certainty
+	}
+	if b.hasDistance {
+		distance := float64(b.distance)
+		nearImage.Distance = &distance
+	}
+	return nearImage
 }

--- a/weaviate/graphql/nearimagebuilder.go
+++ b/weaviate/graphql/nearimagebuilder.go
@@ -83,8 +83,7 @@ func (b *NearImageArgumentBuilder) togrpc() *pb.NearImageSearch {
 		dataReader: b.imageReader,
 	}
 	nearImage := &pb.NearImageSearch{
-		Image:         builder.getContent(),
-		TargetVectors: b.targetVectors,
+		Image: builder.getContent(),
 	}
 	if b.hasCertainty {
 		certainty := float64(b.certainty)
@@ -93,6 +92,12 @@ func (b *NearImageArgumentBuilder) togrpc() *pb.NearImageSearch {
 	if b.hasDistance {
 		distance := float64(b.distance)
 		nearImage.Distance = &distance
+	}
+	if b.targets != nil {
+		nearImage.Targets = b.targets.togrpc()
+	}
+	if len(b.targetVectors) > 0 && b.targets == nil {
+		nearImage.Targets = &pb.Targets{TargetVectors: b.targetVectors}
 	}
 	return nearImage
 }

--- a/weaviate/graphql/nearimubuilder.go
+++ b/weaviate/graphql/nearimubuilder.go
@@ -84,8 +84,7 @@ func (b *NearImuArgumentBuilder) togrpc() *pb.NearIMUSearch {
 		dataReader: b.imuReader,
 	}
 	nearIMU := &pb.NearIMUSearch{
-		Imu:           builder.getContent(),
-		TargetVectors: b.targetVectors,
+		Imu: builder.getContent(),
 	}
 	if b.hasCertainty {
 		certainty := float64(b.certainty)
@@ -94,6 +93,12 @@ func (b *NearImuArgumentBuilder) togrpc() *pb.NearIMUSearch {
 	if b.hasDistance {
 		distance := float64(b.distance)
 		nearIMU.Distance = &distance
+	}
+	if b.targets != nil {
+		nearIMU.Targets = b.targets.togrpc()
+	}
+	if len(b.targetVectors) > 0 && b.targets == nil {
+		nearIMU.Targets = &pb.Targets{TargetVectors: b.targetVectors}
 	}
 	return nearIMU
 }

--- a/weaviate/graphql/nearimubuilder.go
+++ b/weaviate/graphql/nearimubuilder.go
@@ -2,6 +2,8 @@ package graphql
 
 import (
 	"io"
+
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
 
 type NearImuArgumentBuilder struct {
@@ -74,4 +76,24 @@ func (b *NearImuArgumentBuilder) build() string {
 	}
 	builder.withTargets((b.targets))
 	return builder.build()
+}
+
+func (b *NearImuArgumentBuilder) togrpc() *pb.NearIMUSearch {
+	builder := &nearMediaArgumentBuilder{
+		data:       b.imu,
+		dataReader: b.imuReader,
+	}
+	nearIMU := &pb.NearIMUSearch{
+		Imu:           builder.getContent(),
+		TargetVectors: b.targetVectors,
+	}
+	if b.hasCertainty {
+		certainty := float64(b.certainty)
+		nearIMU.Certainty = &certainty
+	}
+	if b.hasDistance {
+		distance := float64(b.distance)
+		nearIMU.Distance = &distance
+	}
+	return nearIMU
 }

--- a/weaviate/graphql/nearobjectbuilder.go
+++ b/weaviate/graphql/nearobjectbuilder.go
@@ -22,91 +22,91 @@ type NearObjectArgumentBuilder struct {
 }
 
 // WithID the id of the object
-func (e *NearObjectArgumentBuilder) WithID(id string) *NearObjectArgumentBuilder {
-	e.id = id
-	return e
+func (b *NearObjectArgumentBuilder) WithID(id string) *NearObjectArgumentBuilder {
+	b.id = id
+	return b
 }
 
 // WithBeacon the beacon of the object
-func (e *NearObjectArgumentBuilder) WithBeacon(beacon string) *NearObjectArgumentBuilder {
-	e.beacon = beacon
-	return e
+func (b *NearObjectArgumentBuilder) WithBeacon(beacon string) *NearObjectArgumentBuilder {
+	b.beacon = beacon
+	return b
 }
 
 // WithCertainty that is minimally required for an object to be included in the result set
-func (e *NearObjectArgumentBuilder) WithCertainty(certainty float32) *NearObjectArgumentBuilder {
-	e.withCertainty = true
-	e.certainty = certainty
-	return e
+func (b *NearObjectArgumentBuilder) WithCertainty(certainty float32) *NearObjectArgumentBuilder {
+	b.withCertainty = true
+	b.certainty = certainty
+	return b
 }
 
 // WithDistance that is minimally required for an object to be included in the result set
-func (e *NearObjectArgumentBuilder) WithDistance(distance float32) *NearObjectArgumentBuilder {
-	e.withDistance = true
-	e.distance = distance
-	return e
+func (b *NearObjectArgumentBuilder) WithDistance(distance float32) *NearObjectArgumentBuilder {
+	b.withDistance = true
+	b.distance = distance
+	return b
 }
 
 // WithTargetVectors target vector name
-func (e *NearObjectArgumentBuilder) WithTargetVectors(targetVectors ...string) *NearObjectArgumentBuilder {
+func (b *NearObjectArgumentBuilder) WithTargetVectors(targetVectors ...string) *NearObjectArgumentBuilder {
 	if len(targetVectors) > 0 {
-		e.targetVectors = targetVectors
+		b.targetVectors = targetVectors
 	}
-	return e
+	return b
 }
 
 // WithTargets sets the multi target vectors to be used with hybrid query. This builder takes precedence over WithTargetVectors.
 // So if WithTargets is used, WithTargetVectors will be ignored.
-func (h *NearObjectArgumentBuilder) WithTargets(targets *MultiTargetArgumentBuilder) *NearObjectArgumentBuilder {
-	h.targets = targets
-	return h
+func (b *NearObjectArgumentBuilder) WithTargets(targets *MultiTargetArgumentBuilder) *NearObjectArgumentBuilder {
+	b.targets = targets
+	return b
 }
 
 // Build build the given clause
-func (e *NearObjectArgumentBuilder) build() string {
+func (b *NearObjectArgumentBuilder) build() string {
 	clause := []string{}
-	if len(e.id) > 0 {
-		clause = append(clause, fmt.Sprintf("id: \"%s\"", e.id))
+	if len(b.id) > 0 {
+		clause = append(clause, fmt.Sprintf("id: \"%s\"", b.id))
 	}
-	if len(e.beacon) > 0 {
-		clause = append(clause, fmt.Sprintf("beacon: \"%s\"", e.beacon))
+	if len(b.beacon) > 0 {
+		clause = append(clause, fmt.Sprintf("beacon: \"%s\"", b.beacon))
 	}
-	if e.withCertainty {
-		clause = append(clause, fmt.Sprintf("certainty: %v", e.certainty))
+	if b.withCertainty {
+		clause = append(clause, fmt.Sprintf("certainty: %v", b.certainty))
 	}
-	if e.withDistance {
-		clause = append(clause, fmt.Sprintf("distance: %v", e.distance))
+	if b.withDistance {
+		clause = append(clause, fmt.Sprintf("distance: %v", b.distance))
 	}
-	if e.targets != nil {
-		clause = append(clause, fmt.Sprintf("targets:{%s}", e.targets.build()))
+	if b.targets != nil {
+		clause = append(clause, fmt.Sprintf("targets:{%s}", b.targets.build()))
 	}
-	if len(e.targetVectors) > 0 && e.targets == nil {
-		targetVectors, _ := json.Marshal(e.targetVectors)
+	if len(b.targetVectors) > 0 && b.targets == nil {
+		targetVectors, _ := json.Marshal(b.targetVectors)
 		clause = append(clause, fmt.Sprintf("targetVectors: %s", targetVectors))
 	}
 	return fmt.Sprintf("nearObject:{%s}", strings.Join(clause, " "))
 }
 
-func (e *NearObjectArgumentBuilder) togrpc() *pb.NearObject {
+func (b *NearObjectArgumentBuilder) togrpc() *pb.NearObject {
 	nearObject := &pb.NearObject{}
-	id := e.id
-	if len(e.beacon) > 0 {
-		id = crossref.ExtractID(e.beacon)
+	id := b.id
+	if len(b.beacon) > 0 {
+		id = crossref.ExtractID(b.beacon)
 	}
 	nearObject.Id = id
-	if e.withCertainty {
-		certainty := float64(e.certainty)
+	if b.withCertainty {
+		certainty := float64(b.certainty)
 		nearObject.Certainty = &certainty
 	}
-	if e.withDistance {
-		distance := float64(e.distance)
+	if b.withDistance {
+		distance := float64(b.distance)
 		nearObject.Distance = &distance
 	}
-	if e.targets != nil {
-		nearObject.Targets = e.targets.togrpc()
+	if b.targets != nil {
+		nearObject.Targets = b.targets.togrpc()
 	}
-	if len(e.targetVectors) > 0 && e.targets == nil {
-		nearObject.Targets = &pb.Targets{TargetVectors: e.targetVectors}
+	if len(b.targetVectors) > 0 && b.targets == nil {
+		nearObject.Targets = &pb.Targets{TargetVectors: b.targetVectors}
 	}
 	return nearObject
 }

--- a/weaviate/graphql/nearobjectbuilder.go
+++ b/weaviate/graphql/nearobjectbuilder.go
@@ -102,10 +102,11 @@ func (e *NearObjectArgumentBuilder) togrpc() *pb.NearObject {
 		distance := float64(e.distance)
 		nearObject.Distance = &distance
 	}
+	if e.targets != nil {
+		nearObject.Targets = e.targets.togrpc()
+	}
 	if len(e.targetVectors) > 0 && e.targets == nil {
-		nearObject.Targets = &pb.Targets{
-			TargetVectors: e.targetVectors,
-		}
+		nearObject.Targets = &pb.Targets{TargetVectors: e.targetVectors}
 	}
 	return nearObject
 }

--- a/weaviate/graphql/neartextbuilder.go
+++ b/weaviate/graphql/neartextbuilder.go
@@ -196,7 +196,7 @@ func (e *NearTextArgumentBuilder) togrpc() *pb.NearTextSearch {
 	return nearText
 }
 
-func (e *NearTextArgumentBuilder) parseMoveParam(moveParam *MoveParameters) *pb.NearTextSearch_Move {
+func (e *NearTextArgumentBuilder) buildMoveParam(moveParam *MoveParameters) *pb.NearTextSearch_Move {
 	move := &pb.NearTextSearch_Move{
 		Concepts: moveParam.Concepts,
 	}

--- a/weaviate/graphql/neartextbuilder.go
+++ b/weaviate/graphql/neartextbuilder.go
@@ -182,10 +182,10 @@ func (e *NearTextArgumentBuilder) togrpc() *pb.NearTextSearch {
 		nearText.Distance = &distance
 	}
 	if e.moveTo != nil {
-		nearText.MoveTo = e.parseMoveParam(e.moveTo)
+		nearText.MoveTo = e.buildMoveParam(e.moveTo)
 	}
 	if e.moveAwayFrom != nil {
-		nearText.MoveAway = e.parseMoveParam(e.moveAwayFrom)
+		nearText.MoveAway = e.buildMoveParam(e.moveAwayFrom)
 	}
 	if e.targets != nil {
 		nearText.Targets = e.targets.togrpc()

--- a/weaviate/graphql/neartextbuilder.go
+++ b/weaviate/graphql/neartextbuilder.go
@@ -171,8 +171,7 @@ func (e *NearTextArgumentBuilder) build() string {
 
 func (e *NearTextArgumentBuilder) togrpc() *pb.NearTextSearch {
 	nearText := &pb.NearTextSearch{
-		Query:         e.concepts,
-		TargetVectors: e.targetVectors,
+		Query: e.concepts,
 	}
 	if e.withCertainty {
 		certainty := float64(e.certainty)
@@ -187,6 +186,12 @@ func (e *NearTextArgumentBuilder) togrpc() *pb.NearTextSearch {
 	}
 	if e.moveAwayFrom != nil {
 		nearText.MoveAway = e.parseMoveParam(e.moveAwayFrom)
+	}
+	if e.targets != nil {
+		nearText.Targets = e.targets.togrpc()
+	}
+	if len(e.targetVectors) > 0 && e.targets == nil {
+		nearText.Targets = &pb.Targets{TargetVectors: e.targetVectors}
 	}
 	return nearText
 }

--- a/weaviate/graphql/neartextbuilder.go
+++ b/weaviate/graphql/neartextbuilder.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
 
 // fldMover is a type representing field names of a move sub query
@@ -165,4 +167,44 @@ func (e *NearTextArgumentBuilder) build() string {
 		clause = append(clause, fmt.Sprintf("targetVectors: %s", targetVectors))
 	}
 	return fmt.Sprintf("nearText:{%v}", strings.Join(clause, " "))
+}
+
+func (e *NearTextArgumentBuilder) togrpc() *pb.NearTextSearch {
+	nearText := &pb.NearTextSearch{
+		Query:         e.concepts,
+		TargetVectors: e.targetVectors,
+	}
+	if e.withCertainty {
+		certainty := float64(e.certainty)
+		nearText.Certainty = &certainty
+	}
+	if e.withDistance {
+		distance := float64(e.distance)
+		nearText.Distance = &distance
+	}
+	if e.moveTo != nil {
+		nearText.MoveTo = e.parseMoveParam(e.moveTo)
+	}
+	if e.moveAwayFrom != nil {
+		nearText.MoveAway = e.parseMoveParam(e.moveAwayFrom)
+	}
+	return nearText
+}
+
+func (e *NearTextArgumentBuilder) parseMoveParam(moveParam *MoveParameters) *pb.NearTextSearch_Move {
+	move := &pb.NearTextSearch_Move{
+		Concepts: moveParam.Concepts,
+	}
+	if moveParam.Force != 0.0 {
+		move.Force = moveParam.Force
+	}
+	if len(moveParam.Objects) > 0 {
+		uuids := make([]string, len(moveParam.Objects))
+		for i := range moveParam.Objects {
+			// TODO: handle beacon
+			uuids[i] = moveParam.Objects[i].ID
+		}
+		move.Uuids = uuids
+	}
+	return move
 }

--- a/weaviate/graphql/nearthermalbuilder.go
+++ b/weaviate/graphql/nearthermalbuilder.go
@@ -2,6 +2,8 @@ package graphql
 
 import (
 	"io"
+
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
 
 type NearThermalArgumentBuilder struct {
@@ -74,4 +76,24 @@ func (b *NearThermalArgumentBuilder) build() string {
 	}
 	builder.withTargets(b.targets)
 	return builder.build()
+}
+
+func (b *NearThermalArgumentBuilder) togrpc() *pb.NearThermalSearch {
+	builder := &nearMediaArgumentBuilder{
+		data:       b.thermal,
+		dataReader: b.thermalReader,
+	}
+	nearThermal := &pb.NearThermalSearch{
+		Thermal:       builder.getContent(),
+		TargetVectors: b.targetVectors,
+	}
+	if b.hasCertainty {
+		certainty := float64(b.certainty)
+		nearThermal.Certainty = &certainty
+	}
+	if b.hasDistance {
+		distance := float64(b.distance)
+		nearThermal.Distance = &distance
+	}
+	return nearThermal
 }

--- a/weaviate/graphql/nearthermalbuilder.go
+++ b/weaviate/graphql/nearthermalbuilder.go
@@ -84,8 +84,7 @@ func (b *NearThermalArgumentBuilder) togrpc() *pb.NearThermalSearch {
 		dataReader: b.thermalReader,
 	}
 	nearThermal := &pb.NearThermalSearch{
-		Thermal:       builder.getContent(),
-		TargetVectors: b.targetVectors,
+		Thermal: builder.getContent(),
 	}
 	if b.hasCertainty {
 		certainty := float64(b.certainty)
@@ -94,6 +93,12 @@ func (b *NearThermalArgumentBuilder) togrpc() *pb.NearThermalSearch {
 	if b.hasDistance {
 		distance := float64(b.distance)
 		nearThermal.Distance = &distance
+	}
+	if b.targets != nil {
+		nearThermal.Targets = b.targets.togrpc()
+	}
+	if len(b.targetVectors) > 0 && b.targets == nil {
+		nearThermal.Targets = &pb.Targets{TargetVectors: b.targetVectors}
 	}
 	return nearThermal
 }

--- a/weaviate/graphql/nearvectorbuilder.go
+++ b/weaviate/graphql/nearvectorbuilder.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/grpc/common"
 	"github.com/weaviate/weaviate/entities/models"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
 
 type NearVectorArgumentBuilder struct {
@@ -155,4 +157,22 @@ func (b NearVectorArgumentBuilder) prepareTargetVectors(targets []string) (out [
 		}
 	}
 	return
+}
+
+func (b *NearVectorArgumentBuilder) togrpc() *pb.NearVector {
+	nearVector := &pb.NearVector{
+		TargetVectors: b.targetVectors,
+	}
+	if !b.isVectorEmpty(b.vector) && len(b.vectorsPerTarget) == 0 {
+		nearVector.Vectors = []*pb.Vectors{common.GetVector("", b.vector)}
+	}
+	if b.withCertainty {
+		certainty := float64(b.certainty)
+		nearVector.Certainty = &certainty
+	}
+	if b.withDistance {
+		distance := float64(b.distance)
+		nearVector.Distance = &distance
+	}
+	return nearVector
 }

--- a/weaviate/graphql/nearvideobuilder.go
+++ b/weaviate/graphql/nearvideobuilder.go
@@ -83,8 +83,7 @@ func (b *NearVideoArgumentBuilder) togrpc() *pb.NearVideoSearch {
 		dataReader: b.videoReader,
 	}
 	nearVideo := &pb.NearVideoSearch{
-		Video:         builder.getContent(),
-		TargetVectors: b.targetVectors,
+		Video: builder.getContent(),
 	}
 	if b.hasCertainty {
 		certainty := float64(b.certainty)
@@ -93,6 +92,12 @@ func (b *NearVideoArgumentBuilder) togrpc() *pb.NearVideoSearch {
 	if b.hasDistance {
 		distance := float64(b.distance)
 		nearVideo.Distance = &distance
+	}
+	if b.targets != nil {
+		nearVideo.Targets = b.targets.togrpc()
+	}
+	if len(b.targetVectors) > 0 && b.targets == nil {
+		nearVideo.Targets = &pb.Targets{TargetVectors: b.targetVectors}
 	}
 	return nearVideo
 }

--- a/weaviate/graphql/nearvideobuilder.go
+++ b/weaviate/graphql/nearvideobuilder.go
@@ -2,6 +2,8 @@ package graphql
 
 import (
 	"io"
+
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
 
 type NearVideoArgumentBuilder struct {
@@ -73,4 +75,24 @@ func (b *NearVideoArgumentBuilder) build() string {
 	}
 	builder.withTargets(b.targets)
 	return builder.build()
+}
+
+func (b *NearVideoArgumentBuilder) togrpc() *pb.NearVideoSearch {
+	builder := &nearMediaArgumentBuilder{
+		data:       b.video,
+		dataReader: b.videoReader,
+	}
+	nearVideo := &pb.NearVideoSearch{
+		Video:         builder.getContent(),
+		TargetVectors: b.targetVectors,
+	}
+	if b.hasCertainty {
+		certainty := float64(b.certainty)
+		nearVideo.Certainty = &certainty
+	}
+	if b.hasDistance {
+		distance := float64(b.distance)
+		nearVideo.Distance = &distance
+	}
+	return nearVideo
 }

--- a/weaviate/graphql/search.go
+++ b/weaviate/graphql/search.go
@@ -216,6 +216,8 @@ func (s *Search) togrpc() *pb.SearchRequest {
 		// by default always return ID
 		req.Metadata = &pb.MetadataRequest{Uuid: true}
 	}
+	req.Uses_123Api = true
+	req.Uses_125Api = true
 	req.Uses_127Api = true
 	return req
 }

--- a/weaviate/graphql/search.go
+++ b/weaviate/graphql/search.go
@@ -1,0 +1,232 @@
+package graphql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/connection"
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/grpc/common"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+)
+
+type Search struct {
+	grpcClient *connection.GrpcClient
+
+	collection string
+	tenant     string
+
+	limit            uint32
+	offset           uint32
+	autocut          uint32
+	after            string
+	consistencyLevel string
+
+	withNearText    *NearTextArgumentBuilder
+	withNearVector  *NearVectorArgumentBuilder
+	withNearObject  *NearObjectArgumentBuilder
+	withNearImage   *NearImageArgumentBuilder
+	withNearAudio   *NearAudioArgumentBuilder
+	withNearVideo   *NearVideoArgumentBuilder
+	withNearDepth   *NearDepthArgumentBuilder
+	withNearThermal *NearThermalArgumentBuilder
+	withNearImu     *NearImuArgumentBuilder
+	withHybrid      *HybridArgumentBuilder
+	withBM25        *BM25ArgumentBuilder
+
+	withSortBy *SortBuilder
+
+	withProperties []string
+	withReferences []*Reference
+	withMetadata   *Metadata
+}
+
+func NewSearch(grpcClient *connection.GrpcClient) *Search {
+	return &Search{grpcClient: grpcClient}
+}
+
+func (s *Search) WithCollection(collection string) *Search {
+	s.collection = collection
+	return s
+}
+
+func (s *Search) WithTenant(tenant string) *Search {
+	s.tenant = tenant
+	return s
+}
+
+func (s *Search) WithLimit(limit int) *Search {
+	s.limit = uint32(limit)
+	return s
+}
+
+func (s *Search) WithOffset(offset int) *Search {
+	s.offset = uint32(offset)
+	return s
+}
+
+func (s *Search) WithAfter(after string) *Search {
+	s.after = after
+	return s
+}
+
+func (s *Search) WithAutocut(autocut int) *Search {
+	s.autocut = uint32(autocut)
+	return s
+}
+
+func (s *Search) WithConsistencyLevel(consistencyLevel string) *Search {
+	s.consistencyLevel = consistencyLevel
+	return s
+}
+
+func (s *Search) WithNearText(nearText *NearTextArgumentBuilder) *Search {
+	s.withNearText = nearText
+	return s
+}
+
+func (s *Search) WithNearVector(nearVector *NearVectorArgumentBuilder) *Search {
+	s.withNearVector = nearVector
+	return s
+}
+
+func (s *Search) WithNearObject(nearObject *NearObjectArgumentBuilder) *Search {
+	s.withNearObject = nearObject
+	return s
+}
+
+func (s *Search) WithNearImage(nearImage *NearImageArgumentBuilder) *Search {
+	s.withNearImage = nearImage
+	return s
+}
+
+func (s *Search) WithNearAudio(nearAudio *NearAudioArgumentBuilder) *Search {
+	s.withNearAudio = nearAudio
+	return s
+}
+
+func (s *Search) WithNearVideo(nearVideo *NearVideoArgumentBuilder) *Search {
+	s.withNearVideo = nearVideo
+	return s
+}
+
+func (s *Search) WithNearDepth(nearDepth *NearDepthArgumentBuilder) *Search {
+	s.withNearDepth = nearDepth
+	return s
+}
+
+func (s *Search) WithNearImu(nearImu *NearImuArgumentBuilder) *Search {
+	s.withNearImu = nearImu
+	return s
+}
+
+func (s *Search) WithNearThermal(nearThermal *NearThermalArgumentBuilder) *Search {
+	s.withNearThermal = nearThermal
+	return s
+}
+
+func (s *Search) WithHybrid(hybrid *HybridArgumentBuilder) *Search {
+	s.withHybrid = hybrid
+	return s
+}
+
+func (s *Search) WithBM25(bm25 *BM25ArgumentBuilder) *Search {
+	s.withBM25 = bm25
+	return s
+}
+
+func (s *Search) WithSort(sort ...Sort) *Search {
+	if len(sort) > 0 {
+		s.withSortBy = &SortBuilder{sort}
+	}
+	return s
+}
+
+func (s *Search) WithProperties(properties ...string) *Search {
+	s.withProperties = properties
+	return s
+}
+
+func (s *Search) WithReferences(references ...*Reference) *Search {
+	s.withReferences = references
+	return s
+}
+
+func (s *Search) WithMetadata(metadata *Metadata) *Search {
+	s.withMetadata = metadata
+	return s
+}
+
+func (s *Search) togrpc() *pb.SearchRequest {
+	req := &pb.SearchRequest{
+		Collection:       s.collection,
+		Tenant:           s.tenant,
+		Limit:            s.limit,
+		Offset:           s.offset,
+		Autocut:          s.autocut,
+		After:            s.after,
+		ConsistencyLevel: common.GetConsistencyLevel(s.consistencyLevel),
+	}
+	if s.withNearText != nil {
+		req.NearText = s.withNearText.togrpc()
+	}
+	if s.withNearVector != nil {
+		req.NearVector = s.withNearVector.togrpc()
+	}
+	if s.withNearObject != nil {
+		req.NearObject = s.withNearObject.togrpc()
+	}
+	if s.withNearImage != nil {
+		req.NearImage = s.withNearImage.togrpc()
+	}
+	if s.withNearAudio != nil {
+		req.NearAudio = s.withNearAudio.togrpc()
+	}
+	if s.withNearVideo != nil {
+		req.NearVideo = s.withNearVideo.togrpc()
+	}
+	if s.withNearDepth != nil {
+		req.NearDepth = s.withNearDepth.togrpc()
+	}
+	if s.withNearImu != nil {
+		req.NearImu = s.withNearImu.togrpc()
+	}
+	if s.withNearThermal != nil {
+		req.NearThermal = s.withNearThermal.togrpc()
+	}
+	if s.withHybrid != nil {
+		req.HybridSearch = s.withHybrid.togrpc()
+	}
+	if s.withBM25 != nil {
+		req.Bm25Search = s.withBM25.togrpc()
+	}
+	if s.withSortBy != nil {
+		req.SortBy = s.withSortBy.togrpc()
+	}
+	withProps := &Properties{}
+	if len(s.withProperties) > 0 {
+		withProps.WithProperties(s.withProperties...)
+	}
+	if len(s.withReferences) > 0 {
+		withProps.WithReferences(s.withReferences...)
+	}
+	req.Properties = withProps.togrpc()
+	if s.withMetadata != nil {
+		req.Metadata = s.withMetadata.togrpc()
+	} else {
+		// by default always return ID
+		req.Metadata = &pb.MetadataRequest{Uuid: true}
+	}
+	req.Uses_127Api = true
+	return req
+}
+
+func (s *Search) Do(ctx context.Context) ([]SearchResult, error) {
+	if s.grpcClient != nil {
+		reply, err := s.grpcClient.Search(ctx, s.togrpc())
+		if err != nil {
+			return nil, err
+		}
+		return toResults(reply.Results), nil
+	}
+	return nil, fmt.Errorf("please provide gRPC config to the client in order to use search functionality")
+}

--- a/weaviate/graphql/search_metadata.go
+++ b/weaviate/graphql/search_metadata.go
@@ -1,0 +1,34 @@
+package graphql
+
+import (
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+)
+
+type Metadata struct {
+	ID                 bool
+	CreationTimeUnix   bool
+	LastUpdateTimeUnix bool
+	Distance           bool
+	Certainty          bool
+	Score              bool
+	ExplainScore       bool
+	IsConsistent       bool
+	Vector             bool
+	Vectors            []string
+}
+
+func (m *Metadata) togrpc() *pb.MetadataRequest {
+	metadata := &pb.MetadataRequest{
+		Uuid:               m.ID,
+		CreationTimeUnix:   m.CreationTimeUnix,
+		LastUpdateTimeUnix: m.LastUpdateTimeUnix,
+		Distance:           m.Distance,
+		Certainty:          m.Certainty,
+		Score:              m.Score,
+		ExplainScore:       m.ExplainScore,
+		IsConsistent:       m.IsConsistent,
+		Vector:             m.Vector,
+		Vectors:            m.Vectors,
+	}
+	return metadata
+}

--- a/weaviate/graphql/search_operator.go
+++ b/weaviate/graphql/search_operator.go
@@ -36,9 +36,9 @@ func (bm25 *BM25SearchOperatorBuilder) build() string {
 func (bm25 *BM25SearchOperatorBuilder) togrpc() *pb.SearchOperatorOptions {
 	switch bm25.operator {
 	case BM25SearchOperatorAnd:
-		return &pb.SearchOperatorOptions{Operator: pb.SearchOperatorOptions_OPERATOR_AND, MinimumOrTokensMatch: &bm25.minimumMatch}
+		return &pb.SearchOperatorOptions{Operator: pb.SearchOperatorOptions_OPERATOR_AND}
 	case BM25SearchOperatorOr:
-		return &pb.SearchOperatorOptions{Operator: pb.SearchOperatorOptions_OPERATOR_OR}
+		return &pb.SearchOperatorOptions{Operator: pb.SearchOperatorOptions_OPERATOR_OR, MinimumOrTokensMatch: &bm25.minimumMatch}
 	default:
 		return nil
 	}

--- a/weaviate/graphql/search_operator.go
+++ b/weaviate/graphql/search_operator.go
@@ -1,6 +1,10 @@
 package graphql
 
-import "fmt"
+import (
+	"fmt"
+
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+)
 
 const (
 	BM25SearchOperatorAnd = "And"
@@ -9,7 +13,7 @@ const (
 
 type BM25SearchOperatorBuilder struct {
 	operator     string
-	minimumMatch int
+	minimumMatch int32
 }
 
 func (bm25 *BM25SearchOperatorBuilder) WithOperator(operator string) *BM25SearchOperatorBuilder {
@@ -20,11 +24,22 @@ func (bm25 *BM25SearchOperatorBuilder) WithOperator(operator string) *BM25Search
 // WithMinimumMatch is only relevant for BM25SearchOperatorOr operator.
 func (bm25 *BM25SearchOperatorBuilder) WithMinimumMatch(times int) *BM25SearchOperatorBuilder {
 	if bm25.operator != BM25SearchOperatorAnd {
-		bm25.minimumMatch = times
+		bm25.minimumMatch = int32(times)
 	}
 	return bm25
 }
 
 func (bm25 *BM25SearchOperatorBuilder) build() string {
 	return fmt.Sprintf("{operator:%s minimumOrTokensMatch:%d}", bm25.operator, bm25.minimumMatch)
+}
+
+func (bm25 *BM25SearchOperatorBuilder) togrpc() *pb.SearchOperatorOptions {
+	switch bm25.operator {
+	case BM25SearchOperatorAnd:
+		return &pb.SearchOperatorOptions{Operator: pb.SearchOperatorOptions_OPERATOR_AND, MinimumOrTokensMatch: &bm25.minimumMatch}
+	case BM25SearchOperatorOr:
+		return &pb.SearchOperatorOptions{Operator: pb.SearchOperatorOptions_OPERATOR_OR}
+	default:
+		return nil
+	}
 }

--- a/weaviate/graphql/search_properties.go
+++ b/weaviate/graphql/search_properties.go
@@ -1,0 +1,58 @@
+package graphql
+
+import (
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+)
+
+type Properties struct {
+	withProperties []string
+	withReferences []*Reference
+}
+
+func (p *Properties) WithProperties(properties ...string) *Properties {
+	p.withProperties = properties
+	return p
+}
+
+func (p *Properties) WithReferences(references ...*Reference) *Properties {
+	p.withReferences = references
+	return p
+}
+
+func (p *Properties) togrpc() *pb.PropertiesRequest {
+	props := &pb.PropertiesRequest{
+		NonRefProperties:          p.withProperties,
+		ReturnAllNonrefProperties: len(p.withProperties) == 0,
+	}
+	if len(p.withReferences) > 0 {
+		refProperties := make([]*pb.RefPropertiesRequest, len(p.withReferences))
+		for i := range p.withReferences {
+			refProperties[i] = p.withReferences[i].togrpc()
+		}
+		props.RefProperties = refProperties
+	}
+	// TODO: add support for json object properties
+	return props
+}
+
+type Reference struct {
+	TargetCollection  string
+	ReferenceProperty string
+	Properties        []string
+	Metadata          *Metadata
+}
+
+func (p *Reference) togrpc() *pb.RefPropertiesRequest {
+	refProps := &pb.RefPropertiesRequest{
+		TargetCollection:  p.TargetCollection,
+		ReferenceProperty: p.ReferenceProperty,
+	}
+	if len(p.Properties) > 0 {
+		props := &Properties{withProperties: p.Properties}
+		refProps.Properties = props.togrpc()
+	}
+	if p.Metadata != nil {
+		refProps.Metadata = p.Metadata.togrpc()
+	}
+	return refProps
+}

--- a/weaviate/graphql/search_properties.go
+++ b/weaviate/graphql/search_properties.go
@@ -19,6 +19,8 @@ func (p *Properties) WithReferences(references ...*Reference) *Properties {
 	return p
 }
 
+// This method is lacking support for json object properties
+// it only supports non ref and reference properties
 func (p *Properties) togrpc() *pb.PropertiesRequest {
 	props := &pb.PropertiesRequest{
 		NonRefProperties:          p.withProperties,
@@ -31,7 +33,6 @@ func (p *Properties) togrpc() *pb.PropertiesRequest {
 		}
 		props.RefProperties = refProperties
 	}
-	// TODO: add support for json object properties
 	return props
 }
 

--- a/weaviate/graphql/search_result.go
+++ b/weaviate/graphql/search_result.go
@@ -1,0 +1,253 @@
+package graphql
+
+import (
+	"github.com/weaviate/weaviate/entities/models"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/usecases/byteops"
+)
+
+type SearchResult struct {
+	ID         string
+	Collection string
+	Properties map[string]any
+	References []ReferenceResult
+	Metadata   MetadataResult
+	Vector     []float32
+	Vectors    map[string]Vector
+}
+
+type ReferenceResult struct {
+	Name                string
+	ReferenceProperties []ReferencePropertiesResult
+}
+
+type ReferencePropertiesResult struct {
+	Properties map[string]any
+	Metadata   ReferenceMetadataResult
+}
+
+type MetadataResult struct {
+	CreationTimeUnix           int64
+	LastUpdateTimeUnix         int64
+	Certainty, Distance, Score float32
+	ExplainScore               string
+	RerankScore                float64
+	IsConsistent               bool
+}
+
+type ReferenceMetadataResult struct {
+	MetadataResult
+	ID      string
+	Vector  []float32
+	Vectors map[string]Vector
+}
+
+type Vector struct {
+	models.Vector
+}
+
+func (v Vector) GetVector() []float32 {
+	if vec, ok := v.Vector.([]float32); ok {
+		return vec
+	}
+	return nil
+}
+
+func (v Vector) GetMultiVector() [][]float32 {
+	if vec, ok := v.Vector.([][]float32); ok {
+		return vec
+	}
+	return nil
+}
+
+func toResults(results []*pb.SearchResult) []SearchResult {
+	searchResults := make([]SearchResult, len(results))
+	for i, r := range results {
+		searchResults[i] = SearchResult{
+			ID:         extractID(r.GetMetadata()),
+			Collection: extractCollection(r.GetProperties()),
+			Properties: extractProperties(r.GetProperties()),
+			References: extractReferences(r.GetProperties()),
+			Metadata:   extractMetadata(r.GetMetadata()),
+			Vector:     extractVector(r.GetMetadata()),
+			Vectors:    extractVectors(r.GetMetadata()),
+		}
+	}
+	return searchResults
+}
+
+func extractProperties(p *pb.PropertiesResult) map[string]any {
+	if p != nil {
+		properties := make(map[string]any)
+		if nonRefProps := p.GetNonRefProperties(); nonRefProps != nil {
+			properties = nonRefProps.AsMap()
+		} else if nonRefProps := p.GetNonRefProps(); nonRefProps != nil {
+			for name, val := range nonRefProps.GetFields() {
+				properties[name] = getValue(val)
+			}
+		}
+		if props := p.GetTextArrayProperties(); len(props) > 0 {
+			for i := range props {
+				properties[props[i].GetPropName()] = props[i].GetValues()
+			}
+		}
+		if props := p.GetBooleanArrayProperties(); len(props) > 0 {
+			for i := range props {
+				properties[props[i].GetPropName()] = props[i].GetValues()
+			}
+		}
+		if props := p.GetIntArrayProperties(); len(props) > 0 {
+			for i := range props {
+				properties[props[i].GetPropName()] = props[i].GetValues()
+			}
+		}
+		if props := p.GetNumberArrayProperties(); len(props) > 0 {
+			for i := range props {
+				properties[props[i].GetPropName()] = props[i].GetValues()
+			}
+		}
+		return properties
+	}
+	return nil
+}
+
+func extractReferences(p *pb.PropertiesResult) []ReferenceResult {
+	if p != nil {
+		if refProps := p.GetRefProps(); len(refProps) > 0 {
+			references := make([]ReferenceResult, len(refProps))
+			for i := range refProps {
+				references[i] = ReferenceResult{
+					Name:                refProps[i].GetPropName(),
+					ReferenceProperties: extractReferenceProperties(refProps[i].GetProperties()),
+				}
+			}
+			return references
+		}
+	}
+	return nil
+}
+
+func extractReferenceProperties(p []*pb.PropertiesResult) []ReferencePropertiesResult {
+	if len(p) > 0 {
+		properties := make([]ReferencePropertiesResult, len(p))
+		for i := range p {
+			properties[i] = ReferencePropertiesResult{
+				Properties: extractProperties(p[i]),
+				Metadata:   extractReferenceMetadata(p[i].GetMetadata()),
+			}
+		}
+		return properties
+	}
+	return nil
+}
+
+func extractReferenceMetadata(m *pb.MetadataResult) ReferenceMetadataResult {
+	var metadata ReferenceMetadataResult
+	if m != nil {
+		metadata = ReferenceMetadataResult{
+			MetadataResult: extractMetadata(m),
+			ID:             extractID(m),
+			Vector:         extractVector(m),
+			Vectors:        extractVectors(m),
+		}
+	}
+	return metadata
+}
+
+func extractCollection(p *pb.PropertiesResult) string {
+	if p != nil {
+		return p.GetTargetCollection()
+	}
+	return ""
+}
+
+func extractID(m *pb.MetadataResult) string {
+	if m != nil {
+		return m.GetId()
+	}
+	return ""
+}
+
+func extractMetadata(m *pb.MetadataResult) MetadataResult {
+	var metadata MetadataResult
+	if m != nil {
+		if m.GetCreationTimeUnixPresent() {
+			metadata.CreationTimeUnix = m.GetCreationTimeUnix()
+		}
+		if m.GetLastUpdateTimeUnixPresent() {
+			metadata.LastUpdateTimeUnix = m.GetLastUpdateTimeUnix()
+		}
+		if m.GetCertaintyPresent() {
+			metadata.Certainty = m.GetCertainty()
+		}
+		if m.GetDistancePresent() {
+			metadata.Distance = m.GetDistance()
+		}
+		if m.GetScorePresent() {
+			metadata.Score = m.GetScore()
+		}
+		if m.GetExplainScorePresent() {
+			metadata.ExplainScore = m.GetExplainScore()
+		}
+		if m.GetRerankScorePresent() {
+			metadata.RerankScore = m.GetRerankScore()
+		}
+	}
+	return metadata
+}
+
+func extractVector(m *pb.MetadataResult) []float32 {
+	if m != nil && len(m.GetVectorBytes()) > 0 {
+		return byteops.Fp32SliceFromBytes(m.GetVectorBytes())
+	}
+	return nil
+}
+
+func extractVectors(m *pb.MetadataResult) map[string]Vector {
+	var vectors map[string]Vector
+	if m != nil && len(m.GetVectors()) > 0 {
+		vectors = make(map[string]Vector, len(m.GetVectors()))
+		for _, v := range m.GetVectors() {
+			switch v.Type {
+			case pb.Vectors_VECTOR_TYPE_SINGLE_FP32, pb.Vectors_VECTOR_TYPE_UNSPECIFIED:
+				vectors[v.GetName()] = Vector{Vector: byteops.Fp32SliceFromBytes(v.GetVectorBytes())}
+			case pb.Vectors_VECTOR_TYPE_MULTI_FP32:
+				if mv, err := byteops.Fp32SliceOfSlicesFromBytes(v.GetVectorBytes()); err == nil {
+					vectors[v.GetName()] = Vector{Vector: mv}
+				}
+			}
+		}
+	}
+	return vectors
+}
+
+func getValue(val *pb.Value) any {
+	switch val.GetKind().(type) {
+	case *pb.Value_TextValue:
+		return val.GetTextValue()
+	case *pb.Value_NumberValue:
+		return val.GetNumberValue()
+	case *pb.Value_BlobValue:
+		return val.GetBlobValue()
+	case *pb.Value_BoolValue:
+		return val.GetBoolValue()
+	case *pb.Value_DateValue:
+		return val.GetDateValue()
+	case *pb.Value_IntValue:
+		return val.GetIntValue()
+	case *pb.Value_UuidValue:
+		return val.GetUuidValue()
+	case *pb.Value_GeoValue:
+		return val.GetGeoValue()
+	case *pb.Value_ListValue:
+		return val.GetListValue()
+	case *pb.Value_ObjectValue:
+		return val.GetObjectValue()
+	case *pb.Value_PhoneValue:
+		return val.GetPhoneValue()
+	case *pb.Value_NullValue:
+		return val.GetNullValue()
+	default:
+		return nil
+	}
+}

--- a/weaviate/graphql/sortbuilder.go
+++ b/weaviate/graphql/sortbuilder.go
@@ -3,6 +3,8 @@ package graphql
 import (
 	"fmt"
 	"strings"
+
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
 
 type Sort struct {
@@ -25,6 +27,14 @@ func (s Sort) build() string {
 	return fmt.Sprintf("{%s}", strings.Join(clause, " "))
 }
 
+func (s Sort) togrpc() *pb.SortBy {
+	sortBy := &pb.SortBy{
+		Path:      s.Path,
+		Ascending: s.Order == Asc,
+	}
+	return sortBy
+}
+
 type SortBuilder struct {
 	sort []Sort
 }
@@ -37,4 +47,12 @@ func (b *SortBuilder) build() string {
 		}
 	}
 	return fmt.Sprintf("sort:[%s]", strings.Join(clause, ", "))
+}
+
+func (b *SortBuilder) togrpc() []*pb.SortBy {
+	sort := make([]*pb.SortBy, len(b.sort))
+	for i := range b.sort {
+		sort[i] = b.sort[i].togrpc()
+	}
+	return sort
 }

--- a/weaviate/grpc/batch/batch.go
+++ b/weaviate/grpc/batch/batch.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/weaviate/weaviate-go-client/v5/weaviate/data/replication"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/db"
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/grpc/common"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
@@ -142,17 +142,17 @@ func (b Batch) extractProperties(properties map[string]interface{}, rootLevel bo
 			var values []int64
 			switch vv := v.(type) {
 			case []int:
-				values = toInt64Array[int](vv)
+				values = toInt64Array(vv)
 			case []int32:
-				values = toInt64Array[int32](vv)
+				values = toInt64Array(vv)
 			case []int64:
 				values = vv
 			case []uint:
-				values = toInt64Array[uint](vv)
+				values = toInt64Array(vv)
 			case []uint32:
-				values = toInt64Array[uint32](vv)
+				values = toInt64Array(vv)
 			case []uint64:
-				values = toInt64Array[uint64](vv)
+				values = toInt64Array(vv)
 			}
 			intArrayProperties = append(intArrayProperties, &pb.IntArrayProperties{
 				PropName: name, Values: values,
@@ -309,16 +309,7 @@ func (b Batch) getCrossRefs(propName string, crossRefs map[string][]string) ([]*
 }
 
 func (b Batch) GetConsistencyLevel(consistencyLevel string) *pb.ConsistencyLevel {
-	switch consistencyLevel {
-	case replication.ConsistencyLevel.ALL:
-		return pb.ConsistencyLevel_CONSISTENCY_LEVEL_ALL.Enum()
-	case replication.ConsistencyLevel.ONE:
-		return pb.ConsistencyLevel_CONSISTENCY_LEVEL_ONE.Enum()
-	case replication.ConsistencyLevel.QUORUM:
-		return pb.ConsistencyLevel_CONSISTENCY_LEVEL_QUORUM.Enum()
-	default:
-		return nil
-	}
+	return common.GetConsistencyLevel(consistencyLevel)
 }
 
 func (b Batch) ParseReply(reply *pb.BatchObjectsReply, objects []*models.Object) []models.ObjectsGetResponse {

--- a/weaviate/grpc/common/common.go
+++ b/weaviate/grpc/common/common.go
@@ -1,0 +1,40 @@
+package common
+
+import (
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/data/replication"
+	"github.com/weaviate/weaviate/entities/models"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/usecases/byteops"
+)
+
+func GetConsistencyLevel(consistencyLevel string) *pb.ConsistencyLevel {
+	switch consistencyLevel {
+	case replication.ConsistencyLevel.ALL:
+		return pb.ConsistencyLevel_CONSISTENCY_LEVEL_ALL.Enum()
+	case replication.ConsistencyLevel.ONE:
+		return pb.ConsistencyLevel_CONSISTENCY_LEVEL_ONE.Enum()
+	case replication.ConsistencyLevel.QUORUM:
+		return pb.ConsistencyLevel_CONSISTENCY_LEVEL_QUORUM.Enum()
+	default:
+		return nil
+	}
+}
+
+func GetVector(name string, vector models.Vector) *pb.Vectors {
+	switch v := vector.(type) {
+	case []float32:
+		return &pb.Vectors{
+			Name:        name,
+			VectorBytes: byteops.Fp32SliceToBytes(v),
+			Type:        pb.Vectors_VECTOR_TYPE_SINGLE_FP32,
+		}
+	case [][]float32:
+		return &pb.Vectors{
+			Name:        name,
+			VectorBytes: byteops.Fp32SliceOfSlicesToBytes(v),
+			Type:        pb.Vectors_VECTOR_TYPE_MULTI_FP32,
+		}
+	default:
+		return nil
+	}
+}

--- a/weaviate/weaviate_client.go
+++ b/weaviate/weaviate_client.go
@@ -111,6 +111,7 @@ type Client struct {
 	classifications *classifications.API
 	backup          *backup.API
 	graphQL         *graphql.API
+	search          *graphql.Search
 	cluster         *cluster.API
 	roles           *rbac.API
 	users           *users.API
@@ -181,6 +182,7 @@ func NewClient(config Config) (*Client, error) {
 		c11y:            contextionary.New(con),
 		classifications: classifications.New(con),
 		graphQL:         graphql.New(con),
+		search:          graphql.NewSearch(grpcClient),
 		data:            data.New(con, dbVersionSupport),
 		batch:           batch.New(con, grpcClient, dbVersionSupport),
 		backup:          backup.New(con),
@@ -234,6 +236,7 @@ func New(config Config) *Client {
 		cluster:         cluster.New(con),
 		roles:           rbac.New(con),
 		users:           users.New(con),
+		search:          graphql.NewSearch(grpcClient),
 	}
 
 	return client
@@ -300,6 +303,11 @@ func (c *Client) Roles() *rbac.API {
 
 func (c *Client) Users() *users.API {
 	return c.users
+}
+
+// Experimental Search gRPC API group
+func (c *Client) Search() *graphql.Search {
+	return graphql.NewSearch(c.grpcClient)
 }
 
 func createGrpcClient(config Config, gRPCVersionSupport *db.GRPCVersionSupport) (*connection.GrpcClient, error) {


### PR DESCRIPTION
This PR adds experimental support for gRPC Search.

gRPC Search is discoverable through `client.Experimental()` namespace.

`client.Experimental().Search()` uses `graphql.*` argument builders to construct queries but underneath those are translated into gRPC messages.