### PR TITLE
refactor(v6): return nil maps instead of empty maps

### DIFF
--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -945,7 +945,7 @@ func testMessageUnmarshaler[Out transport.ReplyMessage](t *testing.T, tests []Me
 
 			err := tt.dest.UnmarshalMessage(tt.reply)
 			tt.err.Require(t, err, "unmarshal")
-			require.EqualExportedValues(t, tt.want, tt.dest)
+			require.EqualExportedValues(t, tt.want, tt.dest, "bad response")
 		})
 	}
 }
@@ -1009,8 +1009,6 @@ func TestSearchResponse_UnmarshalMessage(t *testing.T) {
 								},
 							},
 						},
-						Properties: make(map[string]any),
-						References: make(map[string][]api.Object),
 					},
 				},
 				GroupByResults: make([]api.Group, 0),
@@ -1039,8 +1037,6 @@ func TestSearchResponse_UnmarshalMessage(t *testing.T) {
 								},
 							},
 						},
-						Properties: make(map[string]any),
-						References: make(map[string][]api.Object),
 					},
 				},
 				GroupByResults: make([]api.Group, 0),
@@ -1122,7 +1118,6 @@ func TestSearchResponse_UnmarshalMessage(t *testing.T) {
 							},
 							"kpop_version": nil,
 						},
-						References: make(map[string][]api.Object),
 					},
 				},
 				GroupByResults: make([]api.Group, 0),
