### PR TITLE
fix(grpc): pass request metadata via request context

### DIFF
--- a/internal/api/transport/transport.go
+++ b/internal/api/transport/transport.go
@@ -144,14 +144,14 @@ func (t *transport) Do(ctx context.Context, req any, dest any) error {
 	}
 }
 
-func newRPC[In RequestMessage, Out ReplyMessage](req Message[In, Out], dest any) rpcFunc {
+func newRPC[In RequestMessage, Out ReplyMessage](req Message[In, Out], dest any) transports.RPC[proto.WeaviateClient] {
 	dev.AssertType[MessageUnmarshaler[Out]](dest, "dest")
 	out := dest.(MessageUnmarshaler[Out])
 
 	body := req.Body()
 	dev.AssertNotNil(body, "body")
 
-	return rpcFunc(func(ctx context.Context, wc proto.WeaviateClient) error {
+	return func(ctx context.Context, wc proto.WeaviateClient) error {
 		in, err := body.MarshalMessage()
 		if err != nil {
 			return fmt.Errorf("%s: marshal message: %w", req, err)
@@ -168,16 +168,7 @@ func newRPC[In RequestMessage, Out ReplyMessage](req Message[In, Out], dest any)
 			return err
 		}
 		return nil
-	})
-}
-
-// rpcFunc implements [transports.RPC] as a function.
-type rpcFunc func(context.Context, proto.WeaviateClient) error
-
-var _ transports.RPC[proto.WeaviateClient] = (*rpcFunc)(nil)
-
-func (f rpcFunc) Do(ctx context.Context, wc proto.WeaviateClient) error {
-	return f(ctx, wc)
+	}
 }
 
 // unmarshal unmarshals reply Out into dest. A nil dest means the reply can be ignored,

--- a/internal/api/transport/transport_test.go
+++ b/internal/api/transport/transport_test.go
@@ -156,8 +156,11 @@ func TestTransport_Do(t *testing.T) {
 	})
 
 	t.Run("grpc message", func(t *testing.T) {
+		fakeGRPC := gRPCFunc(func(ctx context.Context, rpc transports.RPC[proto.WeaviateClient]) error {
+			return rpc(ctx, nil)
+		})
 		t.Run("ok", func(t *testing.T) {
-			tport := transport{gRPC: new(fakeGRPC)}
+			tport := transport{gRPC: fakeGRPC}
 
 			// Actual request is captured by message itself,
 			// because unlike transports.Endpoint, each transports.RPC
@@ -180,7 +183,7 @@ func TestTransport_Do(t *testing.T) {
 		})
 
 		t.Run("error", func(t *testing.T) {
-			tport := transport{gRPC: new(fakeGRPC)}
+			tport := transport{gRPC: fakeGRPC}
 
 			var resp reply[proto.SearchReply]
 			req := &message[proto.SearchRequest, proto.SearchReply]{
@@ -271,14 +274,6 @@ type gRPCFunc func(ctx context.Context, rpc transports.RPC[proto.WeaviateClient]
 
 func (f gRPCFunc) Do(ctx context.Context, rpc transports.RPC[proto.WeaviateClient]) error {
 	return f(ctx, rpc)
-}
-
-// fakeGRPC calls rpc.Do with nil [proto.WeaviateClient].
-// It's a dummy that should be used together with [message].
-type fakeGRPC struct{}
-
-func (*fakeGRPC) Do(ctx context.Context, rpc transports.RPC[proto.WeaviateClient]) error {
-	return rpc.Do(ctx, nil)
 }
 
 // message implements [Message] for testing.

--- a/internal/transports/grpc.go
+++ b/internal/transports/grpc.go
@@ -30,14 +30,12 @@ type GRPCConfig[Client any] struct {
 type NewGRPCClientFunc[Client any] func(grpc.ClientConnInterface) Client
 
 // RPC describes a gRPC request in the given Client.
-type RPC[Client any] interface {
-	Do(context.Context, Client) error
-}
+type RPC[Client any] func(context.Context, Client) error
 
 func (c *GRPC[Client]) Do(ctx context.Context, rpc RPC[Client]) error {
 	dev.AssertNotNil(rpc, "rpc")
 
-	if err := rpc.Do(ctx, c.client); err != nil {
+	if err := rpc(ctx, c.client); err != nil {
 		return fmt.Errorf("grpc: %w", err)
 	}
 	return nil
@@ -58,9 +56,7 @@ type GRPC[Client any] struct {
 func NewGRPC[Client any](cfg GRPCConfig[Client]) (*GRPC[Client], error) {
 	dev.AssertNotNil(cfg.NewGRPCClient, "cfg.NewGRPCClient")
 
-	callOpts := []grpc.CallOption{
-		grpc.Header(cfg.Header),
-	}
+	var callOpts []grpc.CallOption
 	if cfg.MaxMessageSize > 0 {
 		callOpts = append(callOpts,
 			grpc.MaxCallSendMsgSize(cfg.MaxMessageSize),
@@ -70,6 +66,10 @@ func NewGRPC[Client any](cfg GRPCConfig[Client]) (*GRPC[Client], error) {
 
 	dialOpts := []grpc.DialOption{
 		grpc.WithDefaultCallOptions(callOpts...),
+	}
+
+	if cfg.Header != nil {
+		dialOpts = append(dialOpts, withDefaultHeader(*cfg.Header))
 	}
 
 	transportCreds := insecure.NewCredentials()
@@ -104,4 +104,11 @@ var _ io.Closer = (*GRPC[any])(nil)
 
 func (c *GRPC[Client]) Close() error {
 	return c.channel.Close()
+}
+
+// withDefaultHeader creates an interceptor that adds md headers to the request context.
+func withDefaultHeader(md metadata.MD) grpc.DialOption {
+	return grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		return invoker(metadata.NewOutgoingContext(ctx, md), method, req, reply, cc, opts...)
+	})
 }

--- a/internal/transports/grpc.go
+++ b/internal/transports/grpc.go
@@ -109,6 +109,13 @@ func (c *GRPC[Client]) Close() error {
 // withDefaultHeader creates an interceptor that adds md headers to the request context.
 func withDefaultHeader(md metadata.MD) grpc.DialOption {
 	return grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		return invoker(metadata.NewOutgoingContext(ctx, md), method, req, reply, cc, opts...)
+		var pairs []string
+		for k, v := range md {
+			if len(v) == 0 {
+				continue
+			}
+			pairs = append(pairs, k, v[0])
+		}
+		return invoker(metadata.AppendToOutgoingContext(ctx, pairs...), method, req, reply, cc, opts...)
 	})
 }

--- a/internal/transports/grpc_test.go
+++ b/internal/transports/grpc_test.go
@@ -68,20 +68,18 @@ func TestGRPC_Do(t *testing.T) {
 	})
 
 	t.Run("default headers", func(t *testing.T) {
-		header := metadata.MD{"X-FindMe": {"foo", "bar"}}
-
 		// Arrange: start a local gRPC server and register a handler with assertions.
 		ts := startTestService(t, func(_ any, ctx context.Context, _ func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
 			md, ok := metadata.FromIncomingContext(ctx)
 			assert.True(t, ok, "incoming context should contain metadata")
-			assert.Subset(t, md, header, "default headers not present in request metadata")
+			assert.Subset(t, md, metadata.MD{"x-findme": {"foo"}}, "default headers not present in request metadata")
 			return nil, nil
 		})
 
 		gRPC, err := transports.NewGRPC(transports.GRPCConfig[grpc.ClientConnInterface]{
 			Host:          ts.Host(),
 			Port:          ts.Port(),
-			Header:        &header,
+			Header:        &metadata.MD{"X-FindMe": {"foo"}},
 			NewGRPCClient: func(channel grpc.ClientConnInterface) grpc.ClientConnInterface { return channel },
 		})
 		require.NoError(t, err, "new grpc transport")

--- a/internal/transports/grpc_test.go
+++ b/internal/transports/grpc_test.go
@@ -1,3 +1,4 @@
+//nolint:errcheck
 package transports_test
 
 import (

--- a/internal/transports/grpc_test.go
+++ b/internal/transports/grpc_test.go
@@ -2,6 +2,9 @@ package transports_test
 
 import (
 	"context"
+	"net"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +12,8 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
 	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func TestNewGRPC(t *testing.T) {
@@ -32,18 +37,18 @@ func TestNewGRPC(t *testing.T) {
 
 func TestGRPC_Do(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
-		grpc, err := transports.NewGRPC(transports.GRPCConfig[any]{
+		gRPC, err := transports.NewGRPC(transports.GRPCConfig[any]{
 			NewGRPCClient: func(channel grpc.ClientConnInterface) any {
 				return 92
 			},
 		})
 		require.NoError(t, err, "create grpc transport")
-		require.NotNil(t, grpc, "grpc transport")
+		require.NotNil(t, gRPC, "grpc transport")
 
-		require.NoError(t, grpc.Do(t.Context(), rpcFunc(func(_ context.Context, client any) error {
+		require.NoError(t, gRPC.Do(t.Context(), func(_ context.Context, client any) error {
 			assert.Equal(t, 92, client, "injected client")
 			return nil
-		})), "request error")
+		}), "request error")
 	})
 
 	t.Run("with error", func(t *testing.T) {
@@ -55,17 +60,78 @@ func TestGRPC_Do(t *testing.T) {
 		require.NoError(t, err, "create grpc transport")
 		require.NotNil(t, grpc, "grpc transport")
 
-		require.ErrorIs(t, grpc.Do(t.Context(), rpcFunc(func(_ context.Context, client any) error {
+		require.ErrorIs(t, grpc.Do(t.Context(), func(_ context.Context, client any) error {
 			assert.Equal(t, 92, client, "injected client")
 			return testkit.ErrWhaam
-		})), testkit.ErrWhaam, "request error")
+		}), testkit.ErrWhaam, "request error")
+	})
+
+	t.Run("default headers", func(t *testing.T) {
+		header := metadata.MD{"X-FindMe": {"foo", "bar"}}
+
+		// Arrange: start a local gRPC server and register a handler with assertions.
+		ts := startTestService(t, func(_ any, ctx context.Context, _ func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
+			md, ok := metadata.FromIncomingContext(ctx)
+			assert.True(t, ok, "incoming context should contain metadata")
+			assert.Subset(t, md, header, "default headers not present in request metadata")
+			return nil, nil
+		})
+
+		gRPC, err := transports.NewGRPC(transports.GRPCConfig[grpc.ClientConnInterface]{
+			Host:          ts.Host(),
+			Port:          ts.Port(),
+			Header:        &header,
+			NewGRPCClient: func(channel grpc.ClientConnInterface) grpc.ClientConnInterface { return channel },
+		})
+		require.NoError(t, err, "new grpc transport")
+
+		// Act: our handled above will verify that the request included expected headers.
+		gRPC.Do(t.Context(), func(ctx context.Context, client grpc.ClientConnInterface) error {
+			var empty emptypb.Empty
+			return client.Invoke(ctx, ts.MethodName(), nil, &empty)
+		})
 	})
 }
 
-type rpcFunc func(ctx context.Context, client any) error
-
-var _ transports.RPC[any] = (*rpcFunc)(nil)
-
-func (f rpcFunc) Do(ctx context.Context, client any) error {
-	return f(ctx, client)
+type testService struct {
+	lis  net.Listener
+	srv  *grpc.Server
+	host string
+	port int
 }
+
+// startTestService starts a local TCP [net.Listener] and creates a [grpc.Server]
+// using that listener. The mh handler can be used to make assertions about the
+// request or control how the requeset is processed.
+//
+// All resources are freed via [testing.T.Cleanup] hook.
+func startTestService(t *testing.T, mh grpc.MethodHandler) *testService {
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { lis.Close() })
+
+	addr := strings.Split(lis.Addr().String(), ":")
+	port, _ := strconv.Atoi(addr[1])
+
+	srv := grpc.NewServer()
+	srv.RegisterService(&grpc.ServiceDesc{
+		ServiceName: "testService",
+		Methods: []grpc.MethodDesc{
+			{MethodName: "Test", Handler: mh},
+		},
+	}, nil)
+
+	go srv.Serve(lis)
+	t.Cleanup(srv.Stop)
+
+	return &testService{
+		lis:  lis,
+		srv:  srv,
+		host: addr[0],
+		port: port,
+	}
+}
+
+func (ts *testService) Host() string       { return ts.host }
+func (ts *testService) Port() int          { return ts.port }
+func (ts *testService) MethodName() string { return "/testService/Test" }


### PR DESCRIPTION
The `grpc.Header()` function is intended for reading response headers, not supplying request headers. When connecting to a WCD cluster, the `X-Weaviate-Cluster-Url` header was not being propagated, so any queries relying on the Embeddings Service would fail.

I also simplified the type of `transports.RPC` from `interface { Do(...) }` to just a function, because there's no use case for an object-RPC atm. It makes the test code simpler too.