### PR TITLE
Fix typo in method name: WaitForWeavaite -> WaitForWeaviate

### DIFF
--- a/test/misc/misc_version_check_test.go
+++ b/test/misc/misc_version_check_test.go
@@ -45,7 +45,7 @@ func TestMisc_version_check(t *testing.T) {
 	})
 
 	client := testsuit.CreateTestClient(false)
-	require.Nil(t, client.WaitForWeavaite(60*time.Second))
+	require.Nil(t, client.WaitForWeaviate(60*time.Second))
 
 	t.Run("Weaviate is live, perform ready check", func(t *testing.T) {
 		isReady, err := client.Misc().ReadyChecker().Do(context.Background())
@@ -118,7 +118,7 @@ func TestMisc_empty_version_check(t *testing.T) {
 	})
 
 	client := testsuit.CreateTestClient(false)
-	require.Nil(t, client.WaitForWeavaite(60*time.Second))
+	require.Nil(t, client.WaitForWeaviate(60*time.Second))
 
 	t.Run("Create sample schema food, try to perform queries using /v1/objects?class={className}", func(t *testing.T) {
 		testsuit.CreateWeaviateTestSchemaFood(t, client)

--- a/test/mock/wait_for_weaviate_test.go
+++ b/test/mock/wait_for_weaviate_test.go
@@ -22,7 +22,7 @@ func TestWaitForWeaviate(t *testing.T) {
 
 	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
 	client := weaviate.New(cfg)
-	err := client.WaitForWeavaite(60 * time.Second)
+	err := client.WaitForWeaviate(60 * time.Second)
 	assert.Nil(t, err)
 }
 
@@ -34,7 +34,7 @@ func TestWaitForWeaviate_NoConnection(t *testing.T) {
 
 	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
 	client := weaviate.New(cfg)
-	err := client.WaitForWeavaite(5 * time.Second)
+	err := client.WaitForWeaviate(5 * time.Second)
 	assert.NotNil(t, err)
 }
 
@@ -50,7 +50,7 @@ func TestWaitForWeaviate_longTimeforResponse(t *testing.T) {
 	cfg := weaviate.Config{Host: strings.TrimPrefix(s.URL, "http://"), Scheme: "http"}
 	client := weaviate.New(cfg)
 	start := time.Now()
-	err := client.WaitForWeavaite(5 * time.Second)
+	err := client.WaitForWeaviate(5 * time.Second)
 	assert.Nil(t, err)
 	assert.Less(t, time.Since(start).Seconds(), 2.5) // allow for some overhead
 }

--- a/test_deprecated/testsuite.go
+++ b/test_deprecated/testsuite.go
@@ -16,7 +16,7 @@ func CreateTestClient() *weaviate.Client {
 		Scheme: "http",
 	}
 	client := weaviate.New(cfg)
-	client.WaitForWeavaite(60 * time.Second)
+	client.WaitForWeaviate(60 * time.Second)
 	return client
 }
 

--- a/weaviate/weaviate_client.go
+++ b/weaviate/weaviate_client.go
@@ -256,7 +256,7 @@ func New(config Config) *Client {
 }
 
 // Waits for Weaviate to start.
-func (c *Client) WaitForWeavaite(startupTimeout time.Duration) error {
+func (c *Client) WaitForWeaviate(startupTimeout time.Duration) error {
 	return c.connection.WaitForWeaviate(startupTimeout)
 }
 


### PR DESCRIPTION
correct misspelling in the Client.WaitForWeavaite method name and updated all references across the codebase to use the correct spelling WaitForWeaviate.

Fixes: https://github.com/weaviate/weaviate-go-client/issues/298