### PR TITLE
v6: Count objects in collection

### DIFF
--- a/api/rest/schema.check.json
+++ b/api/rest/schema.check.json
@@ -610,16 +610,6 @@
             "type": "string"
           },
           "description": "List of collection names to exclude from the export. Cannot be used with 'include'."
-        },
-        "config": {
-          "type": "object",
-          "description": "Backend-specific configuration",
-          "properties": {
-            "path": {
-              "type": "string",
-              "description": "Path prefix within the bucket or filesystem"
-            }
-          }
         }
       }
     },
@@ -9616,13 +9606,6 @@
             "required": true,
             "type": "string",
             "description": "The unique identifier of the export."
-          },
-          {
-            "name": "path",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "description": "Optional path prefix within the bucket. If not specified, uses the backend's default path."
           }
         ],
         "responses": {
@@ -9685,13 +9668,6 @@
             "required": true,
             "type": "string",
             "description": "The unique identifier of the export to cancel."
-          },
-          {
-            "name": "path",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "description": "Optional path prefix within the bucket."
           }
         ],
         "responses": {

--- a/api/rest/schema.v3.yaml
+++ b/api/rest/schema.v3.yaml
@@ -901,13 +901,6 @@ components:
         ExportCreateRequest:
             description: Request to create a new export operation
             properties:
-                config:
-                    description: Backend-specific configuration
-                    properties:
-                        path:
-                            description: Path prefix within the bucket or filesystem
-                            type: string
-                    type: object
                 exclude:
                     description: List of collection names to exclude from the export. Cannot be used with 'include'.
                     items:
@@ -4928,11 +4921,6 @@ paths:
                   required: true
                   schema:
                     type: string
-                - description: Optional path prefix within the bucket.
-                  in: query
-                  name: path
-                  schema:
-                    type: string
             responses:
                 "204":
                     content: {}
@@ -4989,11 +4977,6 @@ paths:
                   in: path
                   name: id
                   required: true
-                  schema:
-                    type: string
-                - description: Optional path prefix within the bucket. If not specified, uses the backend's default path.
-                  in: query
-                  name: path
                   schema:
                     type: string
             responses:

--- a/collections/client.go
+++ b/collections/client.go
@@ -92,6 +92,16 @@ func (h *Handle) WithOptions(options ...HandleOption) *Handle {
 	return newHandle(h.transport, defaults)
 }
 
+// Count objects in the collection, respecting the tenant if provided.
+func (h *Handle) Count(ctx context.Context) (int64, error) {
+	req := api.CountObjectsRequest(h.defaults)
+	var resp api.CountObjectsResponse
+	if err := h.transport.Do(ctx, &req, &resp); err != nil {
+		return 0, fmt.Errorf("count objects: %w", err)
+	}
+	return resp.Int64(), nil
+}
+
 // Create new collection in the schema. A collection can be created with just the name.
 // To configure the new collection, provide a single instance of CreateOptions as the options argument.
 //

--- a/collections/client_test.go
+++ b/collections/client_test.go
@@ -66,6 +66,23 @@ func TestClient_Use(t *testing.T) {
 	})
 }
 
