### PR TITLE
v6: ORM

### DIFF
--- a/api/rest/schema.check.json
+++ b/api/rest/schema.check.json
@@ -860,6 +860,17 @@
           "items": {
             "$ref": "#/definitions/TokenizerUserDictConfig"
           }
+        },
+        "stopwordPresets": {
+          "description": "User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings.",
+          "type": "object",
+          "x-omitempty": true,
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       },
       "type": "object"
@@ -992,9 +1003,13 @@
           "description": "Optional text analyzer configuration (e.g. ASCII folding).",
           "$ref": "#/definitions/TextAnalyzerConfig"
         },
-        "stopwordConfig": {
-          "description": "Optional stopword configuration. When provided, stopwords are removed from query tokens but preserved in indexed tokens.",
-          "$ref": "#/definitions/StopwordConfig"
+        "stopwordPresets": {
+          "description": "Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals).",
+          "type": "object",
+          "x-omitempty": true,
+          "additionalProperties": {
+            "$ref": "#/definitions/StopwordConfig"
+          }
         }
       }
     },
@@ -1657,6 +1672,11 @@
           "items": {
             "type": "string"
           }
+        },
+        "stopwordPreset": {
+          "description": "Stopword preset name. Overrides the collection-level invertedIndexConfig.stopwords for this property. Only applies to properties using 'word' tokenization. Can be a built-in preset ('en', 'none') or a user-defined preset from invertedIndexConfig.stopwordPresets.",
+          "type": "string",
+          "x-omitempty": true
         }
       },
       "x-omitempty": true,
@@ -3473,7 +3493,7 @@
     },
     "description": "# Introduction<br/> Weaviate is an open source, AI-native vector database that helps developers create intuitive and reliable AI-powered applications. <br/> ### Base Path <br/>The base path for the Weaviate server is structured as `[YOUR-WEAVIATE-HOST]:[PORT]/v1`. As an example, if you wish to access the `schema` endpoint on a local instance, you would navigate to `http://localhost:8080/v1/schema`. Ensure you replace `[YOUR-WEAVIATE-HOST]` and `[PORT]` with your actual server host and port number respectively. <br/> ### Questions? <br/>If you have any comments or questions, please feel free to reach out to us at the community forum [https://forum.weaviate.io/](https://forum.weaviate.io/). <br/>### Issues? <br/>If you find a bug or want to file a feature request, please open an issue on our GitHub repository for [Weaviate](https://github.com/weaviate/weaviate). <br/>### Need more documentation? <br/>For a quickstart, code examples, concepts and more, please visit our [documentation page](https://docs.weaviate.io/weaviate).",
     "title": "Weaviate REST API",
