### PR TITLE
refactor(v6): Unify query marshaling and execution

### DIFF
--- a/query/client.go
+++ b/query/client.go
@@ -169,7 +169,7 @@ func query(ctx context.Context, t internal.Transport, r request, f func(*api.Sea
 				Objects:     objects[from:to],
 			}
 		}
-		setGroupByResult(ctx, &GroupByResult{
+		internal.SetContextValue(ctx, groupByResultKey, &GroupByResult{
 			Took:    resp.Took,
 			Groups:  groups,
 			Objects: objects,
@@ -267,18 +267,10 @@ func unmarshalObject(o *api.Object) Object[map[string]any] {
 // groupByResultKey is used to pass grouped query results to the GroupBy caller.
 var groupByResultKey = internal.ContextKey{}
 
-// contextWithGorupByResult creates a placeholder for *GroupByResult in the ctx.Values store.
-func contextWithGroupByResult(ctx context.Context) context.Context {
-	return internal.ContextWithPlaceholder[GroupByResult](ctx, groupByResultKey)
-}
-
-// getGroupByResult extracts *GroupByResult from the context.
-func getGroupByResult(ctx context.Context) *GroupByResult {
-	return internal.ValueFromContext[GroupByResult](ctx, groupByResultKey)
-}
-
-// setGroupByResult replaces *GroupByResult placeholder
-// in the context with the value at r.
-func setGroupByResult(ctx context.Context, r *GroupByResult) {
-	internal.SetContextValue(ctx, groupByResultKey, r)
+func queryGroupBy[In any](ctx context.Context, f func(context.Context, In) (*Result, error), in In) (*GroupByResult, error) {
+	ctx = internal.ContextWithPlaceholder[GroupByResult](ctx, groupByResultKey)
+	if _, err := f(ctx, in); err != nil {
+		return nil, err
+	}
+	return internal.ValueFromContext[GroupByResult](ctx, groupByResultKey), nil
 }

--- a/query/client.go
+++ b/query/client.go
@@ -2,8 +2,11 @@ package query
 
 import (
 	"context"
+	"fmt"
+	"slices"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
@@ -97,6 +100,88 @@ type Group[T any] struct {
 type GroupObject[T any] struct {
 	Object[T]
 	BelongsToGroup string
+}
+
+type request struct {
+	api.RequestDefaults
+	Limit                  int32
+	Offset                 int32
+	AutoLimit              int32
+	After                  uuid.UUID
+	ReturnMetadata         ReturnMetadata
+	ReturnVectors          []string
+	ReturnReferences       []Reference
+	ReturnNestedProperties []NestedProperty
+	ReturnProperties       []string
+	GroupBy                *GroupBy
+}
+
+func query(ctx context.Context, t internal.Transport, r request, f func(*api.SearchRequest)) (*Result, error) {
+	req := &api.SearchRequest{
+		RequestDefaults:  r.RequestDefaults,
+		Limit:            r.Limit,
+		AutoLimit:        r.AutoLimit,
+		Offset:           r.Offset,
+		After:            r.After,
+		ReturnVectors:    r.ReturnVectors,
+		ReturnMetadata:   api.ReturnMetadata(r.ReturnMetadata),
+		ReturnProperties: marshalReturnProperties(r.ReturnProperties, r.ReturnNestedProperties),
+		ReturnReferences: marshalReturnReferences(r.ReturnReferences),
+	}
+
+	f(req)
+
+	if r.GroupBy != nil {
+		req.GroupBy = &api.GroupBy{
+			Property:       r.GroupBy.Property,
+			Limit:          r.GroupBy.ObjectLimit,
+			NumberOfGroups: r.GroupBy.NumberOfGroups,
+		}
+	}
+
+	var resp api.SearchResponse
+	if err := t.Do(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("near vector: %w", err)
+	}
+
+	// query was called from the GroupBy() method. This means we should put
+	// GroupByResult in the context, as the first return value will be discarded.
+	if r.GroupBy != nil {
+		groups := internal.MakeMap[string, Group[map[string]any]](len(resp.GroupByResults))
+		objects := make([]GroupObject[map[string]any], 0)
+		for _, group := range resp.GroupByResults {
+
+			objects = slices.Grow(objects, len(group.Objects))
+			for _, obj := range group.Objects {
+				objects = append(objects, GroupObject[map[string]any]{
+					BelongsToGroup: group.Name,
+					Object:         unmarshalObject(&obj.Object),
+				})
+			}
+
+			// Create a view into the objects slice rather than allocating a separate one.
+			from, to := len(objects)-len(group.Objects), len(objects)
+			groups[group.Name] = Group[map[string]any]{
+				Name:        group.Name,
+				MinDistance: group.MinDistance,
+				MaxDistance: group.MaxDistance,
+				Size:        group.Size,
+				Objects:     objects[from:to],
+			}
+		}
+		setGroupByResult(ctx, &GroupByResult{
+			Took:    resp.Took,
+			Groups:  groups,
+			Objects: objects,
+		})
+		return nil, nil
+	}
+
+	objects := make([]Object[map[string]any], len(resp.Results))
+	for i, obj := range resp.Results {
+		objects[i] = unmarshalObject(&obj)
+	}
+	return &Result{Took: resp.Took, Objects: objects}, nil
 }
 
 func marshalReturnProperties(properties []string, nested []NestedProperty) []api.ReturnProperty {

--- a/query/near_text.go
+++ b/query/near_text.go
@@ -98,12 +98,8 @@ func nearTextFunc(t internal.Transport, rd api.RequestDefaults) NearTextFunc {
 	}
 }
 
-// GroupBy runs near vector search with a GroupBy clause.
-func (ntf NearTextFunc) GroupBy(ctx context.Context, nv NearText, groupBy GroupBy) (*GroupByResult, error) {
-	nv.groupBy = &groupBy
-	ctx = contextWithGroupByResult(ctx) // safe to reassign since we hold the copy of the original context.
-	if _, err := ntf(ctx, nv); err != nil {
-		return nil, err
-	}
-	return getGroupByResult(ctx), nil
+// GroupBy runs near text search with a GroupBy clause.
+func (ntf NearTextFunc) GroupBy(ctx context.Context, nt NearText, groupBy GroupBy) (*GroupByResult, error) {
+	nt.groupBy = &groupBy
+	return queryGroupBy(ctx, ntf, nt)
 }

--- a/query/near_text.go
+++ b/query/near_text.go
@@ -2,8 +2,6 @@ package query
 
 import (
 	"context"
-	"fmt"
-	"slices"
 
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
@@ -69,98 +67,42 @@ type NearTextFunc func(context.Context, NearText) (*Result, error)
 
 // nearTextFunc makes internal.Transport available to nearText via a closure.
 func nearTextFunc(t internal.Transport, rd api.RequestDefaults) NearTextFunc {
-	return func(ctx context.Context, nv NearText) (*Result, error) {
-		return nearText(ctx, t, rd, nv)
-	}
-}
-
-func nearText(ctx context.Context, t internal.Transport, rd api.RequestDefaults, nt NearText) (*Result, error) {
-	req := &api.SearchRequest{
-		RequestDefaults:  rd,
-		Limit:            nt.Limit,
-		AutoLimit:        nt.AutoLimit,
-		Offset:           nt.Offset,
-		After:            nt.After,
-		ReturnVectors:    nt.ReturnVectors,
-		ReturnMetadata:   api.ReturnMetadata(nt.ReturnMetadata),
-		ReturnProperties: marshalReturnProperties(nt.ReturnProperties, nt.ReturnNestedProperties),
-		ReturnReferences: marshalReturnReferences(nt.ReturnReferences),
-	}
-
-	req.NearText = &api.NearText{
-		Concepts:  nt.Concepts,
-		Distance:  nt.Similarity.Distance(),
-		Certainty: nt.Similarity.Certainty(),
-		MoveTo:    (*api.Move)(nt.MoveTo),
-		MoveAway:  (*api.Move)(nt.MoveAway),
-		Selection: api.Selection{
-			MMR: (*api.SelectionMMR)(nt.Selection.MMR()),
-		},
-	}
-
-	if nt.Target != nil {
-		req.NearText.Target = marshalSearchTarget(nt.Target)
-	}
-
-	if nt.groupBy != nil {
-		req.GroupBy = &api.GroupBy{
-			Property:       nt.groupBy.Property,
-			Limit:          nt.groupBy.ObjectLimit,
-			NumberOfGroups: nt.groupBy.NumberOfGroups,
-		}
-	}
-
-	var resp api.SearchResponse
-	if err := t.Do(ctx, req, &resp); err != nil {
-		return nil, fmt.Errorf("near vector: %w", err)
-	}
-
-	// nearText was called from the NearTextFunc.GroupBy() method.
-	// This means we should put GroupByResult in the context, as the first
-	// return value will be discarded.
-	if nt.groupBy != nil {
-		groups := internal.MakeMap[string, Group[map[string]any]](len(resp.GroupByResults))
-		objects := make([]GroupObject[map[string]any], 0)
-		for _, group := range resp.GroupByResults {
-
-			objects = slices.Grow(objects, len(group.Objects))
-			for _, obj := range group.Objects {
-				objects = append(objects, GroupObject[map[string]any]{
-					BelongsToGroup: group.Name,
-					Object:         unmarshalObject(&obj.Object),
-				})
+	return func(ctx context.Context, nt NearText) (*Result, error) {
+		return query(ctx, t, request{
+			RequestDefaults:        rd,
+			Limit:                  nt.Limit,
+			AutoLimit:              nt.AutoLimit,
+			Offset:                 nt.Offset,
+			After:                  nt.After,
+			ReturnVectors:          nt.ReturnVectors,
+			ReturnMetadata:         nt.ReturnMetadata,
+			ReturnProperties:       nt.ReturnProperties,
+			ReturnNestedProperties: nt.ReturnNestedProperties,
+			ReturnReferences:       nt.ReturnReferences,
+			GroupBy:                nt.groupBy,
+		}, func(req *api.SearchRequest) {
+			req.NearText = &api.NearText{
+				Concepts:  nt.Concepts,
+				Distance:  nt.Similarity.Distance(),
+				Certainty: nt.Similarity.Certainty(),
+				MoveTo:    (*api.Move)(nt.MoveTo),
+				MoveAway:  (*api.Move)(nt.MoveAway),
+				Selection: api.Selection{
+					MMR: (*api.SelectionMMR)(nt.Selection.MMR()),
+				},
 			}
-
-			// Create a view into the objects slice rather than allocating a separate one.
-			from, to := len(objects)-len(group.Objects), len(objects)
-			groups[group.Name] = Group[map[string]any]{
-				Name:        group.Name,
-				MinDistance: group.MinDistance,
-				MaxDistance: group.MaxDistance,
-				Size:        group.Size,
-				Objects:     objects[from:to],
+			if nt.Target != nil {
+				req.NearText.Target = marshalSearchTarget(nt.Target)
 			}
-		}
-		setGroupByResult(ctx, &GroupByResult{
-			Took:    resp.Took,
-			Groups:  groups,
-			Objects: objects,
 		})
-		return nil, nil
 	}
-
-	objects := make([]Object[map[string]any], len(resp.Results))
-	for i, obj := range resp.Results {
-		objects[i] = unmarshalObject(&obj)
-	}
-	return &Result{Took: resp.Took, Objects: objects}, nil
 }
 
 // GroupBy runs near vector search with a GroupBy clause.
-func (nvf NearTextFunc) GroupBy(ctx context.Context, nv NearText, groupBy GroupBy) (*GroupByResult, error) {
+func (ntf NearTextFunc) GroupBy(ctx context.Context, nv NearText, groupBy GroupBy) (*GroupByResult, error) {
 	nv.groupBy = &groupBy
 	ctx = contextWithGroupByResult(ctx) // safe to reassign since we hold the copy of the original context.
-	if _, err := nvf(ctx, nv); err != nil {
+	if _, err := ntf(ctx, nv); err != nil {
 		return nil, err
 	}
 	return getGroupByResult(ctx), nil

--- a/query/near_vector.go
+++ b/query/near_vector.go
@@ -2,8 +2,6 @@ package query
 
 import (
 	"context"
-	"fmt"
-	"slices"
 
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
@@ -51,76 +49,28 @@ type NearVectorFunc func(context.Context, NearVector) (*Result, error)
 // nearVectorFunc makes internal.Transport available to nearVector via a closure.
 func nearVectorFunc(t internal.Transport, rd api.RequestDefaults) NearVectorFunc {
 	return func(ctx context.Context, nv NearVector) (*Result, error) {
-		return nearVector(ctx, t, rd, nv)
-	}
-}
-
-func nearVector(ctx context.Context, t internal.Transport, rd api.RequestDefaults, nv NearVector) (*Result, error) {
-	req := &api.SearchRequest{
-		RequestDefaults:  rd,
-		Limit:            nv.Limit,
-		AutoLimit:        nv.AutoLimit,
-		Offset:           nv.Offset,
-		After:            nv.After,
-		ReturnVectors:    nv.ReturnVectors,
-		ReturnMetadata:   api.ReturnMetadata(nv.ReturnMetadata),
-		ReturnProperties: marshalReturnProperties(nv.ReturnProperties, nv.ReturnNestedProperties),
-		ReturnReferences: marshalReturnReferences(nv.ReturnReferences),
-		NearVector:       nv.Search(),
-	}
-
-	if nv.groupBy != nil {
-		req.GroupBy = &api.GroupBy{
-			Property:       nv.groupBy.Property,
-			Limit:          nv.groupBy.ObjectLimit,
-			NumberOfGroups: nv.groupBy.NumberOfGroups,
-		}
-	}
-
-	var resp api.SearchResponse
-	if err := t.Do(ctx, req, &resp); err != nil {
-		return nil, fmt.Errorf("near vector: %w", err)
-	}
-
-	// nearVector was called from the NearVectorFunc.GroupBy() method.
-	// This means we should put GroupByResult in the context, as the first
-	// return value will be discarded.
-	if nv.groupBy != nil {
-		groups := internal.MakeMap[string, Group[map[string]any]](len(resp.GroupByResults))
-		objects := make([]GroupObject[map[string]any], 0)
-		for _, group := range resp.GroupByResults {
-
-			objects = slices.Grow(objects, len(group.Objects))
-			for _, obj := range group.Objects {
-				objects = append(objects, GroupObject[map[string]any]{
-					BelongsToGroup: group.Name,
-					Object:         unmarshalObject(&obj.Object),
-				})
+		return query(ctx, t, request{
+			RequestDefaults:        rd,
+			Limit:                  nv.Limit,
+			AutoLimit:              nv.AutoLimit,
+			Offset:                 nv.Offset,
+			After:                  nv.After,
+			ReturnVectors:          nv.ReturnVectors,
+			ReturnMetadata:         nv.ReturnMetadata,
+			ReturnProperties:       nv.ReturnProperties,
+			ReturnNestedProperties: nv.ReturnNestedProperties,
+			ReturnReferences:       nv.ReturnReferences,
+			GroupBy:                nv.groupBy,
+		}, func(req *api.SearchRequest) {
+			if nv.Target != nil {
+				req.NearVector = &api.NearVector{
+					Target:    marshalSearchTarget(nv.Target),
+					Distance:  nv.Similarity.Distance(),
+					Certainty: nv.Similarity.Certainty(),
+				}
 			}
-
-			// Create a view into the objects slice rather than allocating a separate one.
-			from, to := len(objects)-len(group.Objects), len(objects)
-			groups[group.Name] = Group[map[string]any]{
-				Name:        group.Name,
-				MinDistance: group.MinDistance,
-				MaxDistance: group.MaxDistance,
-				Size:        group.Size,
-				Objects:     objects[from:to],
-			}
-		}
-		setGroupByResult(ctx, &GroupByResult{
-			Took:    resp.Took,
-			Groups:  groups,
-			Objects: objects,
 		})
-		return nil, nil
 	}
-
-	objects := make([]Object[map[string]any], len(resp.Results))
-	for i, obj := range resp.Results {
-		objects[i] = unmarshalObject(&obj)
-	}
-	return &Result{Took: resp.Took, Objects: objects}, nil
 }
 
 // GroupBy runs near vector search with a GroupBy clause.

--- a/query/near_vector.go
+++ b/query/near_vector.go
@@ -76,11 +76,7 @@ func nearVectorFunc(t internal.Transport, rd api.RequestDefaults) NearVectorFunc
 // GroupBy runs near vector search with a GroupBy clause.
 func (nvf NearVectorFunc) GroupBy(ctx context.Context, nv NearVector, groupBy GroupBy) (*GroupByResult, error) {
 	nv.groupBy = &groupBy
-	ctx = contextWithGroupByResult(ctx) // safe to reassign since we hold the copy of the original context.
-	if _, err := nvf(ctx, nv); err != nil {
-		return nil, err
-	}
-	return getGroupByResult(ctx), nil
+	return queryGroupBy(ctx, nvf, nv)
 }
 
 // Similarity is a cutoff point for query results.


### PR DESCRIPTION
Every query type, i.e. `NearVectorFunc` and `NearTextFunc`, needs to create a `api.SearchRequest` and convert `api.SearchResponse` into `Result`. Each of the query types also has a `.GroupBy` method, which has the same logical structure.

This PR extracts the common parts into `query()` and `queryGroupBy()` functions, which encapsulate most of the logic for running a query. Individual implementations then only serve to present the user with different input structs, e.g. `NearVector(ctx, query.NearVector{...})`. 