### PR TITLE
v6: Near Text

### DIFF
--- a/api/rest/schema.check.json
+++ b/api/rest/schema.check.json
@@ -307,11 +307,6 @@
             }
           }
         },
-        "mcp": {
-          "type": "object",
-          "description": "resources applicable for MCP actions",
-          "properties": {}
-        },
         "action": {
           "type": "string",
           "description": "Allowed actions in weaviate.",
@@ -350,7 +345,9 @@
             "delete_aliases",
             "assign_and_revoke_groups",
             "read_groups",
-            "manage_mcp"
+            "create_mcp",
+            "read_mcp",
+            "update_mcp"
           ]
         }
       },
@@ -3483,7 +3480,7 @@
     },
     "description": "# Introduction<br/> Weaviate is an open source, AI-native vector database that helps developers create intuitive and reliable AI-powered applications. <br/> ### Base Path <br/>The base path for the Weaviate server is structured as `[YOUR-WEAVIATE-HOST]:[PORT]/v1`. As an example, if you wish to access the `schema` endpoint on a local instance, you would navigate to `http://localhost:8080/v1/schema`. Ensure you replace `[YOUR-WEAVIATE-HOST]` and `[PORT]` with your actual server host and port number respectively. <br/> ### Questions? <br/>If you have any comments or questions, please feel free to reach out to us at the community forum [https://forum.weaviate.io/](https://forum.weaviate.io/). <br/>### Issues? <br/>If you find a bug or want to file a feature request, please open an issue on our GitHub repository for [Weaviate](https://github.com/weaviate/weaviate). <br/>### Need more documentation? <br/>For a quickstart, code examples, concepts and more, please visit our [documentation page](https://docs.weaviate.io/weaviate).",
     "title": "Weaviate REST API",