@@ -1186,7 +1181,6 @@ func TestSearchResponse_UnmarshalMessage(t *testing.T) {
 			want: &api.SearchResponse{
 				Results: []api.Object{
 					{
-						Properties: make(map[string]any),
 						References: map[string][]api.Object{
 							"hasAwards": {
 								{
@@ -1194,22 +1188,17 @@ func TestSearchResponse_UnmarshalMessage(t *testing.T) {
 									Properties: map[string]any{
 										"category": "metal",
 									},
-									References: make(map[string][]api.Object),
 								},
 								{
 									Collection: "TonyAward",
 									Metadata: api.ObjectMetadata{
-										UUID:    testkit.UUID,
-										Vectors: make(api.Vectors),
+										UUID: testkit.UUID,
 									},
-									Properties: make(map[string]any),
-									References: make(map[string][]api.Object),
 								},
 							},
 							"writtenBy": {
 								{
 									Collection: "Artists",
-									Properties: make(map[string]any),
 									References: map[string][]api.Object{
 										"belongsToBand": {
 											{
@@ -1217,7 +1206,6 @@ func TestSearchResponse_UnmarshalMessage(t *testing.T) {
 												Properties: map[string]any{
 													"name": "Megadeth",
 												},
-												References: make(map[string][]api.Object),
 											},
 										},
 									},
@@ -1351,8 +1339,6 @@ func TestSearchResponse_UnmarshalMessage(t *testing.T) {
 											},
 										},
 									},
-									Properties: make(map[string]any),
-									References: make(map[string][]api.Object),
 								},
 							},
 							{
@@ -1372,7 +1358,6 @@ func TestSearchResponse_UnmarshalMessage(t *testing.T) {
 										},
 										"kpop_version": nil,
 									},
-									References: make(map[string][]api.Object),
 								},
 							},
 						},
@@ -1386,7 +1371,6 @@ func TestSearchResponse_UnmarshalMessage(t *testing.T) {
 							{
 								BelongsToGroup: "references",
 								Object: api.Object{
-									Properties: make(map[string]any),
 									References: map[string][]api.Object{
 										"hasAwards": {
 											{
@@ -1394,16 +1378,12 @@ func TestSearchResponse_UnmarshalMessage(t *testing.T) {
 												Properties: map[string]any{
 													"category": "metal",
 												},
-												References: make(map[string][]api.Object),
 											},
 											{
 												Collection: "TonyAward",
 												Metadata: api.ObjectMetadata{
-													UUID:    testkit.UUID,
-													Vectors: make(api.Vectors),
+													UUID: testkit.UUID,
 												},
-												Properties: make(map[string]any),
-												References: make(map[string][]api.Object),
 											},
 										},
 									},

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/weaviate/weaviate-go-client/v6/internal"
 	proto "github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/proto/v1"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/transport"
 	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
@@ -500,9 +501,8 @@ func unmarshalObject(pr *proto.PropertiesResult, mr *proto.MetadataResult) (*Obj
 	if err != nil {
 		return nil, err
 	}
-	dev.AssertNotNil(properties, "properties")
 
-	references := make(map[string][]Object, len(pr.GetRefProps()))
+	references := internal.MakeMap[string, []Object](len(pr.GetRefProps()))
 	for _, ref := range pr.GetRefProps() {
 		if ref == nil {
 			continue
@@ -537,7 +537,6 @@ func unmarshalObject(pr *proto.PropertiesResult, mr *proto.MetadataResult) (*Obj
 		if err != nil {
 			return nil, err
 		}
-		dev.AssertNotNil(vectors, "vectors")
 
 		metadata = ObjectMetadata{
 			UUID:          id,
@@ -562,6 +561,9 @@ func unmarshalObject(pr *proto.PropertiesResult, mr *proto.MetadataResult) (*Obj
 // unmarshalProperties unmarshals map[string]proto.Value into map[string]any.
 // ps can be nil, in which case an empty map is returned.
 func unmarshalProperties(ps *proto.Properties) (map[string]any, error) {
+	if len(ps.GetFields()) == 0 {
+		return nil, nil
+	}
 	out := make(map[string]any, len(ps.GetFields()))
 	for name, f := range ps.GetFields() {
 		var v any
@@ -607,6 +609,9 @@ func unmarshalProperties(ps *proto.Properties) (map[string]any, error) {
 }
 
 func unmarshalVectors(mr *proto.MetadataResult) (Vectors, error) {
+	if len(mr.GetVectors()) == 0 && mr.GetVectorBytes() == nil {
+		return nil, nil
+	}
 	out := make(Vectors, len(mr.GetVectors()))
 	for _, vector := range mr.GetVectors() {
 		v := Vector{Name: vector.Name}

--- a/internal/map.go
+++ b/internal/map.go
@@ -1,0 +1,17 @@
+package internal
+
+// MakeMap returns nil if size is 0.
+//
+// This works well with custom types derived from map.
+// Namely, the output of MakeMap can be assigned to a
+// variable or field of that type without an explicit cast.
+//
+// More that anything, this simplifies the testing setup,
+// as we no longer need to pass a make(map[K]V) in every
+// test stub where we don't expect any results.
+func MakeMap[K comparable, V any](size int) map[K]V {
+	if size == 0 {
+		return nil
+	}
+	return make(map[K]V, size)
+}

--- a/internal/map_test.go
+++ b/internal/map_test.go
@@ -1,0 +1,18 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+)
+
+func TestMakeMap(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		assert.Nil(t, internal.MakeMap[string, any](0))
+	})
+
+	t.Run("not empty", func(t *testing.T) {
+		assert.NotNil(t, internal.MakeMap[string, any](92))
+	})
+}

--- a/query/client.go
+++ b/query/client.go
@@ -146,12 +146,12 @@ func marshalSearchTarget(target VectorTarget) api.SearchTarget {
 }
 
 func unmarshalObject(o *api.Object) Object[map[string]any] {
-	vectors := make(types.Vectors, len(o.Metadata.Vectors))
+	vectors := internal.MakeMap[string, types.Vector](len(o.Metadata.Vectors))
 	for k, v := range o.Metadata.Vectors {
 		vectors[k] = types.Vector(v)
 	}
 
-	references := make(map[string][]types.Object[map[string]any], len(o.References))
+	references := internal.MakeMap[string, []types.Object[map[string]any]](len(o.References))
 	for k, refs := range o.References {
 		objects := make([]types.Object[map[string]any], len(refs))
 		for i, ref := range refs {

--- a/query/near_text.go
+++ b/query/near_text.go
@@ -119,7 +119,7 @@ func nearText(ctx context.Context, t internal.Transport, rd api.RequestDefaults,
 	// This means we should put GroupByResult in the context, as the first
 	// return value will be discarded.
 	if nt.groupBy != nil {
-		groups := make(map[string]Group[map[string]any], len(resp.GroupByResults))
+		groups := internal.MakeMap[string, Group[map[string]any]](len(resp.GroupByResults))
 		objects := make([]GroupObject[map[string]any], 0)
 		for _, group := range resp.GroupByResults {
 

--- a/query/near_text.go
+++ b/query/near_text.go
@@ -93,14 +93,13 @@ func nearText(ctx context.Context, t internal.Transport, rd api.RequestDefaults,
 		Certainty: nt.Similarity.Certainty(),
 		MoveTo:    (*api.Move)(nt.MoveTo),
 		MoveAway:  (*api.Move)(nt.MoveAway),
+		Selection: api.Selection{
+			MMR: (*api.SelectionMMR)(nt.Selection.MMR()),
+		},
 	}
 
 	if nt.Target != nil {
 		req.NearText.Target = marshalSearchTarget(nt.Target)
-	}
-
-	req.NearText.Selection = api.Selection{
-		MMR: (*api.SelectionMMR)(nt.Selection.MMR()),
 	}
 
 	if nt.groupBy != nil {

--- a/query/near_text_test.go
+++ b/query/near_text_test.go
@@ -101,8 +101,6 @@ func TestNearText(t *testing.T) {
 								"title":        "I Like Birds",
 								"duration_sec": 151,
 							},
-							Vectors:    make(types.Vectors, 0),
-							References: make(map[string][]types.Object[map[string]any], 0),
 						},
 					},
 				},
@@ -124,7 +122,7 @@ func TestNearText(t *testing.T) {
 
 			got, err := c.NearText(t.Context(), tt.nt)
 			tt.err.Require(t, err, "near vector query")
-			require.Equal(t, tt.want, got, "query result")
+			require.EqualExportedValues(t, tt.want, got, "query result")
 		})
 	}
 }

--- a/query/near_vector.go
+++ b/query/near_vector.go
@@ -86,7 +86,7 @@ func nearVector(ctx context.Context, t internal.Transport, rd api.RequestDefault
 	// This means we should put GroupByResult in the context, as the first
 	// return value will be discarded.
 	if nv.groupBy != nil {
-		groups := make(map[string]Group[map[string]any], len(resp.GroupByResults))
+		groups := internal.MakeMap[string, Group[map[string]any]](len(resp.GroupByResults))
 		objects := make([]GroupObject[map[string]any], 0)
 		for _, group := range resp.GroupByResults {
 

--- a/query/near_vector_test.go
+++ b/query/near_vector_test.go
@@ -12,16 +12,6 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/types"
 )
 
-// As a general rule, client never returns nil maps, as they can
-// cause a nil pointer dereference if not handled correctly.
-// Tests that don't expect a field to be present in the response
-// should use of the variables below to make the intent explicit.
-var (
-	noReferences = make(map[string][]types.Object[map[string]any])
-	noProperties = make(map[string]any)
-	noVectors    = make(types.Vectors)
-)
-
 var (
 	singleVector = []float32{1, 2, 3}
 	multiVector  = [][]float32{{1, 2, 3}, {4, 5, 6}}
@@ -190,12 +180,9 @@ func TestNearVector(t *testing.T) {
 											Properties: map[string]any{
 												"categories": []string{"thrash_metal", "heavy_metal"},
 											},
-											References: make(map[string][]api.Object),
 										},
 										{
 											Collection: "TonyAward",
-											Properties: noProperties,
-											References: make(map[string][]api.Object),
 											Metadata: api.ObjectMetadata{
 												UUID: testkit.UUID,
 												Vectors: api.Vectors{
@@ -240,8 +227,6 @@ func TestNearVector(t *testing.T) {
 										Properties: map[string]any{
 											"categories": []string{"thrash_metal", "heavy_metal"},
 										},
-										Vectors:    noVectors,
-										References: noReferences,
 									},
 									{
 										Collection: "TonyAward",
@@ -252,8 +237,6 @@ func TestNearVector(t *testing.T) {
 												Single: []float32{4, 5, 6},
 											},
 										},
-										Properties: noProperties,
-										References: noReferences,
 									},
 								},
 							},
@@ -290,7 +273,7 @@ func TestNearVector(t *testing.T) {
 
 			got, err := c.NearVector(t.Context(), tt.nv)
 			tt.err.Require(t, err, "near vector query")
-			require.Equal(t, tt.want, got, "query result")
+			require.EqualExportedValues(t, tt.want, got, "query result")
 		})
 	}
 
@@ -391,8 +374,6 @@ func TestNearVector(t *testing.T) {
 									Properties: map[string]any{
 										"title": "High Speed Dirt",
 									},
-									References: noReferences,
-									Vectors:    noVectors,
 								},
 							},
 						},
@@ -403,8 +384,6 @@ func TestNearVector(t *testing.T) {
 									Properties: map[string]any{
 										"title": "Architechture Of Aggression",
 									},
-									References: noReferences,
-									Vectors:    noVectors,
 								},
 							},
 						},
@@ -415,8 +394,6 @@ func TestNearVector(t *testing.T) {
 									Properties: map[string]any{
 										"title": "New World Order",
 									},
-									References: noReferences,
-									Vectors:    noVectors,
 								},
 							},
 						},
@@ -435,8 +412,6 @@ func TestNearVector(t *testing.T) {
 											Properties: map[string]any{
 												"title": "High Speed Dirt",
 											},
-											References: noReferences,
-											Vectors:    noVectors,
 										},
 									},
 								},
@@ -447,8 +422,6 @@ func TestNearVector(t *testing.T) {
 											Properties: map[string]any{
 												"title": "Architechture Of Aggression",
 											},
-											References: noReferences,
-											Vectors:    noVectors,
 										},
 									},
 								},
@@ -467,8 +440,6 @@ func TestNearVector(t *testing.T) {
 											Properties: map[string]any{
 												"title": "New World Order",
 											},
-											References: noReferences,
-											Vectors:    noVectors,
 										},
 									},
 								},
@@ -493,7 +464,7 @@ func TestNearVector(t *testing.T) {
 
 				got, err := c.NearVector.GroupBy(t.Context(), tt.nv, tt.groupBy)
 				tt.err.Require(t, err, "near vector query")
-				require.Equal(t, tt.want, got, "query result")
+				require.EqualExportedValues(t, tt.want, got, "query result")
 			})
 		}
 	})


### PR DESCRIPTION
Since all return values are readonly, returning a nil map is safe, as both `len()` and `range` work with nil maps.

At the same time it removes the need to construct empty maps in test stubs where no results are expected. Doing that is rather tedious and very much unnecessary.