### PR TITLE
Inject version in client header

### DIFF
--- a/tools/prepare_release.sh
+++ b/tools/prepare_release.sh
@@ -62,6 +62,10 @@ sed -i '' \
     -e "s|\($PACKAGE\)/v${CURRENT_MAJOR_VERSION}|\1/v${TARGET_MAJOR_VERSION}|g" \
     -e "/require/s/ v[0-9]*.[0-9]*.[0-9]*$/ $TARGET_VERSION/g" README.md
 
+
+# Update clientVersion in version.go
+sed -i '' "s/^const clientVersion = \".*\"/const clientVersion = \"$TARGET_VERSION\"/" weaviate/internal/version.go
+
 git commit -a -m "Release $TARGET_VERSION version"
 
 git tag -a "$TARGET_VERSION" -m "$TARGET_VERSION"

--- a/weaviate/internal/version.go
+++ b/weaviate/internal/version.go
@@ -1,0 +1,7 @@
+package internal
+
+const clientVersion = "5.6.0"
+
+func GetClientVersionHeader() string {
+	return "weaviate-client-go/" + clientVersion
+}

--- a/weaviate/weaviate_client.go
+++ b/weaviate/weaviate_client.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/graphql"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/groups"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/grpc"
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/internal"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/misc"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/rbac"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/schema"
@@ -157,6 +158,7 @@ func NewClient(config Config) (*Client, error) {
 			config.Headers["X-Weaviate-Api-Key"] = *config.AuthConfig.ApiKey()
 			config.Headers["X-Weaviate-Cluster-URL"] = "https://" + config.Host
 		}
+		config.Headers["X-Weaviate-Client"] = internal.GetClientVersionHeader()
 	}
 
 	con := connection.NewConnection(config.Scheme, config.Host, config.ConnectionClient, config.getTimeout(), config.Headers)


### PR DESCRIPTION
Add a client version header to the requests sent by the Weaviate client. Update the version in the `version.go` file and ensure the header is included in the client configuration.