-    "version": "1.37.0-rc.1"
+    "version": "1.38.0-dev"
   },
   "parameters": {
     "CommonAfterParameterQuery": {

--- a/api/rest/schema.v3.yaml
+++ b/api/rest/schema.v3.yaml
@@ -1463,7 +1463,9 @@ components:
                         - delete_aliases
                         - assign_and_revoke_groups
                         - read_groups
-                        - manage_mcp
+                        - create_mcp
+                        - read_mcp
+                        - update_mcp
                     type: string
                 aliases:
                     description: Resource definition for alias-related actions and permissions. Used to specify which aliases and collections can be accessed or modified.
@@ -1518,10 +1520,6 @@ components:
                             type: string
                         groupType:
                             $ref: '#/components/schemas/GroupType'
-                    type: object
-                mcp:
-                    description: resources applicable for MCP actions
-                    properties: {}
                     type: object
                 nodes:
                     description: Resources applicable for cluster actions.
@@ -2668,7 +2666,7 @@ info:
         url: https://github.com/weaviate
     description: '# Introduction<br/> Weaviate is an open source, AI-native vector database that helps developers create intuitive and reliable AI-powered applications. <br/> ### Base Path <br/>The base path for the Weaviate server is structured as `[YOUR-WEAVIATE-HOST]:[PORT]/v1`. As an example, if you wish to access the `schema` endpoint on a local instance, you would navigate to `http://localhost:8080/v1/schema`. Ensure you replace `[YOUR-WEAVIATE-HOST]` and `[PORT]` with your actual server host and port number respectively. <br/> ### Questions? <br/>If you have any comments or questions, please feel free to reach out to us at the community forum [https://forum.weaviate.io/](https://forum.weaviate.io/). <br/>### Issues? <br/>If you find a bug or want to file a feature request, please open an issue on our GitHub repository for [Weaviate](https://github.com/weaviate/weaviate). <br/>### Need more documentation? <br/>For a quickstart, code examples, concepts and more, please visit our [documentation page](https://docs.weaviate.io/weaviate).'
     title: Weaviate REST API
-    version: 1.37.0-rc.1
+    version: 1.38.0-dev
 openapi: 3.0.1
 paths:
     /:

--- a/cmd/build/contracts.go
+++ b/cmd/build/contracts.go
@@ -131,6 +131,7 @@ func Contracts(ctx context.Context, args []string) error {
 			printError(err)
 			ok = false
 		}
+		updated = true
 	}
 
 	// Regenerate schema.v3.json if files were updated successfully.
@@ -160,6 +161,7 @@ Update them to the latest version by running this command:
 	go run ./cmd/build contracts
 			`) // nolint:staticcheck
 	}
+
 	if updated {
 		log.Print(`
 Contracts were successfully updated, run:

--- a/internal/api/internal/gen/rest/models.go
+++ b/internal/api/internal/gen/rest/models.go
@@ -176,6 +176,7 @@ const (
 	CreateAliases         PermissionAction = "create_aliases"
 	CreateCollections     PermissionAction = "create_collections"
 	CreateData            PermissionAction = "create_data"
+	CreateMcp             PermissionAction = "create_mcp"
 	CreateReplicate       PermissionAction = "create_replicate"
 	CreateRoles           PermissionAction = "create_roles"
 	CreateTenants         PermissionAction = "create_tenants"
@@ -188,12 +189,12 @@ const (
 	DeleteTenants         PermissionAction = "delete_tenants"
 	DeleteUsers           PermissionAction = "delete_users"
 	ManageBackups         PermissionAction = "manage_backups"
-	ManageMcp             PermissionAction = "manage_mcp"
 	ReadAliases           PermissionAction = "read_aliases"
 	ReadCluster           PermissionAction = "read_cluster"
 	ReadCollections       PermissionAction = "read_collections"
 	ReadData              PermissionAction = "read_data"
 	ReadGroups            PermissionAction = "read_groups"
+	ReadMcp               PermissionAction = "read_mcp"
 	ReadNodes             PermissionAction = "read_nodes"
 	ReadReplicate         PermissionAction = "read_replicate"
 	ReadRoles             PermissionAction = "read_roles"
@@ -202,6 +203,7 @@ const (
 	UpdateAliases         PermissionAction = "update_aliases"
 	UpdateCollections     PermissionAction = "update_collections"
 	UpdateData            PermissionAction = "update_data"
+	UpdateMcp             PermissionAction = "update_mcp"
 	UpdateReplicate       PermissionAction = "update_replicate"
 	UpdateRoles           PermissionAction = "update_roles"
 	UpdateTenants         PermissionAction = "update_tenants"
@@ -1401,9 +1403,6 @@ type Permission struct {
 		// GroupType If the group contains OIDC or database users.
 		GroupType GroupType `json:"groupType,omitempty"`
 	} `json:"groups,omitempty"`
-
-	// Mcp resources applicable for MCP actions
-	Mcp map[string]interface{} `json:"mcp,omitempty"`
 
 	// Nodes Resources applicable for cluster actions.
 	Nodes struct {

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -562,6 +562,132 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 			},
 		},
 		{
+			name: "near text implicit target",
+			req: &api.SearchRequest{
+				NearText: &api.NearText{
+					Concepts: []string{"apples", "oranges"},
+					Distance: testkit.Ptr(.92),
+					MoveTo: &api.Move{
+						Force:    0.58,
+						Concepts: []string{"computers"},
+					},
+					MoveAway: &api.Move{
+						Force:   0.22,
+						Objects: []uuid.UUID{uuid.Nil, uuid.Max},
+					},
+				},
+			},
+			want: &proto.SearchRequest{
+				NearText: &proto.NearTextSearch{
+					Query:    []string{"apples", "oranges"},
+					Distance: testkit.Ptr(.92),
+					MoveTo: &proto.NearTextSearch_Move{
+						Force:    0.58,
+						Concepts: []string{"computers"},
+					},
+					MoveAway: &proto.NearTextSearch_Move{
+						Force: 0.22,
+						Uuids: []string{uuid.Nil.String(), uuid.Max.String()},
+					},
+				},
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+			},
+		},
+		{
+			name: "near text explicit target",
+			req: &api.SearchRequest{
+				NearText: &api.NearText{
+					Concepts: []string{"apples", "oranges"},
+					Target: api.SearchTarget{
+						Vectors: []api.TargetVector{
+							{Vector: api.Vector{Name: "title_vec"}},
+						},
+					},
+				},
+			},
+			want: &proto.SearchRequest{
+				NearText: &proto.NearTextSearch{
+					Query: []string{"apples", "oranges"},
+					Targets: &proto.Targets{
+						TargetVectors: []string{"title_vec"},
+					},
+				},
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+			},
+		},
+		{
+			name: "near text multi target sum",
+			req: &api.SearchRequest{
+				NearText: &api.NearText{
+					Concepts: []string{"apples", "oranges"},
+					Target: api.SearchTarget{
+						Vectors: []api.TargetVector{
+							{Vector: api.Vector{Name: "title_vec"}},
+							{Vector: api.Vector{Name: "lyrics_vec"}},
+						},
+						CombinationMethod: api.CombinationMethodSum,
+					},
+				},
+			},
+			want: &proto.SearchRequest{
+				NearText: &proto.NearTextSearch{
+					Query: []string{"apples", "oranges"},
+					Targets: &proto.Targets{
+						TargetVectors: []string{"title_vec", "lyrics_vec"},
+						Combination:   proto.CombinationMethod_COMBINATION_METHOD_TYPE_SUM,
+					},
+				},
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+			},
+		},
+		{
+			name: "near text multi target relative score",
+			req: &api.SearchRequest{
+				NearText: &api.NearText{
+					Concepts: []string{"apples", "oranges"},
+					Target: api.SearchTarget{
+						Vectors: []api.TargetVector{
+							{
+								Vector: api.Vector{Name: "title_vec"},
+								Weight: testkit.Ptr[float32](.11),
+							},
+							{
+								Vector: api.Vector{Name: "lyrics_vec"},
+								Weight: testkit.Ptr[float32](.22),
+							},
+						},
+						CombinationMethod: api.CombinationMethodRelativeScore,
+					},
+				},
+			},
+			want: &proto.SearchRequest{
+				NearText: &proto.NearTextSearch{
+					Query: []string{"apples", "oranges"},
+					Targets: &proto.Targets{
+						TargetVectors: []string{"title_vec", "lyrics_vec"},
+						Combination:   proto.CombinationMethod_COMBINATION_METHOD_TYPE_RELATIVE_SCORE,
+						WeightsForTargets: []*proto.WeightsForTarget{
+							{Target: "title_vec", Weight: .11},
+							{Target: "lyrics_vec", Weight: .22},
+						},
+					},
+				},
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+			},
+		},
+		{
 			name: "group by",
 			req: &api.SearchRequest{
 				GroupBy: &api.GroupBy{

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -575,8 +575,8 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 						Force:   0.22,
 						Objects: []uuid.UUID{uuid.Nil, uuid.Max},
 					},
-					Selection: &api.SelectionMMR{
-						Limit: int32(3),
+					Selection: api.Selection{
+						MMR: &api.SelectionMMR{Limit: int32(3)},
 					},
 				},
 			},

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -575,6 +575,9 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 						Force:   0.22,
 						Objects: []uuid.UUID{uuid.Nil, uuid.Max},
 					},
+					Selection: &api.SelectionMMR{
+						Limit: int32(3),
+					},
 				},
 			},
 			want: &proto.SearchRequest{
@@ -588,6 +591,13 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 					MoveAway: &proto.NearTextSearch_Move{
 						Force: 0.22,
 						Uuids: []string{uuid.Nil.String(), uuid.Max.String()},
+					},
+					Selection: &proto.Selection{
+						Selection: &proto.Selection_Mmr{
+							Mmr: &proto.Selection_MMR{
+								Limit: testkit.Ptr[uint32](3),
+							},
+						},
 					},
 				},
 				Metadata: &proto.MetadataRequest{Uuid: true},

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -318,6 +318,9 @@ func marshalNearText(req *NearText) (*proto.NearTextSearch, error) {
 		Certainty: req.Certainty,
 	}
 
+	// We keep MoveTo and MoveAway marshaling inline to
+	// 1) avoid breeding functions; these params are only needed here
+	// 2) re-use the uuids slice if possible (minor benefit, but still).
 	var uuids []string
 	if m := req.MoveTo; m != nil {
 		uuids = slices.Grow(uuids, len(m.Objects))
@@ -344,6 +347,8 @@ func marshalNearText(req *NearText) (*proto.NearTextSearch, error) {
 	}
 
 	if len(req.Target.Vectors) > 0 {
+		// Pre-allocate slices for targets. Do not allocate WeightsForTarget,
+		// as targets may have no weights.
 		nt.Targets = &proto.Targets{
 			TargetVectors: make([]string, len(req.Target.Vectors)),
 			Combination:   req.Target.CombinationMethod.proto(),

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -25,6 +26,7 @@ type SearchRequest struct {
 	GroupBy          *GroupBy
 
 	NearVector *NearVector
+	NearText   *NearText
 }
 
 var (
@@ -79,6 +81,19 @@ type (
 		Certainty *float64
 		Distance  *float64
 	}
+	NearText struct {
+		Concepts         []string
+		Target           SearchTarget
+		Certainty        *float64
+		Distance         *float64
+		MoveTo, MoveAway *Move
+		// TODO(dyma): add MMR selection
+	}
+	Move struct {
+		Force    float32
+		Objects  []uuid.UUID
+		Concepts []string
+	}
 )
 
 func (r *SearchRequest) MarshalMessage() (*proto.SearchRequest, error) {
@@ -124,6 +139,8 @@ func (r *SearchRequest) MarshalMessage() (*proto.SearchRequest, error) {
 	switch {
 	case r.NearVector != nil:
 		req.NearVector, err = marshalNearVector(r.NearVector)
+	case r.NearText != nil:
+		req.NearText, err = marshalNearText(r.NearText)
 	}
 	if err != nil {
 		return nil, err
@@ -290,6 +307,61 @@ func marshalVector(v *Vector) (*proto.Vectors, error) {
 		return nil, errors.New("empty vector")
 	}
 	return out, nil
+}
+
+func marshalNearText(req *NearText) (*proto.NearTextSearch, error) {
+	dev.AssertNotNil(req, "req")
+
+	nt := &proto.NearTextSearch{
+		Query:     req.Concepts,
+		Distance:  req.Distance,
+		Certainty: req.Certainty,
+	}
+
+	var uuids []string
+	if m := req.MoveTo; m != nil {
+		uuids = slices.Grow(uuids, len(m.Objects))
+		for _, u := range m.Objects {
+			uuids = append(uuids, u.String())
+		}
+		nt.MoveTo = &proto.NearTextSearch_Move{
+			Force:    m.Force,
+			Concepts: m.Concepts,
+			Uuids:    uuids,
+		}
+	}
+
+	if m := req.MoveAway; m != nil {
+		uuids = slices.Grow(uuids[:0], len(m.Objects))
+		for _, u := range m.Objects {
+			uuids = append(uuids, u.String())
+		}
+		nt.MoveAway = &proto.NearTextSearch_Move{
+			Force:    m.Force,
+			Concepts: m.Concepts,
+			Uuids:    uuids,
+		}
+	}
+
+	if len(req.Target.Vectors) > 0 {
+		nt.Targets = &proto.Targets{
+			TargetVectors: make([]string, len(req.Target.Vectors)),
+			Combination:   req.Target.CombinationMethod.proto(),
+		}
+
+		for i, tv := range req.Target.Vectors {
+			nt.Targets.TargetVectors[i] = tv.Name
+			if tv.Weight != nil {
+				nt.Targets.WeightsForTargets = append(nt.Targets.WeightsForTargets,
+					&proto.WeightsForTarget{
+						Target: tv.Name,
+						Weight: *tv.Weight,
+					})
+			}
+		}
+	}
+
+	return nt, nil
 }
 
 type SearchResponse struct {

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -87,12 +87,20 @@ type (
 		Certainty        *float64
 		Distance         *float64
 		MoveTo, MoveAway *Move
-		// TODO(dyma): add MMR selection
+
+		Selection any
 	}
 	Move struct {
 		Force    float32
 		Objects  []uuid.UUID
 		Concepts []string
+	}
+	Selection struct {
+		MMR *SelectionMMR
+	}
+	SelectionMMR struct {
+		Limit   int32
+		Balance float32
 	}
 )
 
@@ -364,6 +372,24 @@ func marshalNearText(req *NearText) (*proto.NearTextSearch, error) {
 					})
 			}
 		}
+	}
+
+	if req.Selection != nil {
+		var sel proto.Selection
+		switch s := req.Selection.(type) {
+		case *SelectionMMR:
+			sel.Selection = &proto.Selection_Mmr{
+				Mmr: &proto.Selection_MMR{
+					Limit:   nilPresent(uint32(s.Limit), s.Limit > 0),
+					Balance: nilPresent(s.Balance, s.Balance > 0),
+				},
+			}
+		default:
+			dev.Unreachable()
+		}
+
+		dev.AssertNotNil(sel.Selection, "sel.Selection")
+		nt.Selection = &sel
 	}
 
 	return nt, nil

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -88,7 +88,7 @@ type (
 		Distance         *float64
 		MoveTo, MoveAway *Move
 
-		Selection any
+		Selection Selection
 	}
 	Move struct {
 		Force    float32
@@ -374,22 +374,17 @@ func marshalNearText(req *NearText) (*proto.NearTextSearch, error) {
 		}
 	}
 
-	if req.Selection != nil {
-		var sel proto.Selection
-		switch s := req.Selection.(type) {
-		case *SelectionMMR:
-			sel.Selection = &proto.Selection_Mmr{
+	switch {
+	case req.Selection.MMR != nil:
+		mmr := req.Selection.MMR
+		nt.Selection = &proto.Selection{
+			Selection: &proto.Selection_Mmr{
 				Mmr: &proto.Selection_MMR{
-					Limit:   nilPresent(uint32(s.Limit), s.Limit > 0),
-					Balance: nilPresent(s.Balance, s.Balance > 0),
+					Limit:   nilPresent(uint32(mmr.Limit), mmr.Limit > 0),
+					Balance: nilPresent(mmr.Balance, mmr.Balance > 0),
 				},
-			}
-		default:
-			dev.Unreachable()
+			},
 		}
-
-		dev.AssertNotNil(sel.Selection, "sel.Selection")
-		nt.Selection = &sel
 	}
 
 	return nt, nil

--- a/internal/dev/assert.go
+++ b/internal/dev/assert.go
@@ -58,6 +58,14 @@ func AssertNotNil(v any, name string) {
 	Assert(!isNil(v), "%s %T is nil", name, v)
 }
 
+// Unreachable panics with message "unreachable" if reached.
+// This is a good way to document the area of the code that
+// is never meant to be executed, e.g. the "default" branch
+// of a switch statement.
+func Unreachable() {
+	panic("unreachable")
+}
+
 // isNil checks if v is nil using [reflect] for typed nil values.
 func isNil(v any) bool {
 	if v == nil {

--- a/query/client.go
+++ b/query/client.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"time"
 
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
@@ -16,6 +17,7 @@ func NewClient(t internal.Transport, rd api.RequestDefaults) *Client {
 		transport:  t,
 		defaults:   rd,
 		NearVector: nearVectorFunc(t, rd),
+		NearText:   nearTextFunc(t, rd),
 	}
 }
 
@@ -24,6 +26,7 @@ type Client struct {
 	defaults  api.RequestDefaults
 
 	NearVector NearVectorFunc
+	NearText   NearTextFunc
 }
 
 type (
@@ -62,6 +65,7 @@ type VectorTarget interface {
 }
 
 type Result struct {
+	Took    time.Duration
 	Objects []Object[map[string]any]
 }
 
@@ -78,6 +82,7 @@ type Metadata struct {
 }
 
 type GroupByResult struct {
+	Took    time.Duration
 	Objects []GroupObject[map[string]any]
 	Groups  map[string]Group[map[string]any]
 }

--- a/query/near_text.go
+++ b/query/near_text.go
@@ -31,6 +31,8 @@ type NearText struct {
 	// Bias the results towards or away from concepts and/or vectors.
 	MoveTo, MoveAway *Move
 
+	MMR *MMR
+
 	// Target vector or a combination of multiple vector targets.
 	// By default, the resulting vectors are compared against the "default"
 	// vector, or the _only_ vector, if the collection only has a single vector index.
@@ -47,7 +49,11 @@ type NearText struct {
 	groupBy *GroupBy
 }
 
-type Move api.Move
+type (
+	// Move adjusts the bias of the query results.
+	Move api.Move
+	MMR  api.SelectionMMR
+)
 
 // NearTextFunc runs plain near text search.
 type NearTextFunc func(context.Context, NearText) (*Result, error)
@@ -72,15 +78,21 @@ func nearText(ctx context.Context, t internal.Transport, rd api.RequestDefaults,
 		ReturnReferences: marshalReturnReferences(nt.ReturnReferences),
 	}
 
+	req.NearText = &api.NearText{
+		Concepts:  nt.Concepts,
+		Distance:  nt.Similarity.Distance(),
+		Certainty: nt.Similarity.Certainty(),
+		MoveTo:    (*api.Move)(nt.MoveTo),
+		MoveAway:  (*api.Move)(nt.MoveAway),
+	}
+
 	if nt.Target != nil {
-		req.NearText = &api.NearText{
-			Concepts:  nt.Concepts,
-			Target:    marshalSearchTarget(nt.Target),
-			Distance:  nt.Similarity.Distance(),
-			Certainty: nt.Similarity.Certainty(),
-			MoveTo:    (*api.Move)(nt.MoveTo),
-			MoveAway:  (*api.Move)(nt.MoveAway),
-		}
+		req.NearText.Target = marshalSearchTarget(nt.Target)
+	}
+
+	switch {
+	case nt.MMR != nil:
+		req.NearText.Selection = (*api.SelectionMMR)(nt.MMR)
 	}
 
 	if nt.groupBy != nil {

--- a/query/near_text.go
+++ b/query/near_text.go
@@ -8,10 +8,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
-	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
 )
 
-type NearVector struct {
+type NearText struct {
 	Limit                  int32            // Limit the number of results returned for the query.
 	Offset                 int32            // Skip the first N objects in the collection.
 	AutoLimit              int32            // Return objects in the first N similarity clusters.
@@ -25,7 +24,16 @@ type NearVector struct {
 	// To not return any properties, initialize this value to an empty slice explicitly.
 	ReturnProperties []string
 
-	// Target vector or a combination of multiple vector targets. Required parameter.
+	// Concepts are vectorized and used and the actual target for the similarity search.
+	// Required parameter.
+	Concepts []string
+
+	// Bias the results towards or away from concepts and/or vectors.
+	MoveTo, MoveAway *Move
+
+	// Target vector or a combination of multiple vector targets.
+	// By default, the resulting vectors are compared against the "default"
+	// vector, or the _only_ vector, if the collection only has a single vector index.
 	// See [MultiVectorTarget] for examples of providing multiple targets.
 	Target VectorTarget
 
@@ -35,45 +43,51 @@ type NearVector struct {
 	// Prefer expressing Similarity in terms of vector distance, as that is a more conventional metric.
 	Similarity *Similarity
 
-	// groupBy can only be set by [NearVectorFunc.GroupBy], as it changes the shape of the response.
+	// groupBy can only be set by [NearTextFunc.GroupBy], as it changes the shape of the response.
 	groupBy *GroupBy
 }
 
-// Distance sets a similarity cutoff in terms of maximum vector distance.
-func Distance(d float64) *Similarity { return &Similarity{distance: &d} }
+type Move api.Move
 
-// Certainty sets a similarity cutoff in terms of certainty.
-func Certainty(c float64) *Similarity { return &Similarity{certainty: &c} }
+// NearTextFunc runs plain near text search.
+type NearTextFunc func(context.Context, NearText) (*Result, error)
 
-// NearVectorFunc runs plain near vector search.
-type NearVectorFunc func(context.Context, NearVector) (*Result, error)
-
-// nearVectorFunc makes internal.Transport available to nearVector via a closure.
-func nearVectorFunc(t internal.Transport, rd api.RequestDefaults) NearVectorFunc {
-	return func(ctx context.Context, nv NearVector) (*Result, error) {
-		return nearVector(ctx, t, rd, nv)
+// nearTextFunc makes internal.Transport available to nearText via a closure.
+func nearTextFunc(t internal.Transport, rd api.RequestDefaults) NearTextFunc {
+	return func(ctx context.Context, nv NearText) (*Result, error) {
+		return nearText(ctx, t, rd, nv)
 	}
 }
 
-func nearVector(ctx context.Context, t internal.Transport, rd api.RequestDefaults, nv NearVector) (*Result, error) {
+func nearText(ctx context.Context, t internal.Transport, rd api.RequestDefaults, nt NearText) (*Result, error) {
 	req := &api.SearchRequest{
 		RequestDefaults:  rd,
-		Limit:            nv.Limit,
-		AutoLimit:        nv.AutoLimit,
-		Offset:           nv.Offset,
-		After:            nv.After,
-		ReturnVectors:    nv.ReturnVectors,
-		ReturnMetadata:   api.ReturnMetadata(nv.ReturnMetadata),
-		ReturnProperties: marshalReturnProperties(nv.ReturnProperties, nv.ReturnNestedProperties),
-		ReturnReferences: marshalReturnReferences(nv.ReturnReferences),
-		NearVector:       nv.Search(),
+		Limit:            nt.Limit,
+		AutoLimit:        nt.AutoLimit,
+		Offset:           nt.Offset,
+		After:            nt.After,
+		ReturnVectors:    nt.ReturnVectors,
+		ReturnMetadata:   api.ReturnMetadata(nt.ReturnMetadata),
+		ReturnProperties: marshalReturnProperties(nt.ReturnProperties, nt.ReturnNestedProperties),
+		ReturnReferences: marshalReturnReferences(nt.ReturnReferences),
 	}
 
-	if nv.groupBy != nil {
+	if nt.Target != nil {
+		req.NearText = &api.NearText{
+			Concepts:  nt.Concepts,
+			Target:    marshalSearchTarget(nt.Target),
+			Distance:  nt.Similarity.Distance(),
+			Certainty: nt.Similarity.Certainty(),
+			MoveTo:    (*api.Move)(nt.MoveTo),
+			MoveAway:  (*api.Move)(nt.MoveAway),
+		}
+	}
+
+	if nt.groupBy != nil {
 		req.GroupBy = &api.GroupBy{
-			Property:       nv.groupBy.Property,
-			Limit:          nv.groupBy.ObjectLimit,
-			NumberOfGroups: nv.groupBy.NumberOfGroups,
+			Property:       nt.groupBy.Property,
+			Limit:          nt.groupBy.ObjectLimit,
+			NumberOfGroups: nt.groupBy.NumberOfGroups,
 		}
 	}
 
@@ -82,10 +96,10 @@ func nearVector(ctx context.Context, t internal.Transport, rd api.RequestDefault
 		return nil, fmt.Errorf("near vector: %w", err)
 	}
 
-	// nearVector was called from the NearVectorFunc.GroupBy() method.
+	// nearText was called from the NearTextFunc.GroupBy() method.
 	// This means we should put GroupByResult in the context, as the first
 	// return value will be discarded.
-	if nv.groupBy != nil {
+	if nt.groupBy != nil {
 		groups := make(map[string]Group[map[string]any], len(resp.GroupByResults))
 		objects := make([]GroupObject[map[string]any], 0)
 		for _, group := range resp.GroupByResults {
@@ -124,41 +138,11 @@ func nearVector(ctx context.Context, t internal.Transport, rd api.RequestDefault
 }
 
 // GroupBy runs near vector search with a GroupBy clause.
-func (nvf NearVectorFunc) GroupBy(ctx context.Context, nv NearVector, groupBy GroupBy) (*GroupByResult, error) {
+func (nvf NearTextFunc) GroupBy(ctx context.Context, nv NearText, groupBy GroupBy) (*GroupByResult, error) {
 	nv.groupBy = &groupBy
 	ctx = contextWithGroupByResult(ctx) // safe to reassign since we hold the copy of the original context.
 	if _, err := nvf(ctx, nv); err != nil {
 		return nil, err
 	}
 	return getGroupByResult(ctx), nil
-}
-
-// Similarity is a cutoff point for query results.
-type Similarity struct{ distance, certainty *float64 }
-
-func (s *Similarity) Distance() *float64 {
-	if s == nil {
-		return nil
-	}
-	return s.distance
-}
-
-func (s *Similarity) Certainty() *float64 {
-	if s == nil {
-		return nil
-	}
-	return s.certainty
-}
-
-func (nv NearVector) Search() *api.NearVector {
-	dev.AssertNotNil(nv, "nv")
-
-	if nv.Target == nil {
-		return nil
-	}
-	return &api.NearVector{
-		Target:    marshalSearchTarget(nv.Target),
-		Distance:  nv.Similarity.Distance(),
-		Certainty: nv.Similarity.Certainty(),
-	}
 }

--- a/query/near_text.go
+++ b/query/near_text.go
@@ -31,7 +31,7 @@ type NearText struct {
 	// Bias the results towards or away from concepts and/or vectors.
 	MoveTo, MoveAway *Move
 
-	MMR *MMR
+	Selection Selection
 
 	// Target vector or a combination of multiple vector targets.
 	// By default, the resulting vectors are compared against the "default"
@@ -54,6 +54,15 @@ type (
 	Move api.Move
 	MMR  api.SelectionMMR
 )
+
+// SelectionMMR creates [Selection] using [MMR] algorithm.
+func SelectionMMR(mmr MMR) Selection { return Selection{mmr: &mmr} }
+
+type Selection struct {
+	mmr *MMR
+}
+
+func (s *Selection) MMR() *MMR { return s.mmr }
 
 // NearTextFunc runs plain near text search.
 type NearTextFunc func(context.Context, NearText) (*Result, error)
@@ -90,9 +99,8 @@ func nearText(ctx context.Context, t internal.Transport, rd api.RequestDefaults,
 		req.NearText.Target = marshalSearchTarget(nt.Target)
 	}
 
-	switch {
-	case nt.MMR != nil:
-		req.NearText.Selection = (*api.SelectionMMR)(nt.MMR)
+	req.NearText.Selection = api.Selection{
+		MMR: (*api.SelectionMMR)(nt.Selection.MMR()),
 	}
 
 	if nt.groupBy != nil {

--- a/query/near_text_test.go
+++ b/query/near_text_test.go
@@ -41,10 +41,10 @@ func TestNearText(t *testing.T) {
 					Force:    .46,
 					Concepts: []string{"train"},
 				},
-				MMR: &query.MMR{
+				Selection: query.SelectionMMR(query.MMR{
 					Limit:   1,
 					Balance: .2,
-				},
+				}),
 			},
 			stubs: []testkit.Stub[api.SearchRequest, api.SearchResponse]{
 				{
@@ -65,9 +65,11 @@ func TestNearText(t *testing.T) {
 								Force:    .46,
 								Concepts: []string{"train"},
 							},
-							Selection: &api.SelectionMMR{
-								Limit:   1,
-								Balance: .2,
+							Selection: api.Selection{
+								MMR: &api.SelectionMMR{
+									Limit:   1,
+									Balance: .2,
+								},
 							},
 						},
 					},

--- a/query/near_text_test.go
+++ b/query/near_text_test.go
@@ -1,0 +1,120 @@
+package query_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+	"github.com/weaviate/weaviate-go-client/v6/query"
+	"github.com/weaviate/weaviate-go-client/v6/types"
+)
+
+func TestNearText(t *testing.T) {
+	rd := api.RequestDefaults{
+		CollectionName:   "Songs",
+		Tenant:           "john_doe",
+		ConsistencyLevel: api.ConsistencyLevelQuorum,
+	}
+
+	for _, tt := range testkit.WithOnly(t, []struct {
+		testkit.Only
+
+		name  string
+		nt    query.NearText
+		stubs []testkit.Stub[api.SearchRequest, api.SearchResponse]
+		want  *query.Result // Expected return value.
+		err   testkit.Error
+	}{
+		{
+			name: "request ok",
+			nt: query.NearText{
+				Concepts: []string{"birds", "chestnuts"},
+				Target:   query.VectorName("title_vec"),
+				MoveTo: &query.Move{
+					Force:   .92,
+					Objects: []uuid.UUID{uuid.Nil},
+				},
+				MoveAway: &query.Move{
+					Force:    .46,
+					Concepts: []string{"train"},
+				},
+			},
+			stubs: []testkit.Stub[api.SearchRequest, api.SearchResponse]{
+				{
+					Request: &api.SearchRequest{
+						RequestDefaults: rd,
+						NearText: &api.NearText{
+							Concepts: []string{"birds", "chestnuts"},
+							Target: api.SearchTarget{
+								Vectors: []api.TargetVector{{
+									Vector: api.Vector{Name: "title_vec"},
+								}},
+							},
+							MoveTo: &api.Move{
+								Force:   .92,
+								Objects: []uuid.UUID{uuid.Nil},
+							},
+							MoveAway: &api.Move{
+								Force:    .46,
+								Concepts: []string{"train"},
+							},
+						},
+					},
+					Response: api.SearchResponse{
+						Took: 92 * time.Second,
+						Results: []api.Object{
+							{
+								Collection: "Songs",
+								Metadata: api.ObjectMetadata{
+									UUID: testkit.UUID,
+								},
+								Properties: map[string]any{
+									"title":        "I Like Birds",
+									"duration_sec": 151,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &query.Result{
+				Took: 92 * time.Second,
+				Objects: []query.Object[map[string]any]{
+					{
+						Object: types.Object[map[string]any]{
+							Collection: "Songs",
+							UUID:       testkit.UUID,
+							Properties: map[string]any{
+								"title":        "I Like Birds",
+								"duration_sec": 151,
+							},
+							Vectors:    make(types.Vectors, 0),
+							References: make(map[string][]types.Object[map[string]any], 0),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "request error",
+			stubs: []testkit.Stub[api.SearchRequest, api.SearchResponse]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	}) {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+
+			c := query.NewClient(transport, rd)
+			require.NotNil(t, c, "client")
+
+			got, err := c.NearText(t.Context(), tt.nt)
+			tt.err.Require(t, err, "near vector query")
+			require.Equal(t, tt.want, got, "query result")
+		})
+	}
+}

--- a/query/near_text_test.go
+++ b/query/near_text_test.go
@@ -41,6 +41,10 @@ func TestNearText(t *testing.T) {
 					Force:    .46,
 					Concepts: []string{"train"},
 				},
+				MMR: &query.MMR{
+					Limit:   1,
+					Balance: .2,
+				},
 			},
 			stubs: []testkit.Stub[api.SearchRequest, api.SearchResponse]{
 				{
@@ -60,6 +64,10 @@ func TestNearText(t *testing.T) {
 							MoveAway: &api.Move{
 								Force:    .46,
 								Concepts: []string{"train"},
+							},
+							Selection: &api.SelectionMMR{
+								Limit:   1,
+								Balance: .2,
 							},
 						},
 					},

--- a/query/near_vector_test.go
+++ b/query/near_vector_test.go
@@ -214,6 +214,7 @@ func TestNearVector(t *testing.T) {
 				},
 			},
 			want: &query.Result{
+				Took: 92 * time.Second,
 				Objects: []query.Object[map[string]any]{
 					{
 						Object: types.Object[map[string]any]{
@@ -381,6 +382,7 @@ func TestNearVector(t *testing.T) {
 					},
 				},
 				want: &query.GroupByResult{
+					Took: 92 * time.Second,
 					Objects: []query.GroupObject[map[string]any]{
 						{
 							BelongsToGroup: "Countdown To Extinction",

--- a/query/target.go
+++ b/query/target.go
@@ -46,6 +46,9 @@ func (name VectorName) Vectors() []api.TargetVector {
 // - Min
 // - ManualWeights
 // - RelativeScore
+//
+// Use [types.Vector] to pass in a vector target.
+// Use [VectorName] to specify a target vector index.
 type MultiVectorTarget struct {
 	combinationMethod api.CombinationMethod
 	targets           []api.TargetVector


### PR DESCRIPTION
This PR is the first step on the way to Hybrid search, as NearText is one of the possible parameters. For now NearText structure and implementation pretty much mirror that of the NearVector. There's quite some duplication which I'm planning to reduce in one of the follow-up PRs, keeping this one focused on the functionality itself.

One area to give a closer look to is the `Selection` parameter, which IMO does not have an immediately obvious translation in Go. For one, it's a union. For another, the "MMR" selection type has two _optional primitive_ parameters. After some playing around I settled for what I think is the simplest syntax:

- ~To avoid `any` in the public API NearText has a `{ MMR *MMR }` field that the user can fill out if they wish to use this kind of selection. If some other kind of selection get introduced in the next release, we can add `{ NNS *NNS }` and document that only one selection kind can be supplied.~ This now follows the same "union" pattern as `VectorSimilarity` and `KeywordSimilarity` -- i.e. 1 exported struct with unexported fields + exported constructor for every variant of the union.

- Both `Limit` and `Balance` seem like parameters for which `0` is not a valid value. If so, we do not need to introduce any pointer fields.