-    "version": "1.37.0-rc.0"
+    "version": "1.37.0-rc.1"
   },
   "parameters": {
     "CommonAfterParameterQuery": {

--- a/api/rest/schema.v3.yaml
+++ b/api/rest/schema.v3.yaml
@@ -1102,6 +1102,14 @@ components:
                 indexTimestamps:
                     description: 'Index each object by its internal timestamps (default: `false`).'
                     type: boolean
+                stopwordPresets:
+                    additionalProperties:
+                        items:
+                            type: string
+                        type: array
+                    description: User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings.
+                    type: object
+                    x-omitempty: true
                 stopwords:
                     $ref: '#/components/schemas/StopwordConfig'
                 tokenizerUserDict:
@@ -2368,6 +2376,10 @@ components:
                         type: string
                     type: array
                     x-omitempty: true
+                stopwordPreset:
+                    description: Stopword preset name. Overrides the collection-level invertedIndexConfig.stopwords for this property. Only applies to properties using 'word' tokenization. Can be a built-in preset ('en', 'none') or a user-defined preset from invertedIndexConfig.stopwordPresets.
+                    type: string
+                    x-omitempty: true
             type: object
             x-omitempty: true
         TokenizeRequest:
@@ -2375,8 +2387,12 @@ components:
             properties:
                 analyzerConfig:
                     $ref: '#/components/schemas/TextAnalyzerConfig'
-                stopwordConfig:
-                    $ref: '#/components/schemas/StopwordConfig'
+                stopwordPresets:
+                    additionalProperties:
+                        $ref: '#/components/schemas/StopwordConfig'
+                    description: Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals).
+                    type: object
+                    x-omitempty: true
                 text:
                     description: The text to tokenize.
                     type: string
@@ -2659,7 +2675,7 @@ info:
         url: https://github.com/weaviate
     description: '# Introduction<br/> Weaviate is an open source, AI-native vector database that helps developers create intuitive and reliable AI-powered applications. <br/> ### Base Path <br/>The base path for the Weaviate server is structured as `[YOUR-WEAVIATE-HOST]:[PORT]/v1`. As an example, if you wish to access the `schema` endpoint on a local instance, you would navigate to `http://localhost:8080/v1/schema`. Ensure you replace `[YOUR-WEAVIATE-HOST]` and `[PORT]` with your actual server host and port number respectively. <br/> ### Questions? <br/>If you have any comments or questions, please feel free to reach out to us at the community forum [https://forum.weaviate.io/](https://forum.weaviate.io/). <br/>### Issues? <br/>If you find a bug or want to file a feature request, please open an issue on our GitHub repository for [Weaviate](https://github.com/weaviate/weaviate). <br/>### Need more documentation? <br/>For a quickstart, code examples, concepts and more, please visit our [documentation page](https://docs.weaviate.io/weaviate).'
     title: Weaviate REST API
-    version: 1.37.0-rc.0
+    version: 1.37.0-rc.1
 openapi: 3.0.1
 paths:
     /:

--- a/data/encode.go
+++ b/data/encode.go
@@ -1,0 +1,26 @@
+package data
+
+import (
+	"fmt"
+
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+)
+
+// MustEncode is an Encode wrapper that panics instead of returning an error.
+func MustEncode[T any](v *T) map[string]any {
+	m, err := Encode(v)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// Encode converts a Go struct into map[string]any.
+// Use "json" tags to customize how struct field names get converted to map keys.
+func Encode[T any](v *T) (map[string]any, error) {
+	m := make(map[string]any)
+	if err := internal.Encode(v, m); err != nil {
+		return nil, fmt.Errorf("encode: %w", err)
+	}
+	return m, nil
+}

--- a/data/encode_test.go
+++ b/data/encode_test.go
@@ -1,0 +1,44 @@
+package data_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/data"
+)
+
+func TestEncode(t *testing.T) {
+	type Song struct {
+		Title    string `json:"title"`
+		Duration int    `json:"duration_sec"`
+		Artist   string `json:"artist"`
+	}
+
+	t.Run("ok", func(t *testing.T) {
+		song, err := data.Encode(&Song{
+			Title:    "This Is My Bassdrum",
+			Artist:   "Telebrains",
+			Duration: 202,
+		})
+		require.NoError(t, err, "encode error")
+
+		assert.Equal(t, map[string]any{
+			"title":        "This Is My Bassdrum",
+			"artist":       "Telebrains",
+			"duration_sec": 202,
+		}, song)
+	})
+
+	t.Run("invalid input type", func(t *testing.T) {
+		var f func()
+		song, err := data.Encode(&f)
+		require.Error(t, err, "encode error")
+		require.Nil(t, song, "result map")
+	})
+}
+
+func TestMustEncode(t *testing.T) {
+	var f func()
+	require.Panics(t, func() { data.MustEncode(&f) })
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/weaviate/weaviate-go-client/v6
 go 1.24.10
 
 require (
+	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/google/uuid v1.6.0
 	github.com/oapi-codegen/oapi-codegen/v2 v2.5.1
 	github.com/oapi-codegen/runtime v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
+github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=

--- a/internal/api/internal/gen/rest/models.go
+++ b/internal/api/internal/gen/rest/models.go
@@ -1103,6 +1103,9 @@ type InvertedIndexConfig struct {
 	// IndexTimestamps Index each object by its internal timestamps (default: `false`).
 	IndexTimestamps bool `json:"indexTimestamps,omitempty"`
 
+	// StopwordPresets User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings.
+	StopwordPresets map[string][]string `json:"stopwordPresets,omitempty"`
+
 	// Stopwords Fine-grained control over stopword list usage.
 	Stopwords StopwordConfig `json:"stopwords,omitempty"`
 
@@ -1965,6 +1968,9 @@ type TextAnalyzerConfig struct {
 
 	// AsciiFoldIgnore If provided, specifies a list of characters that should be excluded from ascii folding. For example, if ['é'] is provided, then 'é' will not be folded to 'e' during indexing and search. This list can be updated after the property is created, but updates only affect documents indexed after the change.
 	AsciiFoldIgnore []string `json:"asciiFoldIgnore,omitempty"`
+
+	// StopwordPreset Stopword preset name. Overrides the collection-level invertedIndexConfig.stopwords for this property. Only applies to properties using 'word' tokenization. Can be a built-in preset ('en', 'none') or a user-defined preset from invertedIndexConfig.stopwordPresets.
+	StopwordPreset string `json:"stopwordPreset,omitempty"`
 }
 
 // TokenizeRequest Request body for the generic tokenize endpoint.
@@ -1972,8 +1978,8 @@ type TokenizeRequest struct {
 	// AnalyzerConfig Text analysis options for a property. The asciiFold setting is immutable after creation, while the asciiFoldIgnore list can be updated later; changes to asciiFoldIgnore only affect newly indexed data and do not retroactively re-index existing data. Applies only to text and text[] data types that use an inverted index (searchable or filterable).
 	AnalyzerConfig TextAnalyzerConfig `json:"analyzerConfig,omitempty"`
 
-	// StopwordConfig Fine-grained control over stopword list usage.
-	StopwordConfig StopwordConfig `json:"stopwordConfig,omitempty"`
+	// StopwordPresets Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals).
+	StopwordPresets map[string]StopwordConfig `json:"stopwordPresets,omitempty"`
 
 	// Text The text to tokenize.
 	Text string `json:"text"`

--- a/internal/orm.go
+++ b/internal/orm.go
@@ -1,0 +1,42 @@
+package internal
+
+import (
+	"github.com/go-viper/mapstructure/v2"
+)
+
+// tagName is the tag mapstructure will use to match struct fields to keys in the properties map.
+const tagName = "json"
+
+// Decode is a thin wrapper around mapstructure.Decode
+// that decodes map[string]any into a Go struct.
+// It uses "json" tags instead of the default "mapstructure".
+func Decode[T any](m map[string]any, v *T) error {
+	d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: tagName,
+		Result:  v,
+	})
+	if err != nil {
+		return err
+	}
+	if err := d.Decode(m); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Decode is a thin wrapper around mapstructure.Decode
+// that encodes a Go struct into a map[string]any.
+// It uses "json" tags instead of the default "mapstructure".
+func Encode[T any](v *T, m map[string]any) error {
+	d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: tagName,
+		Result:  &m,
+	})
+	if err != nil {
+		return err
+	}
+	if err := d.Decode(v); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/orm.go
+++ b/internal/orm.go
@@ -10,10 +10,10 @@ const tagName = "json"
 // Decode is a thin wrapper around mapstructure.Decode
 // that decodes map[string]any into a Go struct.
 // It uses "json" tags instead of the default "mapstructure".
-func Decode[T any](m map[string]any, v *T) error {
+func Decode[T any](m map[string]any, dest *T) error {
 	d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		TagName: tagName,
-		Result:  v,
+		Result:  dest,
 	})
 	if err != nil {
 		return err
@@ -27,10 +27,10 @@ func Decode[T any](m map[string]any, v *T) error {
 // Decode is a thin wrapper around mapstructure.Decode
 // that encodes a Go struct into a map[string]any.
 // It uses "json" tags instead of the default "mapstructure".
-func Encode[T any](v *T, m map[string]any) error {
+func Encode[T any](v *T, dest map[string]any) error {
 	d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		TagName: tagName,
-		Result:  &m,
+		Result:  &dest,
 	})
 	if err != nil {
 		return err

--- a/internal/orm_test.go
+++ b/internal/orm_test.go
@@ -1,0 +1,38 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+)
+
+func TestDecodeEncode(t *testing.T) {
+	type Song struct {
+		Title    string `json:"title"`
+		Duration int    `json:"duration_sec"`
+		Artist   string `json:"artist"`
+	}
+
+	song := map[string]any{
+		"title":        "Golden Silver Surfer",
+		"artist":       "Telebrains",
+		"duration_sec": 321,
+	}
+
+	var s Song
+	err := internal.Decode(song, &s)
+	require.NoError(t, err, "decode error")
+
+	require.Equal(t, Song{
+		Title:    "Golden Silver Surfer",
+		Artist:   "Telebrains",
+		Duration: 321,
+	}, s, "bad decode result")
+
+	m := make(map[string]any)
+	err = internal.Encode(&s, m)
+	require.NoError(t, err, "encode err")
+
+	require.Equal(t, song, m, "bad encode result")
+}

--- a/query/decode.go
+++ b/query/decode.go
@@ -1,0 +1,74 @@
+package query
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+)
+
+// Decode decodes map[string]any properties of [query.Result] objects into arbitrary Go structs.
+func Decode[P any](r *Result, dest *[]Object[P]) error {
+	*dest = slices.Grow(*dest, len(r.Objects))
+
+	for i, obj := range r.Objects {
+		if i > len(*dest)-1 {
+			*dest = append(*dest, *new(Object[P]))
+		}
+		d := (*dest)[i]
+		if err := decode(&obj, &d); err != nil {
+			return err
+		}
+		(*dest)[i] = d
+	}
+
+	return nil
+}
+
+// DecodeGrouped decodes map[string]any properties of [query.GroupByResult] objects into arbitrary Go structs.
+func DecodeGrouped[P any](r *GroupByResult, dest *[]GroupObject[P]) (map[string]Group[P], error) {
+	groups := make(map[string]Group[P], len(r.Groups)) // TODO(dyma): use internal.MakeMap
+	*dest = slices.Grow(*dest, len(r.Objects))
+
+	var tail int
+	for _, group := range r.Groups {
+		for _, obj := range group.Objects {
+			if tail > len(*dest)-1 {
+				*dest = append(*dest, *new(GroupObject[P]))
+			}
+			d := (*dest)[tail]
+			if err := decode(&obj.Object, &d.Object); err != nil {
+				return nil, err
+			}
+			d.BelongsToGroup = group.Name
+			(*dest)[tail] = d
+			tail++
+		}
+
+		// Create a view into the Objects slice rather than allocating a separate one.
+		from, to := tail-len(group.Objects), tail
+		if len(group.Objects) == 0 {
+			to = from
+		}
+		groups[group.Name] = Group[P]{
+			Name:        group.Name,
+			MinDistance: group.MinDistance,
+			MaxDistance: group.MaxDistance,
+			Size:        group.Size,
+			Objects:     (*dest)[from:to],
+		}
+	}
+	return groups, nil
+}
+
+func decode[P any](src *Object[map[string]any], dest *Object[P]) error {
+	err := internal.Decode(src.Properties, &dest.Properties)
+	if err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+	dest.UUID = src.UUID
+	dest.CreatedAt = src.CreatedAt
+	dest.LastUpdatedAt = src.LastUpdatedAt
+	dest.Metadata = src.Metadata
+	return nil
+}

--- a/query/decode.go
+++ b/query/decode.go
@@ -9,7 +9,7 @@ import (
 
 // Decode decodes map[string]any properties of [query.Result] objects into arbitrary Go structs.
 func Decode[P any](r *Result, dest *[]Object[P]) error {
-	*dest = slices.Grow(*dest, len(r.Objects))
+	grow(&dest, len(r.Objects))
 
 	for i, obj := range r.Objects {
 		if i > len(*dest)-1 {
@@ -28,7 +28,7 @@ func Decode[P any](r *Result, dest *[]Object[P]) error {
 // DecodeGrouped decodes map[string]any properties of [query.GroupByResult] objects into arbitrary Go structs.
 func DecodeGrouped[P any](r *GroupByResult, dest *[]GroupObject[P]) (map[string]Group[P], error) {
 	groups := make(map[string]Group[P], len(r.Groups)) // TODO(dyma): use internal.MakeMap
-	*dest = slices.Grow(*dest, len(r.Objects))
+	grow(&dest, len(r.Objects))
 
 	var tail int
 	for _, group := range r.Groups {
@@ -61,6 +61,8 @@ func DecodeGrouped[P any](r *GroupByResult, dest *[]GroupObject[P]) (map[string]
 	return groups, nil
 }
 
+// decode map[string]any properties into [query.Object.Properties] of arbitrary type P.
+// The dest object will have the same UUID, CreatedAt, LastUpdatedAt, and Metadata as src.
 func decode[P any](src *Object[map[string]any], dest *Object[P]) error {
 	err := internal.Decode(src.Properties, &dest.Properties)
 	if err != nil {
@@ -71,4 +73,14 @@ func decode[P any](src *Object[map[string]any], dest *Object[P]) error {
 	dest.LastUpdatedAt = src.LastUpdatedAt
 	dest.Metadata = src.Metadata
 	return nil
+}
+
+// grow ensures the slice has enough capacity to fit n items.
+// If the pointer to the slice is nil, a new slice of size n is allocated.
+func grow[E any, S ~[]E](s **S, n int) {
+	if *s == nil {
+		empty := make(S, n)
+		*s = &empty
+	}
+	**s = slices.Grow(**s, n)
 }

--- a/query/decode_test.go
+++ b/query/decode_test.go
@@ -1,0 +1,166 @@
+package query_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+	"github.com/weaviate/weaviate-go-client/v6/query"
+	"github.com/weaviate/weaviate-go-client/v6/types"
+)
+
+func TestDecode(t *testing.T) {
+	type Song struct {
+		Title    string `json:"title"`
+		Duration int    `json:"duration_sec"`
+		Artist   string `json:"artist"`
+	}
+
+	r := query.Result{
+		Objects: []query.Object[map[string]any]{
+			{
+				Object: types.Object[map[string]any]{
+					UUID: testkit.UUID,
+					Properties: map[string]any{
+						"title":        "Golden Silver Surfer",
+						"artist":       "Telebrains",
+						"duration_sec": 321,
+					},
+					CreatedAt:     &testkit.Now,
+					LastUpdatedAt: &testkit.Now,
+				},
+				Metadata: query.Metadata{Distance: testkit.Ptr[float32](.22)},
+			},
+			{
+				Object: types.Object[map[string]any]{
+					Properties: map[string]any{
+						"title":        "Justifier",
+						"artist":       "Telebrains",
+						"duration_sec": 158,
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("nil dest", func(t *testing.T) {
+		var dest []query.Object[Song]
+
+		err := query.Decode(&r, &dest)
+		require.NoError(t, err, "decode error")
+		require.Len(t, dest, len(r.Objects))
+
+		for i := range len(r.Objects) {
+			mapSurfer, structSurfer := r.Objects[i], dest[i]
+			assert.Equal(t, mapSurfer.Properties["title"], structSurfer.Properties.Title, "title")
+			assert.Equal(t, mapSurfer.Properties["artist"], structSurfer.Properties.Artist, "artist")
+			assert.Equal(t, mapSurfer.Properties["duration_sec"], structSurfer.Properties.Duration, "duration_sec")
+
+			assert.Equal(t, mapSurfer.UUID, structSurfer.UUID, "uuid")
+			assert.Equal(t, mapSurfer.CreatedAt, structSurfer.CreatedAt, "created at")
+			assert.Equal(t, mapSurfer.LastUpdatedAt, structSurfer.LastUpdatedAt, "last updated at")
+		}
+	})
+
+	t.Run("reuse dest", func(t *testing.T) {
+		dest := []query.Object[Song]{
+			// The "old" objects have some other UUIDs,
+			// we want to make sure that Decode will overwrite them.
+			{Object: types.Object[Song]{UUID: uuid.New()}},
+			{Object: types.Object[Song]{UUID: uuid.New()}},
+		}
+
+		err := query.Decode(&r, &dest)
+		require.NoError(t, err, "decode error")
+		require.Len(t, dest, len(r.Objects))
+
+		for i := range len(r.Objects) {
+			mapSurfer, structSurfer := r.Objects[i], dest[i]
+			assert.Equal(t, mapSurfer.Properties["title"], structSurfer.Properties.Title, "title")
+			assert.Equal(t, mapSurfer.Properties["artist"], structSurfer.Properties.Artist, "artist")
+			assert.Equal(t, mapSurfer.Properties["duration_sec"], structSurfer.Properties.Duration, "duration_sec")
+
+			assert.Equal(t, mapSurfer.UUID, structSurfer.UUID, "uuid")
+		}
+	})
+}
+
+func TestDecodeGrouped(t *testing.T) {
+	type Song struct {
+		Title    string `json:"title"`
+		Duration int    `json:"duration_sec"`
+		Artist   string `json:"artist"`
+	}
+
+	// DecodeGrouped only reads from Groups, using Objects only to
+	// grow the dest slice appropriately, so it's enough to just allocate it.
+	// This test is, in a way, aware of the implementation, to the extent
+	// that it simplifies the setup.
+	r := query.GroupByResult{
+		Groups: map[string]query.Group[map[string]any]{
+			"My Thoughts Changed Directions": {
+				Name: "My Thoughts Changed Directions",
+				Size: 2,
+				Objects: []query.GroupObject[map[string]any]{
+					{
+						BelongsToGroup: "My Thoughts Changed Directions",
+						Object: query.Object[map[string]any]{
+							Object: types.Object[map[string]any]{
+								UUID: testkit.UUID,
+								Properties: map[string]any{
+									"title":        "Golden Silver Surfer",
+									"artist":       "Telebrains",
+									"duration_sec": 321,
+								},
+								CreatedAt:     &testkit.Now,
+								LastUpdatedAt: &testkit.Now,
+							},
+							Metadata: query.Metadata{Distance: testkit.Ptr[float32](.22)},
+						},
+					},
+					{
+						BelongsToGroup: "My Thoughts Changed Directions",
+						Object: query.Object[map[string]any]{
+							Object: types.Object[map[string]any]{
+								Properties: map[string]any{
+									"title":        "Justifier",
+									"artist":       "Telebrains",
+									"duration_sec": 158,
+								},
+							},
+						},
+					},
+				},
+			},
+			"Tomorrow": {Name: "Tomorrow"}, // empty group to force an edge case
+		},
+		Objects: make([]query.GroupObject[map[string]any], 2),
+	}
+
+	t.Run("nil dest", func(t *testing.T) {
+		var dest []query.GroupObject[Song]
+
+		groups, err := query.DecodeGrouped(&r, &dest)
+		require.NoError(t, err, "decode error")
+
+		assert.Len(t, groups, len(r.Groups), "no. groups")
+		assert.Len(t, dest, len(r.Objects), "no. objects")
+		assert.Contains(t, groups, "My Thoughts Changed Directions")
+		assert.Contains(t, groups, "Tomorrow")
+
+		got := groups["My Thoughts Changed Directions"]
+		want := r.Groups["My Thoughts Changed Directions"]
+		require.Len(t, got.Objects, len(want.Objects), "objects in the group")
+
+		for i := range len(want.Objects) {
+			mapSurfer, structSurfer := want.Objects[i], got.Objects[i]
+			assert.Equal(t, mapSurfer.Properties["title"], structSurfer.Properties.Title, "title")
+			assert.Equal(t, mapSurfer.Properties["artist"], structSurfer.Properties.Artist, "artist")
+			assert.Equal(t, mapSurfer.Properties["duration_sec"], structSurfer.Properties.Duration, "duration_sec")
+
+			assert.Equal(t, mapSurfer.UUID, structSurfer.UUID, "uuid")
+		}
+	})
+}

--- a/query/decode_test.go
+++ b/query/decode_test.go
@@ -45,7 +45,7 @@ func TestDecode(t *testing.T) {
 		},
 	}
 
-	t.Run("nil dest", func(t *testing.T) {
+	t.Run("empty dest", func(t *testing.T) {
 		var dest []query.Object[Song]
 
 		err := query.Decode(&r, &dest)
@@ -84,6 +84,10 @@ func TestDecode(t *testing.T) {
 
 			assert.Equal(t, mapSurfer.UUID, structSurfer.UUID, "uuid")
 		}
+	})
+
+	t.Run("nil dest", func(t *testing.T) {
+		require.NotPanics(t, func() { query.Decode[Song](&r, nil) })
 	})
 }
 
@@ -139,7 +143,7 @@ func TestDecodeGrouped(t *testing.T) {
 		Objects: make([]query.GroupObject[map[string]any], 2),
 	}
 
-	t.Run("nil dest", func(t *testing.T) {
+	t.Run("empty dest", func(t *testing.T) {
 		var dest []query.GroupObject[Song]
 
 		groups, err := query.DecodeGrouped(&r, &dest)
@@ -162,5 +166,9 @@ func TestDecodeGrouped(t *testing.T) {
 
 			assert.Equal(t, mapSurfer.UUID, structSurfer.UUID, "uuid")
 		}
+	})
+
+	t.Run("nil dest", func(t *testing.T) {
+		require.NotPanics(t, func() { query.DecodeGrouped[Song](&r, nil) })
 	})
 }

--- a/query/decode_test.go
+++ b/query/decode_test.go
@@ -87,6 +87,7 @@ func TestDecode(t *testing.T) {
 	})
 
 	t.Run("nil dest", func(t *testing.T) {
+		//nolint:errcheck
 		require.NotPanics(t, func() { query.Decode[Song](&r, nil) })
 	})
 }
@@ -169,6 +170,7 @@ func TestDecodeGrouped(t *testing.T) {
 	})
 
 	t.Run("nil dest", func(t *testing.T) {
+		//nolint:errcheck
 		require.NotPanics(t, func() { query.DecodeGrouped[Song](&r, nil) })
 	})
 }


### PR DESCRIPTION
This PR introduces minimal ORM features, which will enable users to read/write object properties using their custom Go structs. This change affects `data` and `query` packages, which get an `Encode()` and `Decode()` respectively. 

`query.Decode()` has a variant for grouped results, `query.DecodeGrouped()`, while `data.Encode()` has a `data.MustEncode()` variant that panics instead of returning an error to make its use more ergonomic.

The internal implementation wholly relies on [`viper/mapstructure`](https://github.com/go-viper/mapstructure), because it is likely faster and more robust that an in-house solution would be.

The user's code might then look something like this:

```go
type Song struct {
    Title    string
    Artist   string
    Duration int      `json:"duration_sec"`
    Genres   []string `json:"tags"`
}

func write(ctx context.Context, c *weaviate.Client, s *Song) error {
  _, err := c.Data.Insert(ctx, &data.Object{
    Properties: data.MustEncode(s)),
  })
  return err
}

func readSongs(ctx context.Context, c *weaviate.Client, lyrics string) ([]query.Object[Song], error) {
  r, err := c.Query.NearText(ctx, query.NearText{
    Query: lyrics,
    QueryProperties: []string{"lyrics"},
  })
  if err != nil { return nil, err }
  
  var songs []query.Object[Song]
  if err := query.Decode(r, &songs); err != nil { return nil, err }
  return songs
}

func readAlbums(ctx context.Context, c *weaviate.Client, lyrics string) (map[string]query.Group[Song], error) {
  r, err := c.Query.NearText.GroupBy(ctx, query.NearText{
    Query: lyrics,
    QueryProperties: []string{"lyrics"},
  }, query.GroupBy{Property: "album"})
  if err != nil { return nil, err }
  
  // We don't _have_ to allocate our own slice if we aren't going to read from it.
  // var songs []query.GroupObject[Song]
  albums, err := query.DecodeGrouped(r, nil)
  if err != nil { return nil, err }
  return albums
}
```

---

On inputs to Decode/DecodeGrouped:

The reason these two take a pointer to a slice instead of allocating one themselves is to give users more control over the memory usage. A read-intensive workload (like pagination) can benefit from the possibility to re-use the results slice. Of course, the client will still allocate when reading the "original" `map[string]any` results, but if we can potentially reduce the overhead of the ORM code I reckon we should use the chance.