### PR TITLE
fix: retract 5.4.0 and restore golang.org/x/oauth2 dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/weaviate v0.35.0
 	github.com/weaviate/weaviate v1.31.5
 	go.nhat.io/grpcmock v0.26.0
-	golang.org/x/oauth2 v0.27.0
+	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.14.0
 	google.golang.org/grpc v1.72.0
 	google.golang.org/protobuf v1.36.6
@@ -168,4 +168,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-retract v5.0.0 // Malformed go.mod declares v4 module path
+retract (
+	v5.4.0 // Missing entry for golang.org/x/oauth2 in go.sum
+	v5.0.0 // Malformed go.mod declares v4 module path
+)


### PR DESCRIPTION
I got [confused](https://github.com/weaviate/weaviate-go-client/commit/b0a044386e649e2cb4bd7d9aa9661d09c3a51a0e) by a Dependabot alert saying we needed to upgrade `golang.org/x/oauth2` package to `0.27.0` to fix a vulnerability.

In reality, the library was already using a newer version of the dependency. I did a poor job reverting that change locally and it `require golang.org/x/oauth2@0.27.0` made its way to our go.mod file without the corresponding entry in go.sum.

Unfortunately, by the time I noticed that I'd already published the tag. This PR retracts `v5.4.0` and restores the dependency version back to v0.30.0.