+func TestHandle_Count(t *testing.T) {
+	transport := testkit.NewTransport(t, []testkit.Stub[api.CountObjectsRequest, api.CountObjectsResponse]{{
+		Request:  &api.CountObjectsRequest{CollectionName: "Songs", Tenant: "john_doe"},
+		Response: api.CountObjectsResponse(92),
+	}})
+
+	c := collections.NewClient(transport)
+	require.NotNil(t, c, "nil client")
+
+	h := c.Use("Songs", collections.WithTenant("john_doe"))
+	require.NotNil(t, h, "nil handle")
+
+	count, err := h.Count(t.Context())
+	require.NoError(t, err)
+	require.EqualValues(t, 92, count, "wrong count")
+}
+
 func TestClient_Create(t *testing.T) {
 	for _, tt := range []struct {
 		name       string

--- a/internal/api/aggregate.go
+++ b/internal/api/aggregate.go
@@ -1,11 +1,7 @@
 package api
 
 import (
-	"cmp"
 	"fmt"
-	"iter"
-	"maps"
-	"slices"
 	"time"
 
 	proto "github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/proto/v1"
@@ -438,18 +434,6 @@ func nilZero[T comparable](v T) *T {
 		return nil
 	}
 	return &v
-}
-
-// sortedMap returns an iterator over key-value pairs from m;
-// similar to [maps.All], but with pairs sorted by key.
-func sortedMap[Map ~map[K]V, K cmp.Ordered, V any](m Map) iter.Seq2[K, V] {
-	return func(yield func(K, V) bool) {
-		for _, k := range slices.Sorted(maps.Keys(m)) {
-			if !yield(k, m[k]) {
-				return
-			}
-		}
-	}
 }
 
 type (

--- a/internal/api/aggregate.go
+++ b/internal/api/aggregate.go
@@ -1,7 +1,11 @@
 package api
 
 import (
+	"cmp"
 	"fmt"
+	"iter"
+	"maps"
+	"slices"
 	"time"
 
 	proto "github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/proto/v1"
@@ -24,6 +28,12 @@ type AggregateRequest struct {
 
 	NearVector *NearVector
 }
+
+var (
+	_ transport.Message[proto.AggregateRequest, proto.AggregateReply] = (*AggregateRequest)(nil)
+	_ transport.MessageMarshaler[proto.AggregateRequest]              = (*AggregateRequest)(nil)
+)
+
 type (
 	AggregateTextRequest struct {
 		Property string
@@ -75,13 +85,14 @@ type (
 	}
 )
 
-func (r *AggregateRequest) Method() transport.MethodFunc[proto.AggregateRequest, proto.AggregateReply] {
+func (*AggregateRequest) Method() transport.MethodFunc[proto.AggregateRequest, proto.AggregateReply] {
 	return proto.WeaviateClient.Aggregate
 }
 func (r *AggregateRequest) Body() transport.MessageMarshaler[proto.AggregateRequest] { return r }
 
-// MarshalMessage implements [Message].
 func (r *AggregateRequest) MarshalMessage() (*proto.AggregateRequest, error) {
+	dev.AssertNotNil(r, "r")
+
 	var aggregations []*proto.AggregateRequest_Aggregation
 	for _, txt := range r.Text {
 		aggregations = append(aggregations, &proto.AggregateRequest_Aggregation{
@@ -195,6 +206,8 @@ type AggregateResponse struct {
 	GroupByResults []AggregateGroup
 }
 
+var _ transport.MessageUnmarshaler[proto.AggregateReply] = (*AggregateResponse)(nil)
+
 type (
 	Aggregations struct {
 		TotalCount *int64
@@ -267,7 +280,7 @@ func (r *AggregateResponse) UnmarshalMessage(reply *proto.AggregateReply) error 
 
 	single := reply.GetSingleResult()
 	if single != nil {
-		aggregations, err := unmarshalAggregations(single.GetAggregations().Aggregations)
+		aggregations, err := unmarshalAggregations(single.GetAggregations().GetAggregations())
 		if err != nil {
 			return err
 		}
@@ -284,7 +297,7 @@ func (r *AggregateResponse) UnmarshalMessage(reply *proto.AggregateReply) error 
 			property := by.GetPath()[0]
 
 			var results Aggregations
-			aggregations, err := unmarshalAggregations(group.GetAggregations().Aggregations)
+			aggregations, err := unmarshalAggregations(group.GetAggregations().GetAggregations())
 			if err != nil {
 				return err
 			}
@@ -425,4 +438,55 @@ func nilZero[T comparable](v T) *T {
 		return nil
 	}
 	return &v
+}
+
+// sortedMap returns an iterator over key-value pairs from m;
+// similar to [maps.All], but with pairs sorted by key.
+func sortedMap[Map ~map[K]V, K cmp.Ordered, V any](m Map) iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		for _, k := range slices.Sorted(maps.Keys(m)) {
+			if !yield(k, m[k]) {
+				return
+			}
+		}
+	}
+}
+
+type (
+	CountObjectsRequest  RequestDefaults
+	CountObjectsResponse int64
+)
+
+var (
+	_ transport.Message[proto.AggregateRequest, proto.AggregateReply] = (*CountObjectsRequest)(nil)
+	_ transport.MessageUnmarshaler[proto.AggregateReply]              = (*CountObjectsResponse)(nil)
+)
+
+func (*CountObjectsRequest) Method() transport.MethodFunc[proto.AggregateRequest, proto.AggregateReply] {
+	return (*AggregateRequest)(nil).Method() // Safe to call on a nil value.
+}
+
+func (r *CountObjectsRequest) Body() transport.MessageMarshaler[proto.AggregateRequest] {
+	dev.AssertNotNil(r, "r")
+	req := &AggregateRequest{
+		RequestDefaults: RequestDefaults(*r),
+		TotalCount:      true,
+	}
+	return req.Body()
+}
+
+func (r *CountObjectsResponse) UnmarshalMessage(reply *proto.AggregateReply) error {
+	var resp AggregateResponse
+	if err := resp.UnmarshalMessage(reply); err != nil {
+		return err
+	}
+	if resp.Results.TotalCount == nil {
+		return fmt.Errorf("nil total count")
+	}
+	*r = CountObjectsResponse(*resp.Results.TotalCount)
+	return nil
+}
+
+func (r CountObjectsResponse) Int64() int64 {
+	return int64(r)
 }

--- a/internal/api/internal/gen/rest/models.go
+++ b/internal/api/internal/gen/rest/models.go
@@ -955,12 +955,6 @@ type ErrorResponse struct {
 
 // ExportCreateRequest Request to create a new export operation
 type ExportCreateRequest struct {
-	// Config Backend-specific configuration
-	Config struct {
-		// Path Path prefix within the bucket or filesystem
-		Path string `json:"path,omitempty"`
-	} `json:"config,omitempty"`
-
 	// Exclude List of collection names to exclude from the export. Cannot be used with 'include'.
 	Exclude []string `json:"exclude,omitempty"`
 
@@ -2288,18 +2282,6 @@ type BatchReferencesCreateJSONBody = []BatchReference
 type BatchReferencesCreateParams struct {
 	// ConsistencyLevel Determines how many replicas must acknowledge a request before it is considered successful.
 	ConsistencyLevel string `form:"consistency_level,omitempty" json:"consistency_level,omitempty"`
-}
-
-// ExportCancelParams defines parameters for ExportCancel.
-type ExportCancelParams struct {
-	// Path Optional path prefix within the bucket.
-	Path string `form:"path,omitempty" json:"path,omitempty"`
-}
-
-// ExportStatusParams defines parameters for ExportStatus.
-type ExportStatusParams struct {
-	// Path Optional path prefix within the bucket. If not specified, uses the backend's default path.
-	Path string `form:"path,omitempty" json:"path,omitempty"`
 }
 
 // NodesGetParams defines parameters for NodesGet.

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -731,6 +731,18 @@ func TestAggregateRequest_MarshalMessage(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "count objects",
+			req: &api.CountObjectsRequest{
+				CollectionName: "Songs",
+				Tenant:         "john_doe",
+			},
+			want: &proto.AggregateRequest{
+				Collection:   "Songs",
+				Tenant:       "john_doe",
+				ObjectsCount: true,
+			},
+		},
 	})
 
 	t.Run("with query filter", func(t *testing.T) {
@@ -1307,9 +1319,9 @@ func object(m map[string]*proto.Value) *proto.Value {
 	}}}
 }
 
-// TestAggregateRequest_UnmarshalMessage tests that api.AggregateResponse reads
+// TestAggregateResponse_UnmarshalMessage tests that api.AggregateResponse reads
 // proto.AggregateRequest correctly when its UnmarshalMessage is called.
-func TestAggregateRequest_UnmarshalMessage(t *testing.T) {
+func TestAggregateResponse_UnmarshalMessage(t *testing.T) {
 	type Aggregations []*proto.AggregateReply_Aggregations_Aggregation
 
 	// reply is a helper function to wrap returned aggregations in the layers or protobuf bureaucracy.
@@ -1631,6 +1643,18 @@ func TestAggregateRequest_UnmarshalMessage(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "object count",
+			reply: &proto.AggregateReply{
+				Result: &proto.AggregateReply_SingleResult{
+					SingleResult: &proto.AggregateReply_Single{
+						ObjectsCount: testkit.Ptr[int64](92),
+					},
+				},
+			},
+			dest: new(api.CountObjectsResponse),
+			want: testkit.Ptr[api.CountObjectsResponse](92),
 		},
 	})
 }


### PR DESCRIPTION
This PR adds `handle.Count(ctx)` helper function, similar to Python's `len(collection)` and Java's `handle.size()`, as a shorthand for the "count(*)"-aggregation.
