### PR TITLE
chore: update Weaviate version to latest v1.36 main version

### DIFF
--- a/.github/workflows/workflow-tests.yaml
+++ b/.github/workflows/workflow-tests.yaml
@@ -2,7 +2,7 @@ on:
   workflow_call:
 
 env:
-  WEAVIATE_VERSION: 1.33.6
+  WEAVIATE_VERSION: 1.36.0-dev-0fae291
 
 jobs:
   auth-tests:

--- a/test/schema/default_config_test.go
+++ b/test/schema/default_config_test.go
@@ -14,6 +14,7 @@ var defaultInvertedIndexConfig = &models.InvertedIndexConfig{
 	Stopwords: &models.StopwordConfig{
 		Preset: "en",
 	},
+	UsingBlockMaxWAND: config.DefaultUsingBlockMaxWAND,
 }
 
 var defaultModuleConfig = map[string]interface{}{
@@ -96,7 +97,7 @@ var defaultMultivectorConfig = map[string]interface{}{
 
 var defaultReplicationConfig = &models.ReplicationConfig{
 	Factor:           1,
-	DeletionStrategy: models.ReplicationConfigDeletionStrategyDeleteOnConflict,
+	DeletionStrategy: models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
 }
 
 var defaultMultiTenancyConfig = &models.MultiTenancyConfig{


### PR DESCRIPTION
This PR updates Weaviate test version to 1.36.0-dev-0fae291