### PR TITLE
ci: pin GitHub Actions to server SHAs and add hidden-unicode lint

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -16,7 +16,7 @@ jobs:
     needs: [tests]
     steps:
       - name: Create a GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true
           draft: true

--- a/.github/workflows/golang-ci-lint.yaml
+++ b/.github/workflows/golang-ci-lint.yaml
@@ -16,12 +16,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: v2.9.0
           args: --timeout=3m

--- a/.github/workflows/pr-security-lint.yaml
+++ b/.github/workflows/pr-security-lint.yaml
@@ -1,0 +1,35 @@
+name: PR Security Lint
+
+# SECURITY: This workflow uses pull_request_target intentionally so that the
+# workflow definition runs from the BASE branch (main), not the PR. The
+# composite action it invokes lives at a pinned 40-char SHA in
+# weaviate/weaviate — attackers cannot alter the lint logic via a PR or by
+# tampering with an upstream tag.
+#
+# Rules:
+#   1. Do NOT add `ref: ${{ github.event.pull_request.head.sha }}` or any
+#      reference to PR-controlled refs. The composite uses the GitHub API to
+#      fetch the diff text — no PR code is ever executed.
+#   2. Do NOT add secrets to this workflow. The pull_request_target context
+#      grants a token with write access to the base repo and access to all
+#      repo secrets if any are referenced. We reference none and request
+#      minimal permissions; keep it that way.
+#   3. Keep the composite action pinned to a full-length commit SHA. Tag or
+#      branch refs would let an upstream change alter the lint logic at
+#      execution time.
+on:
+  pull_request_target:
+
+permissions: {}
+
+jobs:
+  hidden-unicode:
+    name: hidden unicode characters
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read   # required by the composite's `gh pr diff` call
+    steps:
+      - uses: weaviate/weaviate/.github/actions/security-lint@3e52fc80a244f4644d4facc6a4e705ea6eda9039 # PR #11093
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          github-token: ${{ github.token }}

--- a/.github/workflows/workflow-tests.yaml
+++ b/.github/workflows/workflow-tests.yaml
@@ -14,15 +14,15 @@ jobs:
       WCS_DUMMY_CI_PW: ${{ secrets.WCS_DUMMY_CI_PW }}
       OKTA_DUMMY_CI_PW: ${{ secrets.OKTA_DUMMY_CI_PW }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.25"
           cache: true
@@ -42,15 +42,15 @@ jobs:
       OPENAI_APIKEY: ${{ secrets.OPENAI_APIKEY }}
       VOYAGEAI_APIKEY: ${{ secrets.VOYAGEAI_APIKEY }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.25"
           cache: true
@@ -60,9 +60,9 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.25"
           cache: true
@@ -73,14 +73,14 @@ jobs:
     env:
       EXTERNAL_WEAVIATE_RUNNING: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.25"
           cache: true
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           username: ${{secrets.DOCKER_USERNAME}}


### PR DESCRIPTION
## Summary

- Pin all `uses:` refs in GitHub Actions workflows to the same commit SHAs used by `weaviate/weaviate`, so this client stays in lockstep with the server
- Preserve the tag (e.g. `# v6`) as a trailing comment for readability
- Add `.github/workflows/pr-security-lint.yaml` that scans every PR diff for hidden Unicode / trojan-source characters by delegating to the reusable composite shipped in weaviate/weaviate#11093 (pinned to merge commit `3e52fc80a244f4644d4facc6a4e705ea6eda9039`)

## Context

Two complementary layers of GitHub Actions hardening:

1. **SHA pinning** — going forward, GitHub's repo-level ["Require actions to be pinned to a full-length commit SHA"](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/) policy (shipped 2025-08-15) will enforce this at execution time for every workflow. This commit is the initial consolidation pass.
2. **Hidden-Unicode scan** — the native policy doesn't cover trojan-source attacks. The shared composite in `weaviate/weaviate` is invoked here so all five Weaviate SDKs share one implementation.

### Security notes for the new workflow

- `pull_request_target` runs the workflow definition from the base branch, never from the PR.
- `permissions: {}` at workflow level; `pull-requests: read` is the only grant.
- The composite is pinned to a 40-char SHA — upstream tag retargeting can't alter what runs here.
- No PR-controlled refs are checked out; the composite fetches the diff text via the GitHub API.

## Tradeoffs of delegating to an upstream composite

**Pros**
- Single source of truth for the scan logic — fixes/improvements ship to all 5 SDKs via one SHA bump per repo, not by syncing 5 copies of bash.
- Composite is pinned to a 40-char SHA, so upstream tag retargeting can't change what runs here without a reviewable diff.
- `pull_request_target` runs the workflow definition from the base branch and the composite never checks out PR-controlled refs — a malicious PR can't alter the linter that's checking it.
- Minimal blast radius: `permissions: {}` at workflow level, `pull-requests: read` at job level, no secrets referenced.
- Composable — adding more scanners upstream (shell-script lint, etc.) propagates to every client automatically.

**Cons**
- Cross-repo runtime coupling: deleting or restructuring `weaviate/weaviate/.github/actions/security-lint` breaks all 5 clients until the SHA is bumped.
- `pull_request_target` is a foot-gun — a future editor adding `ref: pull_request.head.sha` or referencing a secret would re-introduce the attack surface this design is built to avoid. The file header warns against it, but the discipline lives in the reviewer.
- SHA-bump treadmill: upstream improvements don't propagate until each client opens a PR to bump the pinned SHA. Dependabot can automate this if we wire it up.
- Failure logs reference a path inside `weaviate/weaviate` rather than this repo, so debugging a false positive requires hopping to another repo to read the script.
- Cold-start adds a small network fetch of the composite per run.
## Test plan

- [ ] CI workflows run and pass on this branch
- [ ] `pr-security-lint` job runs on this PR and passes (clean diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)