### PR TITLE
fix(data): prevent panic on nil response in checker

### DIFF
--- a/weaviate/data/checker.go
+++ b/weaviate/data/checker.go
@@ -41,6 +41,12 @@ func (c *Checker) WithTenant(tenant string) *Checker {
 // Do check the specified data object if it exists in weaviate
 func (checker *Checker) Do(ctx context.Context) (bool, error) {
 	responseData, err := checker.connection.RunREST(ctx, checker.buildPath(), http.MethodHead, nil)
+	// Checking... if responseData is nil before accessing it
+	// This can happen if the request fails..... e.g. timeout, 504, etc.
+	if responseData == nil {
+		return false, except.CheckResponseDataErrorAndStatusCode(responseData, err, 204, 404)
+	}
+
 	exists := responseData.StatusCode == 204
 	return exists, except.CheckResponseDataErrorAndStatusCode(responseData, err, 204, 404)
 }


### PR DESCRIPTION
### What's being changed:

This PR fixes a `nil` pointer dereference panic in the `Checker.Do` method (Issue #299).

When the underlying REST connection fails, such as when it returns a 504 Gateway Timeout or 204 No Content with a nil body in certain edge cases, the `responseData` object can be `nil`. Accessing `responseData.StatusCode` directly led to a panic.

I added a check to ensure that `responseData` is not `nil` before accessing it.

### Review checklist

- [x] All new code is covered by tests where it is reasonable.
