### PR TITLE
v6: Filters

### DIFF
--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -73,6 +73,12 @@ type (
 	MultiTenancyConfig rest.MultiTenancyConfig
 )
 
+const (
+	FieldUUID          = "_id"
+	FieldCreatedAt     = "_creationTimeUnix"
+	FieldLastUpdatedAt = "_lastUpdateTimeUnix"
+)
+
 // DataType defines supported property data types.
 type DataType string
 

--- a/internal/api/internal/gen/proto/v1/base.pb.go
+++ b/internal/api/internal/gen/proto/v1/base.pb.go
@@ -7,13 +7,12 @@
 package protocol
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -1569,35 +1568,32 @@ func file_v1_base_proto_rawDescGZIP() []byte {
 	return file_v1_base_proto_rawDescData
 }
 
-var (
-	file_v1_base_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-	file_v1_base_proto_msgTypes  = make([]protoimpl.MessageInfo, 18)
-	file_v1_base_proto_goTypes   = []any{
-		(ConsistencyLevel)(0),               // 0: weaviate.v1.ConsistencyLevel
-		(Filters_Operator)(0),               // 1: weaviate.v1.Filters.Operator
-		(Vectors_VectorType)(0),             // 2: weaviate.v1.Vectors.VectorType
-		(*NumberArrayProperties)(nil),       // 3: weaviate.v1.NumberArrayProperties
-		(*IntArrayProperties)(nil),          // 4: weaviate.v1.IntArrayProperties
-		(*TextArrayProperties)(nil),         // 5: weaviate.v1.TextArrayProperties
-		(*BooleanArrayProperties)(nil),      // 6: weaviate.v1.BooleanArrayProperties
-		(*ObjectPropertiesValue)(nil),       // 7: weaviate.v1.ObjectPropertiesValue
-		(*ObjectArrayProperties)(nil),       // 8: weaviate.v1.ObjectArrayProperties
-		(*ObjectProperties)(nil),            // 9: weaviate.v1.ObjectProperties
-		(*TextArray)(nil),                   // 10: weaviate.v1.TextArray
-		(*IntArray)(nil),                    // 11: weaviate.v1.IntArray
-		(*NumberArray)(nil),                 // 12: weaviate.v1.NumberArray
-		(*BooleanArray)(nil),                // 13: weaviate.v1.BooleanArray
-		(*Filters)(nil),                     // 14: weaviate.v1.Filters
-		(*FilterReferenceSingleTarget)(nil), // 15: weaviate.v1.FilterReferenceSingleTarget
-		(*FilterReferenceMultiTarget)(nil),  // 16: weaviate.v1.FilterReferenceMultiTarget
-		(*FilterReferenceCount)(nil),        // 17: weaviate.v1.FilterReferenceCount
-		(*FilterTarget)(nil),                // 18: weaviate.v1.FilterTarget
-		(*GeoCoordinatesFilter)(nil),        // 19: weaviate.v1.GeoCoordinatesFilter
-		(*Vectors)(nil),                     // 20: weaviate.v1.Vectors
-		(*structpb.Struct)(nil),             // 21: google.protobuf.Struct
-	}
-)
-
+var file_v1_base_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_v1_base_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_v1_base_proto_goTypes = []any{
+	(ConsistencyLevel)(0),               // 0: weaviate.v1.ConsistencyLevel
+	(Filters_Operator)(0),               // 1: weaviate.v1.Filters.Operator
+	(Vectors_VectorType)(0),             // 2: weaviate.v1.Vectors.VectorType
+	(*NumberArrayProperties)(nil),       // 3: weaviate.v1.NumberArrayProperties
+	(*IntArrayProperties)(nil),          // 4: weaviate.v1.IntArrayProperties
+	(*TextArrayProperties)(nil),         // 5: weaviate.v1.TextArrayProperties
+	(*BooleanArrayProperties)(nil),      // 6: weaviate.v1.BooleanArrayProperties
+	(*ObjectPropertiesValue)(nil),       // 7: weaviate.v1.ObjectPropertiesValue
+	(*ObjectArrayProperties)(nil),       // 8: weaviate.v1.ObjectArrayProperties
+	(*ObjectProperties)(nil),            // 9: weaviate.v1.ObjectProperties
+	(*TextArray)(nil),                   // 10: weaviate.v1.TextArray
+	(*IntArray)(nil),                    // 11: weaviate.v1.IntArray
+	(*NumberArray)(nil),                 // 12: weaviate.v1.NumberArray
+	(*BooleanArray)(nil),                // 13: weaviate.v1.BooleanArray
+	(*Filters)(nil),                     // 14: weaviate.v1.Filters
+	(*FilterReferenceSingleTarget)(nil), // 15: weaviate.v1.FilterReferenceSingleTarget
+	(*FilterReferenceMultiTarget)(nil),  // 16: weaviate.v1.FilterReferenceMultiTarget
+	(*FilterReferenceCount)(nil),        // 17: weaviate.v1.FilterReferenceCount
+	(*FilterTarget)(nil),                // 18: weaviate.v1.FilterTarget
+	(*GeoCoordinatesFilter)(nil),        // 19: weaviate.v1.GeoCoordinatesFilter
+	(*Vectors)(nil),                     // 20: weaviate.v1.Vectors
+	(*structpb.Struct)(nil),             // 21: google.protobuf.Struct
+}
 var file_v1_base_proto_depIdxs = []int32{
 	21, // 0: weaviate.v1.ObjectPropertiesValue.non_ref_properties:type_name -> google.protobuf.Struct
 	3,  // 1: weaviate.v1.ObjectPropertiesValue.number_array_properties:type_name -> weaviate.v1.NumberArrayProperties

--- a/internal/api/internal/gen/proto/v1/base.pb.go
+++ b/internal/api/internal/gen/proto/v1/base.pb.go
@@ -7,12 +7,13 @@
 package protocol
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	structpb "google.golang.org/protobuf/types/known/structpb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
 const (
@@ -1568,32 +1569,35 @@ func file_v1_base_proto_rawDescGZIP() []byte {
 	return file_v1_base_proto_rawDescData
 }
 
-var file_v1_base_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_v1_base_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
-var file_v1_base_proto_goTypes = []any{
-	(ConsistencyLevel)(0),               // 0: weaviate.v1.ConsistencyLevel
-	(Filters_Operator)(0),               // 1: weaviate.v1.Filters.Operator
-	(Vectors_VectorType)(0),             // 2: weaviate.v1.Vectors.VectorType
-	(*NumberArrayProperties)(nil),       // 3: weaviate.v1.NumberArrayProperties
-	(*IntArrayProperties)(nil),          // 4: weaviate.v1.IntArrayProperties
-	(*TextArrayProperties)(nil),         // 5: weaviate.v1.TextArrayProperties
-	(*BooleanArrayProperties)(nil),      // 6: weaviate.v1.BooleanArrayProperties
-	(*ObjectPropertiesValue)(nil),       // 7: weaviate.v1.ObjectPropertiesValue
-	(*ObjectArrayProperties)(nil),       // 8: weaviate.v1.ObjectArrayProperties
-	(*ObjectProperties)(nil),            // 9: weaviate.v1.ObjectProperties
-	(*TextArray)(nil),                   // 10: weaviate.v1.TextArray
-	(*IntArray)(nil),                    // 11: weaviate.v1.IntArray
-	(*NumberArray)(nil),                 // 12: weaviate.v1.NumberArray
-	(*BooleanArray)(nil),                // 13: weaviate.v1.BooleanArray
-	(*Filters)(nil),                     // 14: weaviate.v1.Filters
-	(*FilterReferenceSingleTarget)(nil), // 15: weaviate.v1.FilterReferenceSingleTarget
-	(*FilterReferenceMultiTarget)(nil),  // 16: weaviate.v1.FilterReferenceMultiTarget
-	(*FilterReferenceCount)(nil),        // 17: weaviate.v1.FilterReferenceCount
-	(*FilterTarget)(nil),                // 18: weaviate.v1.FilterTarget
-	(*GeoCoordinatesFilter)(nil),        // 19: weaviate.v1.GeoCoordinatesFilter
-	(*Vectors)(nil),                     // 20: weaviate.v1.Vectors
-	(*structpb.Struct)(nil),             // 21: google.protobuf.Struct
-}
+var (
+	file_v1_base_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+	file_v1_base_proto_msgTypes  = make([]protoimpl.MessageInfo, 18)
+	file_v1_base_proto_goTypes   = []any{
+		(ConsistencyLevel)(0),               // 0: weaviate.v1.ConsistencyLevel
+		(Filters_Operator)(0),               // 1: weaviate.v1.Filters.Operator
+		(Vectors_VectorType)(0),             // 2: weaviate.v1.Vectors.VectorType
+		(*NumberArrayProperties)(nil),       // 3: weaviate.v1.NumberArrayProperties
+		(*IntArrayProperties)(nil),          // 4: weaviate.v1.IntArrayProperties
+		(*TextArrayProperties)(nil),         // 5: weaviate.v1.TextArrayProperties
+		(*BooleanArrayProperties)(nil),      // 6: weaviate.v1.BooleanArrayProperties
+		(*ObjectPropertiesValue)(nil),       // 7: weaviate.v1.ObjectPropertiesValue
+		(*ObjectArrayProperties)(nil),       // 8: weaviate.v1.ObjectArrayProperties
+		(*ObjectProperties)(nil),            // 9: weaviate.v1.ObjectProperties
+		(*TextArray)(nil),                   // 10: weaviate.v1.TextArray
+		(*IntArray)(nil),                    // 11: weaviate.v1.IntArray
+		(*NumberArray)(nil),                 // 12: weaviate.v1.NumberArray
+		(*BooleanArray)(nil),                // 13: weaviate.v1.BooleanArray
+		(*Filters)(nil),                     // 14: weaviate.v1.Filters
+		(*FilterReferenceSingleTarget)(nil), // 15: weaviate.v1.FilterReferenceSingleTarget
+		(*FilterReferenceMultiTarget)(nil),  // 16: weaviate.v1.FilterReferenceMultiTarget
+		(*FilterReferenceCount)(nil),        // 17: weaviate.v1.FilterReferenceCount
+		(*FilterTarget)(nil),                // 18: weaviate.v1.FilterTarget
+		(*GeoCoordinatesFilter)(nil),        // 19: weaviate.v1.GeoCoordinatesFilter
+		(*Vectors)(nil),                     // 20: weaviate.v1.Vectors
+		(*structpb.Struct)(nil),             // 21: google.protobuf.Struct
+	}
+)
+
 var file_v1_base_proto_depIdxs = []int32{
 	21, // 0: weaviate.v1.ObjectPropertiesValue.non_ref_properties:type_name -> google.protobuf.Struct
 	3,  // 1: weaviate.v1.ObjectPropertiesValue.number_array_properties:type_name -> weaviate.v1.NumberArrayProperties

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -219,6 +219,70 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 			},
 		},
 		{
+			name: "filter by single-target reference",
+			req: &api.SearchRequest{
+				Filter: api.Filter{
+					Target:   []string{"performedBy", "bornIn", "population"},
+					Operator: api.FilterOperatorGreaterThanEqual,
+					Value:    400_000,
+				},
+			},
+			want: &proto.SearchRequest{
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+				Filters: &proto.Filters{
+					Target: &proto.FilterTarget{
+						Target: &proto.FilterTarget_SingleTarget{
+							SingleTarget: &proto.FilterReferenceSingleTarget{
+								On: "performedBy",
+								Target: &proto.FilterTarget{
+									Target: &proto.FilterTarget_SingleTarget{
+										SingleTarget: &proto.FilterReferenceSingleTarget{
+											On:     "bornIn",
+											Target: propertyTarget("population"),
+										},
+									},
+								},
+							},
+						},
+					},
+					Operator:  proto.Filters_OPERATOR_GREATER_THAN_EQUAL,
+					TestValue: &proto.Filters_ValueInt{ValueInt: 400_000},
+				},
+			},
+		},
+		{
+			name: "filter by multi-target references",
+			req: &api.SearchRequest{
+				Filter: api.Filter{
+					Target:   []string{"hasAwards", "GrammyAward", "weight_kg"},
+					Operator: api.FilterOperatorEqual,
+					Value:    2.3,
+				},
+			},
+			want: &proto.SearchRequest{
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+				Filters: &proto.Filters{
+					Target: &proto.FilterTarget{
+						Target: &proto.FilterTarget_MultiTarget{
+							MultiTarget: &proto.FilterReferenceMultiTarget{
+								On:               "hasAwards",
+								TargetCollection: "GrammyAward",
+								Target:           propertyTarget("weight_kg"),
+							},
+						},
+					},
+					Operator:  proto.Filters_OPERATOR_EQUAL,
+					TestValue: &proto.Filters_ValueNumber{ValueNumber: 2.3},
+				},
+			},
+		},
+		{
 			name: "return metadata",
 			req: &api.SearchRequest{
 				ReturnMetadata: api.ReturnMetadata{

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -64,6 +64,14 @@ var (
 )
 
 func TestSearchRequest_MarshalMessage(t *testing.T) {
+	propertyTarget := func(s string) *proto.FilterTarget {
+		return &proto.FilterTarget{
+			Target: &proto.FilterTarget_Property{
+				Property: s,
+			},
+		}
+	}
+
 	// UUID is always included in the [proto.MetadataRequest].
 	testMessageMarshaler(t, []MessageMarshalerTest[proto.SearchRequest, proto.SearchReply]{
 		{
@@ -90,6 +98,123 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 				After:            uuid.Max.String(),
 				Properties: &proto.PropertiesRequest{
 					ReturnAllNonrefProperties: true,
+				},
+			},
+		},
+		{
+			name: "filter by property",
+			req: &api.SearchRequest{
+				Filter: api.Filter{
+					Operator: api.FilterOperatorAnd,
+					Exprs: []api.Filter{
+						{
+							Target:   []string{"duration_sec"},
+							Operator: api.FilterOperatorGreaterThan,
+							Value:    123,
+						},
+						{
+							Target:   []string{"release_date"},
+							Operator: api.FilterOperatorLessThanEqual,
+							Value:    testkit.Now,
+						},
+						{
+							Operator: api.FilterOperatorOr,
+							Exprs: []api.Filter{
+								{
+									Target:   []string{"album"},
+									Operator: api.FilterOperatorEqual,
+									Value:    "Youthanasia",
+								},
+								{
+									Target:   []string{"isSingle"},
+									Operator: api.FilterOperatorEqual,
+									Value:    true,
+								},
+							},
+						},
+						{
+							Operator: api.FilterOperatorNot,
+							Exprs: []api.Filter{{
+								Target:   []string{"tags"},
+								Operator: api.FilterOperatorContainsAll,
+								Value:    []string{"#soul", "#grime"},
+							}},
+						},
+						{Operator: api.FilterOperatorAnd},
+					},
+				},
+			},
+			want: &proto.SearchRequest{
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+				Filters: &proto.Filters{
+					Operator: proto.Filters_OPERATOR_AND,
+					Filters: []*proto.Filters{
+						{
+							Target:    propertyTarget("duration_sec"),
+							Operator:  proto.Filters_OPERATOR_GREATER_THAN,
+							TestValue: &proto.Filters_ValueInt{ValueInt: 123},
+						},
+						{
+							Target:    propertyTarget("release_date"),
+							Operator:  proto.Filters_OPERATOR_LESS_THAN_EQUAL,
+							TestValue: &proto.Filters_ValueText{ValueText: testkit.Now.Format(api.TimeLayout)},
+						},
+						{
+							Operator: proto.Filters_OPERATOR_OR,
+							Filters: []*proto.Filters{
+								{
+									Target:    propertyTarget("album"),
+									Operator:  proto.Filters_OPERATOR_EQUAL,
+									TestValue: &proto.Filters_ValueText{ValueText: "Youthanasia"},
+								},
+								{
+									Target:    propertyTarget("isSingle"),
+									Operator:  proto.Filters_OPERATOR_EQUAL,
+									TestValue: &proto.Filters_ValueBoolean{ValueBoolean: true},
+								},
+							},
+						},
+						{
+							Operator: proto.Filters_OPERATOR_NOT,
+							Filters: []*proto.Filters{{
+								Target:   propertyTarget("tags"),
+								Operator: proto.Filters_OPERATOR_CONTAINS_ALL,
+								TestValue: &proto.Filters_ValueTextArray{
+									ValueTextArray: &proto.TextArray{Values: []string{"#soul", "#grime"}},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "filter by reference count",
+			req: &api.SearchRequest{
+				Filter: api.Filter{
+					Target:   []string{"count(hasAwards)"},
+					Operator: api.FilterOperatorGreaterThanEqual,
+					Value:    4,
+				},
+			},
+			want: &proto.SearchRequest{
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+				Filters: &proto.Filters{
+					Target: &proto.FilterTarget{
+						Target: &proto.FilterTarget_Count{
+							Count: &proto.FilterReferenceCount{
+								On: "hasAwards",
+							},
+						},
+					},
+					Operator:  proto.Filters_OPERATOR_GREATER_THAN_EQUAL,
+					TestValue: &proto.Filters_ValueInt{ValueInt: 4},
 				},
 			},
 		},

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -104,9 +104,9 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 		{
 			name: "filter by property",
 			req: &api.SearchRequest{
-				Filter: api.Filter{
+				Filter: api.FilterExpr{
 					Operator: api.FilterOperatorAnd,
-					Exprs: []api.Filter{
+					Exprs: []api.FilterExpr{
 						{
 							Target:   []string{"duration_sec"},
 							Operator: api.FilterOperatorGreaterThan,
@@ -119,7 +119,7 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 						},
 						{
 							Operator: api.FilterOperatorOr,
-							Exprs: []api.Filter{
+							Exprs: []api.FilterExpr{
 								{
 									Target:   []string{"album"},
 									Operator: api.FilterOperatorEqual,
@@ -134,7 +134,7 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 						},
 						{
 							Operator: api.FilterOperatorNot,
-							Exprs: []api.Filter{{
+							Exprs: []api.FilterExpr{{
 								Target:   []string{"tags"},
 								Operator: api.FilterOperatorContainsAll,
 								Value:    []string{"#soul", "#grime"},
@@ -194,7 +194,7 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 		{
 			name: "filter by reference count",
 			req: &api.SearchRequest{
-				Filter: api.Filter{
+				Filter: api.FilterExpr{
 					Target:   []string{"count(hasAwards)"},
 					Operator: api.FilterOperatorGreaterThanEqual,
 					Value:    4,
@@ -221,7 +221,7 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 		{
 			name: "filter by single-target reference",
 			req: &api.SearchRequest{
-				Filter: api.Filter{
+				Filter: api.FilterExpr{
 					Target:   []string{"performedBy", "bornIn", "population"},
 					Operator: api.FilterOperatorGreaterThanEqual,
 					Value:    400_000,
@@ -256,7 +256,7 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 		{
 			name: "filter by multi-target references",
 			req: &api.SearchRequest{
-				Filter: api.Filter{
+				Filter: api.FilterExpr{
 					Target:   []string{"hasAwards", "GrammyAward", "weight_kg"},
 					Operator: api.FilterOperatorEqual,
 					Value:    2.3,

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -257,7 +257,7 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 			name: "filter by multi-target references",
 			req: &api.SearchRequest{
 				Filter: api.FilterExpr{
-					Target:   []string{"hasAwards", "GrammyAward", "weight_kg"},
+					Target:   []string{api.MultiTargetReference("hasAwards", "GrammyAward"), "weight_kg"},
 					Operator: api.FilterOperatorEqual,
 					Value:    2.3,
 				},

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -712,3 +712,21 @@ func (cl ConsistencyLevel) proto() *proto.ConsistencyLevel {
 		return nil
 	}
 }
+
+type FilterOperator proto.Filters_Operator
+
+const (
+	FilterOperatorNot              FilterOperator = FilterOperator(proto.Filters_OPERATOR_NOT)
+	FilterOperatorAnd              FilterOperator = FilterOperator(proto.Filters_OPERATOR_AND)
+	FilterOperatorOr               FilterOperator = FilterOperator(proto.Filters_OPERATOR_OR)
+	FilterOperatorEqual            FilterOperator = FilterOperator(proto.Filters_OPERATOR_EQUAL)
+	FilterOperatorLessThan         FilterOperator = FilterOperator(proto.Filters_OPERATOR_LESS_THAN)
+	FilterOperatorLessThanEqual    FilterOperator = FilterOperator(proto.Filters_OPERATOR_LESS_THAN_EQUAL)
+	FilterOperatorGreaterThan      FilterOperator = FilterOperator(proto.Filters_OPERATOR_GREATER_THAN)
+	FilterOperatorGreaterThanEqual FilterOperator = FilterOperator(proto.Filters_OPERATOR_GREATER_THAN_EQUAL)
+	FilterOperatorLike             FilterOperator = FilterOperator(proto.Filters_OPERATOR_LIKE)
+	FilterOperatorIsNull           FilterOperator = FilterOperator(proto.Filters_OPERATOR_IS_NULL)
+	FilterOperatorContainsAll      FilterOperator = FilterOperator(proto.Filters_OPERATOR_CONTAINS_ALL)
+	FilterOperatorContainsAny      FilterOperator = FilterOperator(proto.Filters_OPERATOR_CONTAINS_ANY)
+	FilterOperatorContainsNone     FilterOperator = FilterOperator(proto.Filters_OPERATOR_CONTAINS_NONE)
+)

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"slices"
 	"time"
+	"unicode"
 
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
@@ -44,6 +45,12 @@ func (r *SearchRequest) Method() transport.MethodFunc[proto.SearchRequest, proto
 func (r *SearchRequest) Body() transport.MessageMarshaler[proto.SearchRequest] { return r }
 
 type (
+	Filter struct {
+		Operator FilterOperator
+		Exprs    []Filter // Sub-expressions of logical operators AND/OR/NOT.
+		Target   []string // Target of a comparison expression, i.e. property, reference.
+		Value    any      // Test value appropriate for the target data type.
+	}
 	ReturnMetadata struct {
 		CreatedAt    bool
 		LastUpdateAt bool
@@ -263,6 +270,181 @@ func marshalReturnVectors(req *proto.MetadataRequest, vectors []string) {
 		req.Vectors = nil
 	} else {
 		req.Vectors = vectors
+	}
+}
+
+// referenceCountRe matches property names wrapped in the count() "operator".
+// If FindStringSubmatch returns a slice with 2 items, the pattern was matched,
+// and the original property name is the second item.
+var referenceCountRe = regexp.MustCompile(`count\((.*)\)`)
+
+func marshalFilter(f Filter) *proto.Filters {
+	var pf proto.Filters
+
+	switch f.Operator {
+
+	// Logical operators AND, OR, and NOT  have a list of sub-expressions, and no target.
+	case FilterOperatorAnd, FilterOperatorOr, FilterOperatorNot:
+		var fs []*proto.Filters
+		for _, expr := range f.Exprs {
+			if f := marshalFilter(expr); f != nil {
+				fs = append(fs, f)
+			}
+		}
+
+		// Using AND/OR/NOT with an empty list of sub-expressions is not
+		// a mistake, but omitting such will save a few bits on the wire.
+		if len(fs) == 0 {
+			return nil
+		}
+		pf.Filters = fs
+
+	// All other operators are comparison operators with a target and a test value.
+	default:
+		pf.Target = marshalFilterTarget(f.Target)
+		if pf.Target == nil { // A filter with nil target is not useful.
+			return nil
+		}
+
+		// The values should've really been [structpb.Value].
+		// Marshaling it would've been as simple as [structpb.NewValue].
+		switch v := f.Value.(type) {
+		case nil:
+			return nil // Null-ness should be checked via [FilterOperatorIsNull].
+		case string:
+			pf.TestValue = &proto.Filters_ValueText{ValueText: v}
+		case []string:
+			pf.TestValue = &proto.Filters_ValueTextArray{
+				ValueTextArray: &proto.TextArray{Values: v},
+			}
+		case time.Time:
+			// Date values are passed as formatted date strings.
+			pf.TestValue = &proto.Filters_ValueText{ValueText: v.Format(TimeLayout)}
+		case bool:
+			pf.TestValue = &proto.Filters_ValueBoolean{ValueBoolean: v}
+		case []bool:
+			pf.TestValue = &proto.Filters_ValueBooleanArray{
+				ValueBooleanArray: &proto.BooleanArray{Values: v},
+			}
+
+		// Integer values must be cast to int64 before marshaling.
+		// structpb package supports uints, but those are probably
+		// quite rare in the use cases where Weaviate is used, so
+		// we ignore them.
+		case int:
+			pf.TestValue = &proto.Filters_ValueInt{ValueInt: int64(v)}
+		case int32:
+			pf.TestValue = &proto.Filters_ValueInt{ValueInt: int64(v)}
+		case int64:
+			pf.TestValue = &proto.Filters_ValueInt{ValueInt: v}
+		case []int:
+			values := make([]int64, len(v))
+			for i := range v {
+				values[i] = int64(v[i])
+			}
+			pf.TestValue = &proto.Filters_ValueIntArray{
+				ValueIntArray: &proto.IntArray{Values: values},
+			}
+		case []int32:
+			values := make([]int64, len(v))
+			for i := range v {
+				values[i] = int64(v[i])
+			}
+			pf.TestValue = &proto.Filters_ValueIntArray{
+				ValueIntArray: &proto.IntArray{Values: values},
+			}
+		case []int64:
+			pf.TestValue = &proto.Filters_ValueIntArray{
+				ValueIntArray: &proto.IntArray{Values: v},
+			}
+
+		// Float values must be cast to float64 before marshaling.
+		case float32:
+			pf.TestValue = &proto.Filters_ValueNumber{ValueNumber: float64(v)}
+		case float64:
+			pf.TestValue = &proto.Filters_ValueNumber{ValueNumber: v}
+
+		case []float32:
+			values := make([]float64, len(v))
+			for i := range v {
+				values[i] = float64(v[i])
+			}
+			pf.TestValue = &proto.Filters_ValueNumberArray{
+				ValueNumberArray: &proto.NumberArray{Values: values},
+			}
+		case []float64:
+			pf.TestValue = &proto.Filters_ValueNumberArray{
+				ValueNumberArray: &proto.NumberArray{Values: v},
+			}
+		default:
+			// TODO(dyma): add GeoCoordinates property
+			panic(fmt.Sprintf("%T are not supported", v))
+		}
+	}
+
+	pf.Operator = proto.Filters_Operator(f.Operator)
+	return &pf
+}
+
+func marshalFilterTarget(path []string) *proto.FilterTarget {
+	switch len(path) {
+	case 0:
+		// An empty target is not valid. We do not return an error here
+		// because the client does not validate intpus and because empty
+		// path is a possible scenario in the recursive case (see default).
+		return nil
+	case 1:
+		// The server allows using property lenght as a filter property
+		// by wrapping its name in the len() operator, e.g. len(tags).
+		// This package extends that with a count() operator, which
+		// allows using reference count as the property. This requires
+		// the property name to be sent in the [proto.FilterTarget_Count] message.
+		property := path[0]
+		if count := referenceCountRe.FindStringSubmatch(property); len(count) == 2 {
+			return &proto.FilterTarget{
+				Target: &proto.FilterTarget_Count{
+					Count: &proto.FilterReferenceCount{
+						On: count[1],
+					},
+				},
+			}
+		} else {
+			return &proto.FilterTarget{
+				Target: &proto.FilterTarget_Property{
+					Property: property,
+				},
+			}
+		}
+	default:
+		// Here we can be sure that path has more than 1 item.
+		// If the second item starts with an uppercase letter,
+		// assume it's a collection name and marshal referenceProperty
+		// as a multi-target reference.
+		// Continue marshaling the remainder of the path recursively
+		// until the last element is a property or a count() expression.
+		referenceProperty, path := path[0], path[1:]
+		if unicode.IsUpper(rune(path[0][0])) {
+			collection, path := path[0], path[1:]
+			return &proto.FilterTarget{
+				Target: &proto.FilterTarget_MultiTarget{
+					MultiTarget: &proto.FilterReferenceMultiTarget{
+						On:               referenceProperty,
+						TargetCollection: collection,
+						Target:           marshalFilterTarget(path),
+					},
+				},
+			}
+		} else {
+			return &proto.FilterTarget{
+				Target: &proto.FilterTarget_SingleTarget{
+					SingleTarget: &proto.FilterReferenceSingleTarget{
+						On:     referenceProperty,
+						Target: marshalFilterTarget(path),
+					},
+				},
+			}
+		}
+
 	}
 }
 
@@ -716,13 +898,6 @@ func (cl ConsistencyLevel) proto() *proto.ConsistencyLevel {
 	}
 }
 
-type Filter struct {
-	Operator FilterOperator
-	Exprs    []Filter
-	Target   []string
-	Value    any
-}
-
 type FilterOperator proto.Filters_Operator
 
 const (
@@ -740,112 +915,3 @@ const (
 	FilterOperatorContainsAny      FilterOperator = FilterOperator(proto.Filters_OPERATOR_CONTAINS_ANY)
 	FilterOperatorContainsNone     FilterOperator = FilterOperator(proto.Filters_OPERATOR_CONTAINS_NONE)
 )
-
-var countRe = regexp.MustCompile(`count\((.*)\)`)
-
-func marshalFilter(f Filter) *proto.Filters {
-	pf := proto.Filters{
-		Operator: proto.Filters_Operator(f.Operator),
-	}
-	switch f.Operator {
-	case FilterOperatorAnd, FilterOperatorOr, FilterOperatorNot:
-		var fs []*proto.Filters
-		for _, expr := range f.Exprs {
-			if f := marshalFilter(expr); f != nil {
-				fs = append(fs, f)
-			}
-		}
-		if len(fs) == 0 {
-			return nil
-		}
-		pf.Filters = fs
-	default:
-		switch len(f.Target) {
-		case 0:
-			return nil
-		case 1:
-			target := f.Target[0]
-			if sub := countRe.FindStringSubmatch(target); len(sub) == 2 {
-				pf.Target = &proto.FilterTarget{
-					Target: &proto.FilterTarget_Count{
-						Count: &proto.FilterReferenceCount{
-							On: sub[1],
-						},
-					},
-				}
-			} else {
-				// TODO(dyma): handle count(property) target
-				pf.Target = &proto.FilterTarget{
-					Target: &proto.FilterTarget_Property{
-						Property: target,
-					},
-				}
-			}
-		default:
-			// TODO(dyma): handle reference targets
-		}
-
-		switch v := f.Value.(type) {
-		case string:
-			pf.TestValue = &proto.Filters_ValueText{ValueText: v}
-		case time.Time:
-			pf.TestValue = &proto.Filters_ValueText{ValueText: v.Format(TimeLayout)}
-		case bool:
-			pf.TestValue = &proto.Filters_ValueBoolean{ValueBoolean: v}
-		case int:
-			pf.TestValue = &proto.Filters_ValueInt{ValueInt: int64(v)}
-		case int32:
-			pf.TestValue = &proto.Filters_ValueInt{ValueInt: int64(v)}
-		case int64:
-			pf.TestValue = &proto.Filters_ValueInt{ValueInt: v}
-		case float32:
-			pf.TestValue = &proto.Filters_ValueNumber{ValueNumber: float64(v)}
-		case float64:
-			pf.TestValue = &proto.Filters_ValueNumber{ValueNumber: v}
-		case []string:
-			pf.TestValue = &proto.Filters_ValueTextArray{
-				ValueTextArray: &proto.TextArray{Values: v},
-			}
-		case []bool:
-			pf.TestValue = &proto.Filters_ValueBooleanArray{
-				ValueBooleanArray: &proto.BooleanArray{Values: v},
-			}
-		case []int:
-			values := make([]int64, len(v))
-			for i := range v {
-				values[i] = int64(v[i])
-			}
-			pf.TestValue = &proto.Filters_ValueIntArray{
-				ValueIntArray: &proto.IntArray{Values: values},
-			}
-		case []int32:
-			values := make([]int64, len(v))
-			for i := range v {
-				values[i] = int64(v[i])
-			}
-			pf.TestValue = &proto.Filters_ValueIntArray{
-				ValueIntArray: &proto.IntArray{Values: values},
-			}
-		case []int64:
-			pf.TestValue = &proto.Filters_ValueIntArray{
-				ValueIntArray: &proto.IntArray{Values: v},
-			}
-		case []float32:
-			values := make([]float64, len(v))
-			for i := range v {
-				values[i] = float64(v[i])
-			}
-			pf.TestValue = &proto.Filters_ValueNumberArray{
-				ValueNumberArray: &proto.NumberArray{Values: values},
-			}
-		case []float64:
-			pf.TestValue = &proto.Filters_ValueNumberArray{
-				ValueNumberArray: &proto.NumberArray{Values: v},
-			}
-		default:
-			panic("GeoProperties are not supported")
-		}
-	}
-
-	return &pf
-}

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"time"
 
@@ -20,6 +21,7 @@ type SearchRequest struct {
 	Offset           int32
 	AutoLimit        int32
 	After            uuid.UUID
+	Filter           Filter
 	ReturnProperties []ReturnProperty
 	ReturnReferences []ReturnReference
 	ReturnVectors    []string
@@ -144,6 +146,7 @@ func (r *SearchRequest) MarshalMessage() (*proto.SearchRequest, error) {
 		Offset:           uint32(r.Offset),
 		Autocut:          uint32(r.AutoLimit),
 		After:            after,
+		Filters:          marshalFilter(r.Filter),
 		Metadata: &proto.MetadataRequest{
 			Uuid:               true,
 			Distance:           r.ReturnMetadata.Distance,
@@ -713,6 +716,13 @@ func (cl ConsistencyLevel) proto() *proto.ConsistencyLevel {
 	}
 }
 
+type Filter struct {
+	Operator FilterOperator
+	Exprs    []Filter
+	Target   []string
+	Value    any
+}
+
 type FilterOperator proto.Filters_Operator
 
 const (
@@ -730,3 +740,112 @@ const (
 	FilterOperatorContainsAny      FilterOperator = FilterOperator(proto.Filters_OPERATOR_CONTAINS_ANY)
 	FilterOperatorContainsNone     FilterOperator = FilterOperator(proto.Filters_OPERATOR_CONTAINS_NONE)
 )
+
+var countRe = regexp.MustCompile(`count\((.*)\)`)
+
+func marshalFilter(f Filter) *proto.Filters {
+	pf := proto.Filters{
+		Operator: proto.Filters_Operator(f.Operator),
+	}
+	switch f.Operator {
+	case FilterOperatorAnd, FilterOperatorOr, FilterOperatorNot:
+		var fs []*proto.Filters
+		for _, expr := range f.Exprs {
+			if f := marshalFilter(expr); f != nil {
+				fs = append(fs, f)
+			}
+		}
+		if len(fs) == 0 {
+			return nil
+		}
+		pf.Filters = fs
+	default:
+		switch len(f.Target) {
+		case 0:
+			return nil
+		case 1:
+			target := f.Target[0]
+			if sub := countRe.FindStringSubmatch(target); len(sub) == 2 {
+				pf.Target = &proto.FilterTarget{
+					Target: &proto.FilterTarget_Count{
+						Count: &proto.FilterReferenceCount{
+							On: sub[1],
+						},
+					},
+				}
+			} else {
+				// TODO(dyma): handle count(property) target
+				pf.Target = &proto.FilterTarget{
+					Target: &proto.FilterTarget_Property{
+						Property: target,
+					},
+				}
+			}
+		default:
+			// TODO(dyma): handle reference targets
+		}
+
+		switch v := f.Value.(type) {
+		case string:
+			pf.TestValue = &proto.Filters_ValueText{ValueText: v}
+		case time.Time:
+			pf.TestValue = &proto.Filters_ValueText{ValueText: v.Format(TimeLayout)}
+		case bool:
+			pf.TestValue = &proto.Filters_ValueBoolean{ValueBoolean: v}
+		case int:
+			pf.TestValue = &proto.Filters_ValueInt{ValueInt: int64(v)}
+		case int32:
+			pf.TestValue = &proto.Filters_ValueInt{ValueInt: int64(v)}
+		case int64:
+			pf.TestValue = &proto.Filters_ValueInt{ValueInt: v}
+		case float32:
+			pf.TestValue = &proto.Filters_ValueNumber{ValueNumber: float64(v)}
+		case float64:
+			pf.TestValue = &proto.Filters_ValueNumber{ValueNumber: v}
+		case []string:
+			pf.TestValue = &proto.Filters_ValueTextArray{
+				ValueTextArray: &proto.TextArray{Values: v},
+			}
+		case []bool:
+			pf.TestValue = &proto.Filters_ValueBooleanArray{
+				ValueBooleanArray: &proto.BooleanArray{Values: v},
+			}
+		case []int:
+			values := make([]int64, len(v))
+			for i := range v {
+				values[i] = int64(v[i])
+			}
+			pf.TestValue = &proto.Filters_ValueIntArray{
+				ValueIntArray: &proto.IntArray{Values: values},
+			}
+		case []int32:
+			values := make([]int64, len(v))
+			for i := range v {
+				values[i] = int64(v[i])
+			}
+			pf.TestValue = &proto.Filters_ValueIntArray{
+				ValueIntArray: &proto.IntArray{Values: values},
+			}
+		case []int64:
+			pf.TestValue = &proto.Filters_ValueIntArray{
+				ValueIntArray: &proto.IntArray{Values: v},
+			}
+		case []float32:
+			values := make([]float64, len(v))
+			for i := range v {
+				values[i] = float64(v[i])
+			}
+			pf.TestValue = &proto.Filters_ValueNumberArray{
+				ValueNumberArray: &proto.NumberArray{Values: values},
+			}
+		case []float64:
+			pf.TestValue = &proto.Filters_ValueNumberArray{
+				ValueNumberArray: &proto.NumberArray{Values: v},
+			}
+		default:
+			panic("GeoProperties are not supported")
+		}
+	}
+
+	return &pf
+}

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -915,3 +915,7 @@ const (
 	FilterOperatorContainsAny      FilterOperator = FilterOperator(proto.Filters_OPERATOR_CONTAINS_ANY)
 	FilterOperatorContainsNone     FilterOperator = FilterOperator(proto.Filters_OPERATOR_CONTAINS_NONE)
 )
+
+func (o FilterOperator) String() string {
+	return proto.Filters_Operator(o).String()
+}

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -422,6 +422,12 @@ func marshalFilterTarget(path []string) *proto.FilterTarget {
 		// as a multi-target reference.
 		// Continue marshaling the remainder of the path recursively
 		// until the last element is a property or a count() expression.
+		//
+		// TODO(dyma): Weaviate might not enforce that properties be lowercase,
+		// in which case (no pun intended), we may accidentally confuse a property
+		// for a name of the collection. Instead, we could use some special formatting
+		// like 'property#Collection' for multi-target references and search for #
+		// in the path element rather than checking IsUpper.
 		referenceProperty, path := path[0], path[1:]
 		if unicode.IsUpper(rune(path[0][0])) {
 			collection, path := path[0], path[1:]

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -394,7 +394,7 @@ func marshalFilterTarget(path []string) *proto.FilterTarget {
 		// path is a possible scenario in the recursive case (see default).
 		return nil
 	case 1:
-		// The server allows using property lenght as a filter property
+		// The server allows using property length as a filter property
 		// by wrapping its name in the len() operator, e.g. len(tags).
 		// This package extends that with a count() operator, which
 		// allows using reference count as the property. This requires
@@ -444,7 +444,6 @@ func marshalFilterTarget(path []string) *proto.FilterTarget {
 				},
 			}
 		}
-
 	}
 }
 

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -22,7 +22,7 @@ type SearchRequest struct {
 	Offset           int32
 	AutoLimit        int32
 	After            uuid.UUID
-	Filter           Filter
+	Filter           FilterExpr
 	ReturnProperties []ReturnProperty
 	ReturnReferences []ReturnReference
 	ReturnVectors    []string
@@ -45,11 +45,11 @@ func (r *SearchRequest) Method() transport.MethodFunc[proto.SearchRequest, proto
 func (r *SearchRequest) Body() transport.MessageMarshaler[proto.SearchRequest] { return r }
 
 type (
-	Filter struct {
+	FilterExpr struct {
 		Operator FilterOperator
-		Exprs    []Filter // Sub-expressions of logical operators AND/OR/NOT.
-		Target   []string // Target of a comparison expression, i.e. property, reference.
-		Value    any      // Test value appropriate for the target data type.
+		Exprs    []FilterExpr // Sub-expressions of logical operators AND/OR/NOT.
+		Target   []string     // Target of a comparison expression, i.e. property, reference.
+		Value    any          // Test value appropriate for the target data type.
 	}
 	ReturnMetadata struct {
 		CreatedAt    bool
@@ -278,7 +278,7 @@ func marshalReturnVectors(req *proto.MetadataRequest, vectors []string) {
 // and the original property name is the second item.
 var referenceCountRe = regexp.MustCompile(`count\((.*)\)`)
 
-func marshalFilter(f Filter) *proto.Filters {
+func marshalFilter(f FilterExpr) *proto.Filters {
 	var pf proto.Filters
 
 	switch f.Operator {
@@ -901,19 +901,19 @@ func (cl ConsistencyLevel) proto() *proto.ConsistencyLevel {
 type FilterOperator proto.Filters_Operator
 
 const (
-	FilterOperatorNot              FilterOperator = FilterOperator(proto.Filters_OPERATOR_NOT)
-	FilterOperatorAnd              FilterOperator = FilterOperator(proto.Filters_OPERATOR_AND)
-	FilterOperatorOr               FilterOperator = FilterOperator(proto.Filters_OPERATOR_OR)
-	FilterOperatorEqual            FilterOperator = FilterOperator(proto.Filters_OPERATOR_EQUAL)
-	FilterOperatorLessThan         FilterOperator = FilterOperator(proto.Filters_OPERATOR_LESS_THAN)
-	FilterOperatorLessThanEqual    FilterOperator = FilterOperator(proto.Filters_OPERATOR_LESS_THAN_EQUAL)
-	FilterOperatorGreaterThan      FilterOperator = FilterOperator(proto.Filters_OPERATOR_GREATER_THAN)
-	FilterOperatorGreaterThanEqual FilterOperator = FilterOperator(proto.Filters_OPERATOR_GREATER_THAN_EQUAL)
-	FilterOperatorLike             FilterOperator = FilterOperator(proto.Filters_OPERATOR_LIKE)
-	FilterOperatorIsNull           FilterOperator = FilterOperator(proto.Filters_OPERATOR_IS_NULL)
-	FilterOperatorContainsAll      FilterOperator = FilterOperator(proto.Filters_OPERATOR_CONTAINS_ALL)
-	FilterOperatorContainsAny      FilterOperator = FilterOperator(proto.Filters_OPERATOR_CONTAINS_ANY)
-	FilterOperatorContainsNone     FilterOperator = FilterOperator(proto.Filters_OPERATOR_CONTAINS_NONE)
+	FilterOperatorNot              = FilterOperator(proto.Filters_OPERATOR_NOT)
+	FilterOperatorAnd              = FilterOperator(proto.Filters_OPERATOR_AND)
+	FilterOperatorOr               = FilterOperator(proto.Filters_OPERATOR_OR)
+	FilterOperatorEqual            = FilterOperator(proto.Filters_OPERATOR_EQUAL)
+	FilterOperatorLessThan         = FilterOperator(proto.Filters_OPERATOR_LESS_THAN)
+	FilterOperatorLessThanEqual    = FilterOperator(proto.Filters_OPERATOR_LESS_THAN_EQUAL)
+	FilterOperatorGreaterThan      = FilterOperator(proto.Filters_OPERATOR_GREATER_THAN)
+	FilterOperatorGreaterThanEqual = FilterOperator(proto.Filters_OPERATOR_GREATER_THAN_EQUAL)
+	FilterOperatorLike             = FilterOperator(proto.Filters_OPERATOR_LIKE)
+	FilterOperatorIsNull           = FilterOperator(proto.Filters_OPERATOR_IS_NULL)
+	FilterOperatorContainsAll      = FilterOperator(proto.Filters_OPERATOR_CONTAINS_ALL)
+	FilterOperatorContainsAny      = FilterOperator(proto.Filters_OPERATOR_CONTAINS_ANY)
+	FilterOperatorContainsNone     = FilterOperator(proto.Filters_OPERATOR_CONTAINS_NONE)
 )
 
 func (o FilterOperator) String() string {

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strings"
 	"time"
-	"unicode"
 
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
@@ -413,6 +413,33 @@ func marshalFilter(f FilterExpr) *proto.Filters {
 	return &pf
 }
 
+// multiRefSep separates parts of the concatenated multi-target reference.
+const multiRefSep = ":"
+
+// MultiTargetReference constructs a multi-target reference such that
+// the name of the property and collection components are encoded unambiguously.
+//
+// Weaviate does not require a property name to be lowercase, so we cannot
+// rely on a heuristic a Collection being the only possible upper-case part
+// of the filter target path.
+func MultiTargetReference(property, collection string) string {
+	return property + multiRefSep + collection
+}
+
+// splitReferenceTarget returns the reference-property and collection components
+// of a reference target. If it's a single-target reference, collection is empty.
+// Otherwise, collection is the remainder of the string following [multiRefSep].
+func splitReferenceTarget(ref string) (property, collection string) {
+	parts := strings.Split(ref, multiRefSep)
+	dev.Assert(len(parts) > 0, "len(parts)")
+
+	property = parts[0]
+	if len(parts) > 1 {
+		collection = parts[1]
+	}
+	return
+}
+
 func marshalFilterTarget(path []string) *proto.FilterTarget {
 	switch len(path) {
 	case 0:
@@ -445,23 +472,17 @@ func marshalFilterTarget(path []string) *proto.FilterTarget {
 	default:
 		// Here we can be sure that path has more than 1 item.
 		// If the second item starts with an uppercase letter,
-		// assume it's a collection name and marshal referenceProperty
+		// assume it's a collection name and marshal property
 		// as a multi-target reference.
 		// Continue marshaling the remainder of the path recursively
 		// until the last element is a property or a count() expression.
-		//
-		// TODO(dyma): Weaviate might not enforce that properties be lowercase,
-		// in which case (no pun intended), we may accidentally confuse a property
-		// for a name of the collection. Instead, we could use some special formatting
-		// like 'property#Collection' for multi-target references and search for #
-		// in the path element rather than checking IsUpper.
-		referenceProperty, path := path[0], path[1:]
-		if unicode.IsUpper(rune(path[0][0])) {
-			collection, path := path[0], path[1:]
+		property, collection := splitReferenceTarget(path[0])
+		path = path[1:]
+		if collection != "" {
 			return &proto.FilterTarget{
 				Target: &proto.FilterTarget_MultiTarget{
 					MultiTarget: &proto.FilterReferenceMultiTarget{
-						On:               referenceProperty,
+						On:               property,
 						TargetCollection: collection,
 						Target:           marshalFilterTarget(path),
 					},
@@ -471,7 +492,7 @@ func marshalFilterTarget(path []string) *proto.FilterTarget {
 			return &proto.FilterTarget{
 				Target: &proto.FilterTarget_SingleTarget{
 					SingleTarget: &proto.FilterReferenceSingleTarget{
-						On:     referenceProperty,
+						On:     property,
 						Target: marshalFilterTarget(path),
 					},
 				},

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -327,10 +327,6 @@ func marshalFilter(f FilterExpr) *proto.Filters {
 				ValueBooleanArray: &proto.BooleanArray{Values: v},
 			}
 
-		// Integer values must be cast to int64 before marshaling.
-		// structpb package supports uints, but those are probably
-		// quite rare in the use cases where Weaviate is used, so
-		// we ignore them.
 		case int:
 			pf.TestValue = &proto.Filters_ValueInt{ValueInt: int64(v)}
 		case int32:
@@ -356,6 +352,37 @@ func marshalFilter(f FilterExpr) *proto.Filters {
 		case []int64:
 			pf.TestValue = &proto.Filters_ValueIntArray{
 				ValueIntArray: &proto.IntArray{Values: v},
+			}
+
+		case uint:
+			pf.TestValue = &proto.Filters_ValueInt{ValueInt: int64(v)}
+		case uint32:
+			pf.TestValue = &proto.Filters_ValueInt{ValueInt: int64(v)}
+		case uint64:
+			pf.TestValue = &proto.Filters_ValueInt{ValueInt: int64(v)}
+		case []uint:
+			values := make([]int64, len(v))
+			for i := range v {
+				values[i] = int64(v[i])
+			}
+			pf.TestValue = &proto.Filters_ValueIntArray{
+				ValueIntArray: &proto.IntArray{Values: values},
+			}
+		case []uint32:
+			values := make([]int64, len(v))
+			for i := range v {
+				values[i] = int64(v[i])
+			}
+			pf.TestValue = &proto.Filters_ValueIntArray{
+				ValueIntArray: &proto.IntArray{Values: values},
+			}
+		case []uint64:
+			values := make([]int64, len(v))
+			for i := range v {
+				values[i] = int64(v[i])
+			}
+			pf.TestValue = &proto.Filters_ValueIntArray{
+				ValueIntArray: &proto.IntArray{Values: values},
 			}
 
 		// Float values must be cast to float64 before marshaling.

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -431,7 +431,9 @@ func MultiTargetReference(property, collection string) string {
 // Otherwise, collection is the remainder of the string following [multiRefSep].
 func splitReferenceTarget(ref string) (property, collection string) {
 	parts := strings.Split(ref, multiRefSep)
-	dev.Assert(len(parts) > 0, "len(parts)")
+
+	// multiRefSep is not an empty string, so parts will always be non-empty.
+	dev.Assert(len(parts) > 0, "len(reference path)")
 
 	property = parts[0]
 	if len(parts) > 1 {

--- a/internal/time.go
+++ b/internal/time.go
@@ -1,5 +1,0 @@
-package internal
-
-import "time"
-
-const TimeFormat = time.RFC3339Nano

--- a/query/client.go
+++ b/query/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
+	"github.com/weaviate/weaviate-go-client/v6/query/filter"
 	"github.com/weaviate/weaviate-go-client/v6/types"
 )
 
@@ -110,6 +111,7 @@ type request struct {
 	Offset                 int32
 	AutoLimit              int32
 	After                  uuid.UUID
+	Filter                 filter.Expr
 	ReturnMetadata         ReturnMetadata
 	ReturnVectors          []string
 	ReturnReferences       []Reference
@@ -125,6 +127,7 @@ func query(ctx context.Context, t internal.Transport, r request, f func(*api.Sea
 		AutoLimit:        r.AutoLimit,
 		Offset:           r.Offset,
 		After:            r.After,
+		Filter:           marshalFilter(r.Filter),
 		ReturnVectors:    r.ReturnVectors,
 		ReturnMetadata:   api.ReturnMetadata(r.ReturnMetadata),
 		ReturnProperties: marshalReturnProperties(r.ReturnProperties, r.ReturnNestedProperties),
@@ -220,6 +223,23 @@ func marshalReturnReferences(in []Reference) []api.ReturnReference {
 		}
 	}
 	return out
+}
+
+func marshalFilter(expr filter.Expr) api.Filter {
+	if expr == nil {
+		return api.Filter{}
+	}
+	f := api.Filter{
+		Operator: expr.Operator(),
+		Target:   expr.Target(),
+		Value:    expr.Value(),
+	}
+
+	for _, e := range expr.Exprs() {
+		f.Exprs = append(f.Exprs, marshalFilter(e))
+	}
+
+	return f
 }
 
 func marshalSearchTarget(target VectorTarget) api.SearchTarget {

--- a/query/client.go
+++ b/query/client.go
@@ -127,11 +127,16 @@ func query(ctx context.Context, t internal.Transport, r request, f func(*api.Sea
 		AutoLimit:        r.AutoLimit,
 		Offset:           r.Offset,
 		After:            r.After,
-		Filter:           marshalFilter(r.Filter),
 		ReturnVectors:    r.ReturnVectors,
 		ReturnMetadata:   api.ReturnMetadata(r.ReturnMetadata),
 		ReturnProperties: marshalReturnProperties(r.ReturnProperties, r.ReturnNestedProperties),
 		ReturnReferences: marshalReturnReferences(r.ReturnReferences),
+	}
+
+	if r.Filter != nil {
+		if expr := r.Filter.Expr(); expr != nil {
+			req.Filter = *expr
+		}
 	}
 
 	f(req)
@@ -223,23 +228,6 @@ func marshalReturnReferences(in []Reference) []api.ReturnReference {
 		}
 	}
 	return out
-}
-
-func marshalFilter(expr filter.Expr) api.Filter {
-	if expr == nil {
-		return api.Filter{}
-	}
-	f := api.Filter{
-		Operator: expr.Operator(),
-		Target:   expr.Target(),
-		Value:    expr.Value(),
-	}
-
-	for _, e := range expr.Exprs() {
-		f.Exprs = append(f.Exprs, marshalFilter(e))
-	}
-
-	return f
 }
 
 func marshalSearchTarget(target VectorTarget) api.SearchTarget {

--- a/query/filter/filter.go
+++ b/query/filter/filter.go
@@ -7,17 +7,33 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 )
 
-// NB(dyma): These need to be public interface methods, because we want the `query`
-// package to be able to marshal filters independently
+// Expr describes a filter exression. Expressions can be combined into [And] and [Or] groups.
 type Expr interface {
-	Operator() api.FilterOperator // api.FilterOperator
-	Exprs() []Expr                // For AND/OR
+	Operator() api.FilterOperator
+	Exprs() []Expr // For AND/OR
 
 	Target() []string
 	Value() any
 }
 
-func Property[T any](property string) Builder[T] { return target[T]{property} }
+// Property constructs the left-hand side of the filter expression.
+// It is representsed as a path to the filter property:
+//
+//   - For regular properties, it is the name of the target property.
+//   - For properties belonging to a single-target reference, it is
+//     then name of the reference property followed by the name of
+//     the target property, arbitrarily nested.
+//   - For properties belonging to a multi-target reference, it is
+//     the name of the reference property followed by the name of
+//     the target collection and the property therein, arbitrarily nested.
+//
+// Example:
+//
+//	filter.Property("album") // Property "album" of the root Songs collection
+//	filter.Property("performedBy", "given_name") // Property "given_name" of the referenced Artists collection (single-target reference)
+//	filter.Property("hasAwards", "GrammyAward", "year") // Property "year" of the referenced Grammy collection (multi-target reference)
+//	filter.Property("performedBy", "bornIn", "population")  // performedBy -[Artists]-> bornIn -[Cities]-> population
+func Property[T any](path ...string) Target[T] { return target[T](path) }
 
 var (
 	UUID          = Property[uuid.UUID](api.FieldUUID)
@@ -25,57 +41,82 @@ var (
 	LastUpdatedAt = Property[time.Time](api.FieldLastUpdatedAt)
 )
 
-type Builder[T any] interface {
+// Len turns the last element of the property path into a len(property) expression.
+func Len(path ...string) Target[int64] {
+	if l := len(path); l > 0 {
+		path[l-1] = "len(" + path[l-1] + ")"
+	}
+	return Property[int64](path...)
+}
+
+// ReferenceCount turns the last element of the property path into reference-count target.
+func ReferenceCount(path ...string) Target[int64] {
+	if l := len(path); l > 0 {
+		path[l-1] = "count(" + path[l-1] + ")"
+	}
+	return Property[int64](path...)
+}
+
+// Target is the left-hand side of the filter expression.
+type Target[T any] interface {
 	Equal(T) Expr
-	NotEqual(T) Expr
 	LessThan(T) Expr
 	LessThanEqual(T) Expr
 	GreaterThan(T) Expr
 	GreaterThanEqual(T) Expr
 	Like(string) Expr
+	Null() Expr
 	ContainsAny(...T) Expr
 	ContainsAll(...T) Expr
 	ContainsNone(...T) Expr
 }
 
-func Not(e Expr) Expr { return &expr{operator: api.FilterOperatorNot, exprs: []Expr{e}} }
-func Null(target string) Expr {
-	return &expr{operator: api.FilterOperatorIsNull, target: []string{target}}
+// Not negates the expression.
+func Not(e Expr) Expr {
+	return &expr{operator: api.FilterOperatorNot, exprs: []Expr{e}}
 }
 
+// And is a group of sub-expressions joined with the AND operator.
+// It can be the top level exression or combined with other sub-expressions.
 type And []Expr
+
+var _ Expr = (And)(nil)
 
 func (and And) Exprs() []Expr                { return and }
 func (and And) Operator() api.FilterOperator { return api.FilterOperatorAnd }
 func (and And) Target() []string             { return nil }
 func (and And) Value() any                   { return nil }
 
-var _ Expr = (And)(nil)
-
+// Or is a group of sub-expressions joined with the OR operator.
+// It can be the top level exression or combined with other sub-expressions.
 type Or []Expr
+
+var _ Expr = (And)(nil)
 
 func (or Or) Exprs() []Expr                { return or }
 func (or Or) Operator() api.FilterOperator { return api.FilterOperatorOr }
 func (or Or) Target() []string             { return nil }
 func (or Or) Value() any                   { return nil }
 
+// target implements [Target] for a property path.
 type target[T any] []string
 
+var _ Target[any] = (*target[any])(nil)
+
 func (t target[T]) Equal(v T) Expr            { return t.expr(api.FilterOperatorEqual, v) }
-func (t target[T]) NotEqual(v T) Expr         { return Not(t.Equal(v)) }
 func (t target[T]) LessThan(v T) Expr         { return t.expr(api.FilterOperatorLessThan, v) }
 func (t target[T]) LessThanEqual(v T) Expr    { return t.expr(api.FilterOperatorLessThanEqual, v) }
 func (t target[T]) GreaterThan(v T) Expr      { return t.expr(api.FilterOperatorGreaterThan, v) }
 func (t target[T]) GreaterThanEqual(v T) Expr { return t.expr(api.FilterOperatorGreaterThanEqual, v) }
 func (t target[T]) Like(v string) Expr        { return t.expr(api.FilterOperatorLike, v) }
+func (t target[T]) Null() Expr                { return t.expr(api.FilterOperatorIsNull, nil) }
 func (t target[T]) ContainsAll(vs ...T) Expr  { return t.expr(api.FilterOperatorContainsAll, vs) }
 func (t target[T]) ContainsAny(vs ...T) Expr  { return t.expr(api.FilterOperatorContainsAny, vs) }
 func (t target[T]) ContainsNone(vs ...T) Expr { return t.expr(api.FilterOperatorContainsNone, vs) }
+
 func (t target[T]) expr(op api.FilterOperator, v any) *expr {
 	return &expr{operator: op, target: t, value: v}
 }
-
-var _ Builder[any] = (*target[any])(nil)
 
 type expr struct {
 	operator api.FilterOperator

--- a/query/filter/filter.go
+++ b/query/filter/filter.go
@@ -1,0 +1,92 @@
+package filter
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+)
+
+// NB(dyma): These need to be public interface methods, because we want the `query`
+// package to be able to marshal filters independently
+type Expr interface {
+	Operator() api.FilterOperator // api.FilterOperator
+	Exprs() []Expr                // For AND/OR
+
+	Target() []string
+	Value() any
+}
+
+func Property[T any](property string) Builder[T] { return target[T]{property} }
+
+var (
+	UUID          = Property[uuid.UUID](api.FieldUUID)
+	CreatedAt     = Property[time.Time](api.FieldCreatedAt)
+	LastUpdatedAt = Property[time.Time](api.FieldLastUpdatedAt)
+)
+
+type Builder[T any] interface {
+	Equal(T) Expr
+	NotEqual(T) Expr
+	LessThan(T) Expr
+	LessThanEqual(T) Expr
+	GreaterThan(T) Expr
+	GreaterThanEqual(T) Expr
+	Like(string) Expr
+	ContainsAny(...T) Expr
+	ContainsAll(...T) Expr
+	ContainsNone(...T) Expr
+}
+
+func Not(e Expr) Expr { return &expr{operator: api.FilterOperatorNot, exprs: []Expr{e}} }
+func Null(target string) Expr {
+	return &expr{operator: api.FilterOperatorIsNull, target: []string{target}}
+}
+
+type And []Expr
+
+func (and And) Exprs() []Expr                { return and }
+func (and And) Operator() api.FilterOperator { return api.FilterOperatorAnd }
+func (and And) Target() []string             { return nil }
+func (and And) Value() any                   { return nil }
+
+var _ Expr = (And)(nil)
+
+type Or []Expr
+
+func (or Or) Exprs() []Expr                { return or }
+func (or Or) Operator() api.FilterOperator { return api.FilterOperatorOr }
+func (or Or) Target() []string             { return nil }
+func (or Or) Value() any                   { return nil }
+
+type target[T any] []string
+
+func (t target[T]) Equal(v T) Expr            { return t.expr(api.FilterOperatorEqual, v) }
+func (t target[T]) NotEqual(v T) Expr         { return Not(t.Equal(v)) }
+func (t target[T]) LessThan(v T) Expr         { return t.expr(api.FilterOperatorLessThan, v) }
+func (t target[T]) LessThanEqual(v T) Expr    { return t.expr(api.FilterOperatorLessThanEqual, v) }
+func (t target[T]) GreaterThan(v T) Expr      { return t.expr(api.FilterOperatorGreaterThan, v) }
+func (t target[T]) GreaterThanEqual(v T) Expr { return t.expr(api.FilterOperatorGreaterThanEqual, v) }
+func (t target[T]) Like(v string) Expr        { return t.expr(api.FilterOperatorLike, v) }
+func (t target[T]) ContainsAll(vs ...T) Expr  { return t.expr(api.FilterOperatorContainsAll, vs) }
+func (t target[T]) ContainsAny(vs ...T) Expr  { return t.expr(api.FilterOperatorContainsAny, vs) }
+func (t target[T]) ContainsNone(vs ...T) Expr { return t.expr(api.FilterOperatorContainsNone, vs) }
+func (t target[T]) expr(op api.FilterOperator, v any) *expr {
+	return &expr{operator: op, target: t, value: v}
+}
+
+var _ Builder[any] = (*target[any])(nil)
+
+type expr struct {
+	operator api.FilterOperator
+	exprs    []Expr
+	target   []string
+	value    any
+}
+
+var _ Expr = (*expr)(nil)
+
+func (e *expr) Operator() api.FilterOperator { return e.operator }
+func (e *expr) Exprs() []Expr                { return e.exprs }
+func (e *expr) Target() []string             { return e.target }
+func (e *expr) Value() any                   { return e.value }

--- a/query/filter/filter.go
+++ b/query/filter/filter.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
 )
 
 // Expr describes a filter expression. Expressions can be combined into [And] and [Or] groups.
@@ -173,9 +174,10 @@ func (r Reference) Reference(reference string) Reference { return Reference(r.Pr
 // Collection specifies target collection name for a multi-target reference.
 func (r Reference) Collection(collection string) Reference {
 	path := split(string(r))
-	if l := len(path); l > 0 {
-		path[l-1] = api.MultiTargetReference(path[l-1], collection)
-	}
+	l := len(path)
+	dev.Assert(l > 0, "len(reference path)")
+
+	path[l-1] = api.MultiTargetReference(path[l-1], collection)
 	return Reference(join(path...))
 }
 
@@ -185,14 +187,15 @@ func (r Reference) Property(property string) string { return join(string(r), pro
 // Count converts the reference path into a reference-count target.
 func (r Reference) Count() string {
 	path := split(string(r))
-	if l := len(path); l > 0 {
-		path[l-1] = "count(" + path[l-1] + ")"
-	}
+	l := len(path)
+	dev.Assert(l > 0, "len(reference path)")
+
+	path[l-1] = "count(" + path[l-1] + ")"
 	return join(path...)
 }
 
 // pathSep separates parts of the concatenated Target path.
 const pathSep = "/"
 
-func split(s string) []string { return strings.Split(s, pathSep) }
+func split(s string) []string { return strings.Split(s, pathSep) } // Returned slice is always non-empty.
 func join(s ...string) string { return strings.Join(s, pathSep) }

--- a/query/filter/filter.go
+++ b/query/filter/filter.go
@@ -1,6 +1,8 @@
 package filter
 
 import (
+	"strings"
+
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 )
 
@@ -40,22 +42,18 @@ type Cond struct {
 	// It is representsed as a path to the filter property:
 	//
 	//   - For regular properties, it is the name of the target property.
-	//   - For properties belonging to a single-target reference, it is
-	//     then name of the reference property followed by the name of
-	//     the target property, arbitrarily nested.
-	//   - For properties belonging to a multi-target reference, it is
-	//     the name of the reference property followed by the name of
-	//     the target collection and the property therein, arbitrarily nested.
+	//   - For properties belonging to a referenced collection, it is
+	//     the path to that property constructed via [Reference] methods.
 	//
 	// Example:
 	//
-	//	[]string{"album"} 									// Property "album" of the root Songs collection
-	//	[]string{"performedBy", "given_name"} 				// Property "given_name" of the referenced Artists collection (single-target reference)
-	//	[]string{"hasAwards", "GrammyAward", "year"} 		// Property "year" of the referenced Grammy collection (multi-target reference)
-	//	[]string{"performedBy", "bornIn", "population"}  	// performedBy -[Artists]-> bornIn -[Cities]-> population
+	//	"album" 															// Property "album" of the root Songs collection
+	//	Reference("performedBy").Property("given_name") 					// Property "given_name" of the referenced Artists collection (single-target reference)
+	//	Reference("hasAwards").Collection("GrammyAward").Property("year")	// Property "year" of the referenced Grammy collection (multi-target reference)
+	//	Reference("performedBy").Reference("bornIn").Property("population")	// performedBy -[Artists]-> bornIn -[Cities]-> population
 	//
-	// See [Len] and [ReferenceCount].
-	Target []string
+	// See [Len].
+	Target string
 
 	// Value represents the right-hand side of the filter expression.
 	// Its type should match the data type of the [Target] property.
@@ -73,7 +71,7 @@ func (c *Cond) Expr() *api.FilterExpr {
 	}
 	return &api.FilterExpr{
 		Operator: api.FilterOperator(c.Operator),
-		Target:   c.Target,
+		Target:   split(c.Target),
 		Value:    c.Value,
 	}
 }
@@ -151,18 +149,44 @@ var (
 	LastUpdatedAt = api.FieldLastUpdatedAt // Last update time property name.
 )
 
-// Len turns the last element of the property path into a len(property) expression.
-func Len(path ...string) []string {
+// Len turns the property target a len(property) expression.
+// Do not use together with the output of [Reference.Count].
+func Len(property string) string {
+	path := split(property)
 	if l := len(path); l > 0 {
 		path[l-1] = "len(" + path[l-1] + ")"
 	}
-	return path
+	return join(path...)
 }
 
-// ReferenceCount turns the last element of the property path into reference-count target.
-func ReferenceCount(path ...string) []string {
+// Reference describes the path to the target property.
+// The path may contain any arbitrary number of "hops",
+// each pointing to another collection.
+//
+// Every path must terminate either in a collection property (see [Reference.Property]),
+// or reference-count target (see [Reference.Count]).
+type Reference string
+
+// Reference adds another "hop" to the path.
+func (r Reference) Reference(reference string) Reference { return Reference(r.Property(reference)) }
+
+// Collection specifies target collection name for a multi-target reference.
+func (r Reference) Collection(collection string) Reference { panic("implement") }
+
+// Property appends a property target at the end of the reference path.
+func (r Reference) Property(property string) string { return join(string(r), property) }
+
+// Count converts the reference path into a reference-count target.
+func (r Reference) Count() string {
+	path := split(string(r))
 	if l := len(path); l > 0 {
 		path[l-1] = "count(" + path[l-1] + ")"
 	}
-	return path
+	return join(path...)
 }
+
+// pathSep separates parts of the concatenated Target path.
+const pathSep = "/"
+
+func split(s string) []string { return strings.Split(s, pathSep) }
+func join(s ...string) string { return strings.Join(s, pathSep) }

--- a/query/filter/filter.go
+++ b/query/filter/filter.go
@@ -85,11 +85,16 @@ func (and And) Expr() *api.FilterExpr {
 	if len(and) == 0 {
 		return nil
 	}
-	exprs := make([]api.FilterExpr, len(and))
-	for i := range and {
-		if expr := and[i].Expr(); expr != nil {
-			exprs[i] = *expr
+	exprs := make([]api.FilterExpr, 0, len(and))
+	for _, ex := range and {
+		if ex != nil {
+			if expr := ex.Expr(); expr != nil {
+				exprs = append(exprs, *expr)
+			}
 		}
+	}
+	if len(exprs) == 0 {
+		return nil
 	}
 	return &api.FilterExpr{
 		Operator: api.FilterOperatorAnd,
@@ -105,11 +110,16 @@ func (or Or) Expr() *api.FilterExpr {
 	if len(or) == 0 {
 		return nil
 	}
-	exprs := make([]api.FilterExpr, len(or))
-	for i := range or {
-		if expr := or[i].Expr(); expr != nil {
-			exprs[i] = *expr
+	exprs := make([]api.FilterExpr, 0, len(or))
+	for _, ex := range or {
+		if ex != nil {
+			if expr := ex.Expr(); expr != nil {
+				exprs = append(exprs, *expr)
+			}
 		}
+	}
+	if len(exprs) == 0 {
+		return nil
 	}
 	return &api.FilterExpr{
 		Operator: api.FilterOperatorOr,
@@ -121,6 +131,9 @@ func (or Or) Expr() *api.FilterExpr {
 type Not struct{ P Expr }
 
 func (not Not) Expr() *api.FilterExpr {
+	if not.P == nil {
+		return nil
+	}
 	expr := not.P.Expr()
 	if expr == nil {
 		return nil

--- a/query/filter/filter.go
+++ b/query/filter/filter.go
@@ -1,133 +1,154 @@
 package filter
 
 import (
-	"time"
-
-	"github.com/google/uuid"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 )
 
-// Expr describes a filter exression. Expressions can be combined into [And] and [Or] groups.
+// Expr describes a filter expression. Expressions can be combined into [And] and [Or] groups.
 type Expr interface {
-	Operator() api.FilterOperator
-	Exprs() []Expr // For AND/OR
-
-	Target() []string
-	Value() any
+	Expr() *api.FilterExpr
 }
-
-// Property constructs the left-hand side of the filter expression.
-// It is representsed as a path to the filter property:
-//
-//   - For regular properties, it is the name of the target property.
-//   - For properties belonging to a single-target reference, it is
-//     then name of the reference property followed by the name of
-//     the target property, arbitrarily nested.
-//   - For properties belonging to a multi-target reference, it is
-//     the name of the reference property followed by the name of
-//     the target collection and the property therein, arbitrarily nested.
-//
-// Example:
-//
-//	filter.Property("album") // Property "album" of the root Songs collection
-//	filter.Property("performedBy", "given_name") // Property "given_name" of the referenced Artists collection (single-target reference)
-//	filter.Property("hasAwards", "GrammyAward", "year") // Property "year" of the referenced Grammy collection (multi-target reference)
-//	filter.Property("performedBy", "bornIn", "population")  // performedBy -[Artists]-> bornIn -[Cities]-> population
-func Property[T any](path ...string) Target[T] { return target[T](path) }
 
 var (
-	UUID          = Property[uuid.UUID](api.FieldUUID)
-	CreatedAt     = Property[time.Time](api.FieldCreatedAt)
-	LastUpdatedAt = Property[time.Time](api.FieldLastUpdatedAt)
+	_ Expr = (*Cond)(nil)
+	_ Expr = (*And)(nil)
+	_ Expr = (*Or)(nil)
 )
 
-// Len turns the last element of the property path into a len(property) expression.
-func Len(path ...string) Target[int64] {
-	if l := len(path); l > 0 {
-		path[l-1] = "len(" + path[l-1] + ")"
+type Operator api.FilterOperator
+
+const (
+	Equal            = Operator(api.FilterOperatorEqual)
+	LessThan         = Operator(api.FilterOperatorLessThan)
+	LessThanEqual    = Operator(api.FilterOperatorLessThanEqual)
+	GreaterThan      = Operator(api.FilterOperatorGreaterThan)
+	GreaterThanEqual = Operator(api.FilterOperatorGreaterThanEqual)
+	Like             = Operator(api.FilterOperatorLike)
+	IsNull           = Operator(api.FilterOperatorIsNull)
+	ContainsAll      = Operator(api.FilterOperatorContainsAll)
+	ContainsAny      = Operator(api.FilterOperatorContainsAny)
+	ContainsNone     = Operator(api.FilterOperatorContainsNone)
+)
+
+type Cond struct {
+	// Comparison operator.
+	// See [Value] for discussion of values supported by different operators.
+	Operator Operator
+
+	// Target describes the left-hand side of the filter expression.
+	// It is representsed as a path to the filter property:
+	//
+	//   - For regular properties, it is the name of the target property.
+	//   - For properties belonging to a single-target reference, it is
+	//     then name of the reference property followed by the name of
+	//     the target property, arbitrarily nested.
+	//   - For properties belonging to a multi-target reference, it is
+	//     the name of the reference property followed by the name of
+	//     the target collection and the property therein, arbitrarily nested.
+	//
+	// Example:
+	//
+	//	[]string{"album"} 									// Property "album" of the root Songs collection
+	//	[]string{"performedBy", "given_name"} 				// Property "given_name" of the referenced Artists collection (single-target reference)
+	//	[]string{"hasAwards", "GrammyAward", "year"} 		// Property "year" of the referenced Grammy collection (multi-target reference)
+	//	[]string{"performedBy", "bornIn", "population"}  	// performedBy -[Artists]-> bornIn -[Cities]-> population
+	//
+	// See [Len] and [ReferenceCount].
+	Target []string
+
+	// Value represents the right-hand side of the filter expression.
+	// Its type should match the data type of the [Target] property.
+	//
+	//	- [Like] operator requires a regular expression string.
+	//	- [IsNull] operator does not need a value.
+	//	- Contains- operators require a slice of values.
+	// 	- Date properties should be compared to instances of [time.Time].
+	Value any
+}
+
+func (c *Cond) Expr() *api.FilterExpr {
+	if c == nil {
+		return nil
 	}
-	return Property[int64](path...)
-}
-
-// ReferenceCount turns the last element of the property path into reference-count target.
-func ReferenceCount(path ...string) Target[int64] {
-	if l := len(path); l > 0 {
-		path[l-1] = "count(" + path[l-1] + ")"
+	return &api.FilterExpr{
+		Operator: api.FilterOperator(c.Operator),
+		Target:   c.Target,
+		Value:    c.Value,
 	}
-	return Property[int64](path...)
-}
-
-// Target is the left-hand side of the filter expression.
-type Target[T any] interface {
-	Equal(T) Expr
-	LessThan(T) Expr
-	LessThanEqual(T) Expr
-	GreaterThan(T) Expr
-	GreaterThanEqual(T) Expr
-	Like(string) Expr
-	Null() Expr
-	ContainsAny(...T) Expr
-	ContainsAll(...T) Expr
-	ContainsNone(...T) Expr
-}
-
-// Not negates the expression.
-func Not(e Expr) Expr {
-	return &expr{operator: api.FilterOperatorNot, exprs: []Expr{e}}
 }
 
 // And is a group of sub-expressions joined with the AND operator.
 // It can be the top level exression or combined with other sub-expressions.
 type And []Expr
 
-var _ Expr = (And)(nil)
-
-func (and And) Exprs() []Expr                { return and }
-func (and And) Operator() api.FilterOperator { return api.FilterOperatorAnd }
-func (and And) Target() []string             { return nil }
-func (and And) Value() any                   { return nil }
+func (and And) Expr() *api.FilterExpr {
+	if len(and) == 0 {
+		return nil
+	}
+	exprs := make([]api.FilterExpr, len(and))
+	for i := range and {
+		if expr := and[i].Expr(); expr != nil {
+			exprs[i] = *expr
+		}
+	}
+	return &api.FilterExpr{
+		Operator: api.FilterOperatorAnd,
+		Exprs:    exprs,
+	}
+}
 
 // Or is a group of sub-expressions joined with the OR operator.
 // It can be the top level exression or combined with other sub-expressions.
 type Or []Expr
 
-var _ Expr = (And)(nil)
-
-func (or Or) Exprs() []Expr                { return or }
-func (or Or) Operator() api.FilterOperator { return api.FilterOperatorOr }
-func (or Or) Target() []string             { return nil }
-func (or Or) Value() any                   { return nil }
-
-// target implements [Target] for a property path.
-type target[T any] []string
-
-var _ Target[any] = (*target[any])(nil)
-
-func (t target[T]) Equal(v T) Expr            { return t.expr(api.FilterOperatorEqual, v) }
-func (t target[T]) LessThan(v T) Expr         { return t.expr(api.FilterOperatorLessThan, v) }
-func (t target[T]) LessThanEqual(v T) Expr    { return t.expr(api.FilterOperatorLessThanEqual, v) }
-func (t target[T]) GreaterThan(v T) Expr      { return t.expr(api.FilterOperatorGreaterThan, v) }
-func (t target[T]) GreaterThanEqual(v T) Expr { return t.expr(api.FilterOperatorGreaterThanEqual, v) }
-func (t target[T]) Like(v string) Expr        { return t.expr(api.FilterOperatorLike, v) }
-func (t target[T]) Null() Expr                { return t.expr(api.FilterOperatorIsNull, nil) }
-func (t target[T]) ContainsAll(vs ...T) Expr  { return t.expr(api.FilterOperatorContainsAll, vs) }
-func (t target[T]) ContainsAny(vs ...T) Expr  { return t.expr(api.FilterOperatorContainsAny, vs) }
-func (t target[T]) ContainsNone(vs ...T) Expr { return t.expr(api.FilterOperatorContainsNone, vs) }
-
-func (t target[T]) expr(op api.FilterOperator, v any) *expr {
-	return &expr{operator: op, target: t, value: v}
+func (or Or) Expr() *api.FilterExpr {
+	if len(or) == 0 {
+		return nil
+	}
+	exprs := make([]api.FilterExpr, len(or))
+	for i := range or {
+		if expr := or[i].Expr(); expr != nil {
+			exprs[i] = *expr
+		}
+	}
+	return &api.FilterExpr{
+		Operator: api.FilterOperatorOr,
+		Exprs:    exprs,
+	}
 }
 
-type expr struct {
-	operator api.FilterOperator
-	exprs    []Expr
-	target   []string
-	value    any
+// Not negates the expression.
+type Not struct{ P Expr }
+
+func (not Not) Expr() *api.FilterExpr {
+	expr := not.P.Expr()
+	if expr == nil {
+		return nil
+	}
+	return &api.FilterExpr{
+		Operator: api.FilterOperatorNot,
+		Exprs:    []api.FilterExpr{*expr},
+	}
 }
 
-var _ Expr = (*expr)(nil)
+var (
+	UUID          = api.FieldUUID          // UUID property name.
+	CreatedAt     = api.FieldCreatedAt     // Creation time property name.
+	LastUpdatedAt = api.FieldLastUpdatedAt // Last update time property name.
+)
 
-func (e *expr) Operator() api.FilterOperator { return e.operator }
-func (e *expr) Exprs() []Expr                { return e.exprs }
-func (e *expr) Target() []string             { return e.target }
-func (e *expr) Value() any                   { return e.value }
+// Len turns the last element of the property path into a len(property) expression.
+func Len(path ...string) []string {
+	if l := len(path); l > 0 {
+		path[l-1] = "len(" + path[l-1] + ")"
+	}
+	return path
+}
+
+// ReferenceCount turns the last element of the property path into reference-count target.
+func ReferenceCount(path ...string) []string {
+	if l := len(path); l > 0 {
+		path[l-1] = "count(" + path[l-1] + ")"
+	}
+	return path
+}

--- a/query/filter/filter.go
+++ b/query/filter/filter.go
@@ -13,6 +13,7 @@ var (
 	_ Expr = (*Cond)(nil)
 	_ Expr = (*And)(nil)
 	_ Expr = (*Or)(nil)
+	_ Expr = (*Not)(nil)
 )
 
 type Operator api.FilterOperator

--- a/query/filter/filter.go
+++ b/query/filter/filter.go
@@ -49,7 +49,7 @@ type Cond struct {
 	//
 	//	"album" 															// Property "album" of the root Songs collection
 	//	Reference("performedBy").Property("given_name") 					// Property "given_name" of the referenced Artists collection (single-target reference)
-	//	Reference("hasAwards").Collection("GrammyAward").Property("year")	// Property "year" of the referenced Grammy collection (multi-target reference)
+	//	Reference("hasAwards").Collection("GrammyAwards").Property("year")	// Property "year" of the referenced GrammyAwards collection (multi-target reference)
 	//	Reference("performedBy").Reference("bornIn").Property("population")	// performedBy -[Artists]-> bornIn -[Cities]-> population
 	//
 	// See [Len].
@@ -171,7 +171,13 @@ type Reference string
 func (r Reference) Reference(reference string) Reference { return Reference(r.Property(reference)) }
 
 // Collection specifies target collection name for a multi-target reference.
-func (r Reference) Collection(collection string) Reference { panic("implement") }
+func (r Reference) Collection(collection string) Reference {
+	path := split(string(r))
+	if l := len(path); l > 0 {
+		path[l-1] = api.MultiTargetReference(path[l-1], collection)
+	}
+	return Reference(join(path...))
+}
 
 // Property appends a property target at the end of the reference path.
 func (r Reference) Property(property string) string { return join(string(r), property) }

--- a/query/filter/filter_test.go
+++ b/query/filter/filter_test.go
@@ -2,25 +2,207 @@ package filter_test
 
 import (
 	"testing"
-	"time"
 
-	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/query/filter"
 )
 
 func TestFilter(t *testing.T) {
-	filter.Property[int]("price").Equal(92)
-	filter.Property[string]("title").Like("%box")
-	filter.Property[string]("tags").ContainsAll("foo", "bar")
+	for _, tt := range []struct {
+		name string
+		expr filter.Expr
+		want api.Filter
+	}{
+		{
+			name: "eq",
+			expr: filter.Property[int]("size").Equal(3),
+			want: api.Filter{
+				Operator: api.FilterOperatorEqual,
+				Target:   []string{"size"},
+				Value:    3,
+			},
+		},
+		{
+			name: "lt",
+			expr: filter.Property[int]("size").LessThan(3),
+			want: api.Filter{
+				Operator: api.FilterOperatorLessThan,
+				Target:   []string{"size"},
+				Value:    3,
+			},
+		},
+		{
+			name: "lte",
+			expr: filter.Property[int]("size").LessThanEqual(3),
+			want: api.Filter{
+				Operator: api.FilterOperatorLessThanEqual,
+				Target:   []string{"size"},
+				Value:    3,
+			},
+		},
+		{
+			name: "gt",
+			expr: filter.Property[int]("size").GreaterThan(3),
+			want: api.Filter{
+				Operator: api.FilterOperatorGreaterThan,
+				Target:   []string{"size"},
+				Value:    3,
+			},
+		},
+		{
+			name: "gte",
+			expr: filter.Property[int]("size").GreaterThanEqual(3),
+			want: api.Filter{
+				Operator: api.FilterOperatorGreaterThanEqual,
+				Target:   []string{"size"},
+				Value:    3,
+			},
+		},
+		{
+			name: "like",
+			expr: filter.Property[string]("model").Like("[0-9]+Roadster"),
+			want: api.Filter{
+				Operator: api.FilterOperatorLike,
+				Target:   []string{"model"},
+				Value:    "[0-9]+Roadster",
+			},
+		},
+		{
+			name: "null",
+			expr: filter.Property[string]("discount").Null(),
+			want: api.Filter{
+				Operator: api.FilterOperatorIsNull,
+				Target:   []string{"discount"},
+			},
+		},
+		{
+			name: "contains all",
+			expr: filter.Property[int]("gears").ContainsAll(1, 2, 3),
+			want: api.Filter{
+				Operator: api.FilterOperatorContainsAll,
+				Target:   []string{"gears"},
+				Value:    []int{1, 2, 3},
+			},
+		},
+		{
+			name: "contains any",
+			expr: filter.Property[int]("gears").ContainsAny(1, 2, 3),
+			want: api.Filter{
+				Operator: api.FilterOperatorContainsAny,
+				Target:   []string{"gears"},
+				Value:    []int{1, 2, 3},
+			},
+		},
+		{
+			name: "contains none",
+			expr: filter.Property[int]("gears").ContainsNone(1, 2, 3),
+			want: api.Filter{
+				Operator: api.FilterOperatorContainsNone,
+				Target:   []string{"gears"},
+				Value:    []int{1, 2, 3},
+			},
+		},
+		{
+			name: "len(property)",
+			expr: filter.Len("model").Equal(4),
+			want: api.Filter{
+				Operator: api.FilterOperatorEqual,
+				Target:   []string{"len(model)"},
+				Value:    4,
+			},
+		},
+		{
+			name: "reference count",
+			expr: filter.ReferenceCount("soldIn").LessThan(10),
+			want: api.Filter{
+				Operator: api.FilterOperatorLessThan,
+				Target:   []string{"count(soldIn)"},
+				Value:    10,
+			},
+		},
+		{
+			name: "and",
+			expr: filter.And{
+				filter.Property[int]("length").Equal(2),
+				filter.Property[int]("width").Equal(3),
+			},
+			want: api.Filter{
+				Operator: api.FilterOperatorAnd,
+				Exprs: []api.Filter{
+					{Operator: api.FilterOperatorEqual, Target: []string{"length"}, Value: 2},
+					{Operator: api.FilterOperatorEqual, Target: []string{"width"}, Value: 3},
+				},
+			},
+		},
+		{
+			name: "or",
+			expr: filter.Or{
+				filter.Property[int]("length").Equal(2),
+				filter.Property[int]("width").Equal(3),
+			},
+			want: api.Filter{
+				Operator: api.FilterOperatorOr,
+				Exprs: []api.Filter{
+					{Operator: api.FilterOperatorEqual, Target: []string{"length"}, Value: 2},
+					{Operator: api.FilterOperatorEqual, Target: []string{"width"}, Value: 3},
+				},
+			},
+		},
+		{
+			name: "not",
+			expr: filter.Not(filter.Property[int]("length").Equal(2)),
+			want: api.Filter{
+				Operator: api.FilterOperatorNot,
+				Exprs: []api.Filter{
+					{Operator: api.FilterOperatorEqual, Target: []string{"length"}, Value: 2},
+				},
+			},
+		},
+		{
+			name: "reference",
+			expr: filter.Property[string]("ownedBy", "name").Like(".*_doe"),
+			want: api.Filter{
+				Operator: api.FilterOperatorLike,
+				Target:   []string{"ownedBy", "name"},
+				Value:    ".*_doe",
+			},
+		},
+		{
+			name: "len(property) in reference",
+			expr: filter.Len("ownedBy", "name").GreaterThan(12),
+			want: api.Filter{
+				Operator: api.FilterOperatorGreaterThan,
+				Target:   []string{"ownedBy", "len(name)"},
+				Value:    12,
+			},
+		},
+		{
+			name: "reference count in reference",
+			expr: filter.ReferenceCount("ownedBy", "hasFriends").LessThan(4),
+			want: api.Filter{
+				Operator: api.FilterOperatorLessThan,
+				Target:   []string{"ownedBy", "count(hasFriends)"},
+				Value:    4,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			checkExpr(t, tt.expr, tt.want)
+		})
+	}
+}
 
-	var exprs []filter.Expr
+// checkExpr asserts that [filter.Expr] returns the expected operator,
+// target, test value, and sub-expressions.
+func checkExpr(t *testing.T, e filter.Expr, want api.Filter) {
+	assert.Equal(t, want.Operator, e.Operator(), "want %s, got %s", want.Operator, e.Operator())
+	assert.Equal(t, want.Target, e.Target(), "target")
+	assert.EqualValues(t, want.Value, e.Value(), "value")
 
-	exprs = append(exprs, filter.And{
-		filter.UUID.Equal(testkit.UUID),
-	}, filter.And{
-		filter.CreatedAt.LessThanEqual(testkit.Now.Add(-time.Hour)),
-		filter.LastUpdatedAt.GreaterThan(testkit.Now),
-	})
-
-	_ = filter.Or(exprs)
+	exprs := e.Exprs()
+	assert.Len(t, exprs, len(want.Exprs), "sub-expressions")
+	for i := range exprs {
+		checkExpr(t, exprs[i], want.Exprs[i])
+	}
 }

--- a/query/filter/filter_test.go
+++ b/query/filter/filter_test.go
@@ -1,0 +1,26 @@
+package filter_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+	"github.com/weaviate/weaviate-go-client/v6/query/filter"
+)
+
+func TestFilter(t *testing.T) {
+	filter.Property[int]("price").Equal(92)
+	filter.Property[string]("title").Like("%box")
+	filter.Property[string]("tags").ContainsAll("foo", "bar")
+
+	var exprs []filter.Expr
+
+	exprs = append(exprs, filter.And{
+		filter.UUID.Equal(testkit.UUID),
+	}, filter.And{
+		filter.CreatedAt.LessThanEqual(testkit.Now.Add(-time.Hour)),
+		filter.LastUpdatedAt.GreaterThan(testkit.Now),
+	})
+
+	_ = filter.Or(exprs)
+}

--- a/query/filter/filter_test.go
+++ b/query/filter/filter_test.go
@@ -267,6 +267,36 @@ func TestFilter(t *testing.T) {
 				Value:    4,
 			},
 		},
+		{
+			name: "empty AND group",
+			expr: filter.And{},
+			want: nil,
+		},
+		{
+			name: "empty OR group",
+			expr: filter.Or{},
+			want: nil,
+		},
+		{
+			name: "nil filter in AND group",
+			expr: filter.And{nil},
+			want: nil,
+		},
+		{
+			name: "nil filter in OR group",
+			expr: filter.Or{nil},
+			want: nil,
+		},
+		{
+			name: "negating a nil filter",
+			expr: filter.Not{nil},
+			want: nil,
+		},
+		{
+			name: "negating an empty AND group",
+			expr: filter.Not{filter.And{}},
+			want: nil,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			checkExpr(t, tt.expr.Expr(), tt.want)
@@ -278,6 +308,9 @@ func TestFilter(t *testing.T) {
 // target, test value, and sub-expressions.
 func checkExpr(t *testing.T, got, want *api.FilterExpr) {
 	assert.Equal(t, want, got)
+	if want == nil {
+		return
+	}
 	assert.Len(t, got.Exprs, len(want.Exprs), "sub-expressions")
 	for i := range got.Exprs {
 		checkExpr(t, &got.Exprs[i], &want.Exprs[i])

--- a/query/filter/filter_test.go
+++ b/query/filter/filter_test.go
@@ -17,7 +17,7 @@ func TestFilter(t *testing.T) {
 		{
 			name: "eq",
 			expr: &filter.Cond{
-				Target:   []string{"size"},
+				Target:   "size",
 				Operator: filter.Equal,
 				Value:    3,
 			},
@@ -30,7 +30,7 @@ func TestFilter(t *testing.T) {
 		{
 			name: "lt",
 			expr: &filter.Cond{
-				Target:   []string{"size"},
+				Target:   "size",
 				Operator: filter.LessThan,
 				Value:    3,
 			},
@@ -43,7 +43,7 @@ func TestFilter(t *testing.T) {
 		{
 			name: "lte",
 			expr: &filter.Cond{
-				Target:   []string{"size"},
+				Target:   "size",
 				Operator: filter.LessThanEqual,
 				Value:    3,
 			},
@@ -56,7 +56,7 @@ func TestFilter(t *testing.T) {
 		{
 			name: "gt",
 			expr: &filter.Cond{
-				Target:   []string{"size"},
+				Target:   "size",
 				Operator: filter.GreaterThan,
 				Value:    3,
 			},
@@ -69,7 +69,7 @@ func TestFilter(t *testing.T) {
 		{
 			name: "gte",
 			expr: &filter.Cond{
-				Target:   []string{"size"},
+				Target:   "size",
 				Operator: filter.GreaterThanEqual,
 				Value:    3,
 			},
@@ -82,7 +82,7 @@ func TestFilter(t *testing.T) {
 		{
 			name: "like",
 			expr: &filter.Cond{
-				Target:   []string{"model"},
+				Target:   "model",
 				Operator: filter.Like,
 				Value:    "[0-9]+Roadster",
 			},
@@ -95,7 +95,7 @@ func TestFilter(t *testing.T) {
 		{
 			name: "null",
 			expr: &filter.Cond{
-				Target:   []string{"discount"},
+				Target:   "discount",
 				Operator: filter.IsNull,
 			},
 			want: &api.FilterExpr{
@@ -106,7 +106,7 @@ func TestFilter(t *testing.T) {
 		{
 			name: "contains all",
 			expr: &filter.Cond{
-				Target:   []string{"gears"},
+				Target:   "gears",
 				Operator: filter.ContainsAll,
 				Value:    []int{1, 2, 3},
 			},
@@ -119,7 +119,7 @@ func TestFilter(t *testing.T) {
 		{
 			name: "contains any",
 			expr: &filter.Cond{
-				Target:   []string{"gears"},
+				Target:   "gears",
 				Operator: filter.ContainsAny,
 				Value:    []int{1, 2, 3},
 			},
@@ -132,7 +132,7 @@ func TestFilter(t *testing.T) {
 		{
 			name: "contains none",
 			expr: &filter.Cond{
-				Target:   []string{"gears"},
+				Target:   "gears",
 				Operator: filter.ContainsNone,
 				Value:    []int{1, 2, 3},
 			},
@@ -158,7 +158,7 @@ func TestFilter(t *testing.T) {
 		{
 			name: "reference count",
 			expr: &filter.Cond{
-				Target:   filter.ReferenceCount("soldIn"),
+				Target:   filter.Reference("soldIn").Count(),
 				Operator: filter.LessThan,
 				Value:    10,
 			},
@@ -172,12 +172,12 @@ func TestFilter(t *testing.T) {
 			name: "and",
 			expr: filter.And{
 				&filter.Cond{
-					Target:   []string{"length"},
+					Target:   "length",
 					Operator: filter.Equal,
 					Value:    2,
 				},
 				&filter.Cond{
-					Target:   []string{"width"},
+					Target:   "width",
 					Operator: filter.Equal,
 					Value:    3,
 				},
@@ -194,12 +194,12 @@ func TestFilter(t *testing.T) {
 			name: "or",
 			expr: filter.Or{
 				&filter.Cond{
-					Target:   []string{"length"},
+					Target:   "length",
 					Operator: filter.Equal,
 					Value:    2,
 				},
 				&filter.Cond{
-					Target:   []string{"width"},
+					Target:   "width",
 					Operator: filter.Equal,
 					Value:    3,
 				},
@@ -216,7 +216,7 @@ func TestFilter(t *testing.T) {
 			name: "not",
 			expr: filter.Not{
 				&filter.Cond{
-					Target:   []string{"length"},
+					Target:   "length",
 					Operator: filter.Equal,
 					Value:    2,
 				},
@@ -231,7 +231,7 @@ func TestFilter(t *testing.T) {
 		{
 			name: "reference",
 			expr: &filter.Cond{
-				Target:   []string{"ownedBy", "name"},
+				Target:   filter.Reference("ownedBy").Property("name"),
 				Operator: filter.Like,
 				Value:    ".*_doe",
 			},
@@ -244,7 +244,7 @@ func TestFilter(t *testing.T) {
 		{
 			name: "len(property) in reference",
 			expr: &filter.Cond{
-				Target:   filter.Len("ownedBy", "name"),
+				Target:   filter.Len(filter.Reference("ownedBy").Property("name")),
 				Operator: filter.GreaterThan,
 				Value:    12,
 			},
@@ -257,7 +257,7 @@ func TestFilter(t *testing.T) {
 		{
 			name: "reference count in reference",
 			expr: &filter.Cond{
-				Target:   filter.ReferenceCount("ownedBy", "hasFriends"),
+				Target:   filter.Reference("ownedBy").Reference("hasFriends").Count(),
 				Operator: filter.LessThan,
 				Value:    4,
 			},

--- a/query/filter/filter_test.go
+++ b/query/filter/filter_test.go
@@ -268,6 +268,19 @@ func TestFilter(t *testing.T) {
 			},
 		},
 		{
+			name: "multi-target reference",
+			expr: &filter.Cond{
+				Operator: filter.GreaterThanEqual,
+				Target:   filter.Reference("hasAwards").Collection("GrammyAwards").Property("year"),
+				Value:    1974,
+			},
+			want: &api.FilterExpr{
+				Operator: api.FilterOperatorGreaterThanEqual,
+				Target:   []string{"hasAwards:GrammyAwards", "year"},
+				Value:    1974,
+			},
+		},
+		{
 			name: "empty AND group",
 			expr: filter.And{},
 			want: nil,

--- a/query/filter/filter_test.go
+++ b/query/filter/filter_test.go
@@ -12,12 +12,16 @@ func TestFilter(t *testing.T) {
 	for _, tt := range []struct {
 		name string
 		expr filter.Expr
-		want api.Filter
+		want *api.FilterExpr
 	}{
 		{
 			name: "eq",
-			expr: filter.Property[int]("size").Equal(3),
-			want: api.Filter{
+			expr: &filter.Cond{
+				Target:   []string{"size"},
+				Operator: filter.Equal,
+				Value:    3,
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorEqual,
 				Target:   []string{"size"},
 				Value:    3,
@@ -25,8 +29,12 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "lt",
-			expr: filter.Property[int]("size").LessThan(3),
-			want: api.Filter{
+			expr: &filter.Cond{
+				Target:   []string{"size"},
+				Operator: filter.LessThan,
+				Value:    3,
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorLessThan,
 				Target:   []string{"size"},
 				Value:    3,
@@ -34,8 +42,12 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "lte",
-			expr: filter.Property[int]("size").LessThanEqual(3),
-			want: api.Filter{
+			expr: &filter.Cond{
+				Target:   []string{"size"},
+				Operator: filter.LessThanEqual,
+				Value:    3,
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorLessThanEqual,
 				Target:   []string{"size"},
 				Value:    3,
@@ -43,8 +55,12 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "gt",
-			expr: filter.Property[int]("size").GreaterThan(3),
-			want: api.Filter{
+			expr: &filter.Cond{
+				Target:   []string{"size"},
+				Operator: filter.GreaterThan,
+				Value:    3,
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorGreaterThan,
 				Target:   []string{"size"},
 				Value:    3,
@@ -52,8 +68,12 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "gte",
-			expr: filter.Property[int]("size").GreaterThanEqual(3),
-			want: api.Filter{
+			expr: &filter.Cond{
+				Target:   []string{"size"},
+				Operator: filter.GreaterThanEqual,
+				Value:    3,
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorGreaterThanEqual,
 				Target:   []string{"size"},
 				Value:    3,
@@ -61,8 +81,12 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "like",
-			expr: filter.Property[string]("model").Like("[0-9]+Roadster"),
-			want: api.Filter{
+			expr: &filter.Cond{
+				Target:   []string{"model"},
+				Operator: filter.Like,
+				Value:    "[0-9]+Roadster",
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorLike,
 				Target:   []string{"model"},
 				Value:    "[0-9]+Roadster",
@@ -70,16 +94,23 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "null",
-			expr: filter.Property[string]("discount").Null(),
-			want: api.Filter{
+			expr: &filter.Cond{
+				Target:   []string{"discount"},
+				Operator: filter.IsNull,
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorIsNull,
 				Target:   []string{"discount"},
 			},
 		},
 		{
 			name: "contains all",
-			expr: filter.Property[int]("gears").ContainsAll(1, 2, 3),
-			want: api.Filter{
+			expr: &filter.Cond{
+				Target:   []string{"gears"},
+				Operator: filter.ContainsAll,
+				Value:    []int{1, 2, 3},
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorContainsAll,
 				Target:   []string{"gears"},
 				Value:    []int{1, 2, 3},
@@ -87,8 +118,12 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "contains any",
-			expr: filter.Property[int]("gears").ContainsAny(1, 2, 3),
-			want: api.Filter{
+			expr: &filter.Cond{
+				Target:   []string{"gears"},
+				Operator: filter.ContainsAny,
+				Value:    []int{1, 2, 3},
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorContainsAny,
 				Target:   []string{"gears"},
 				Value:    []int{1, 2, 3},
@@ -96,8 +131,12 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "contains none",
-			expr: filter.Property[int]("gears").ContainsNone(1, 2, 3),
-			want: api.Filter{
+			expr: &filter.Cond{
+				Target:   []string{"gears"},
+				Operator: filter.ContainsNone,
+				Value:    []int{1, 2, 3},
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorContainsNone,
 				Target:   []string{"gears"},
 				Value:    []int{1, 2, 3},
@@ -105,17 +144,25 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "len(property)",
-			expr: filter.Len("model").Equal(4),
-			want: api.Filter{
-				Operator: api.FilterOperatorEqual,
+			expr: &filter.Cond{
+				Target:   filter.Len("model"),
+				Operator: filter.Equal,
+				Value:    4,
+			},
+			want: &api.FilterExpr{
 				Target:   []string{"len(model)"},
+				Operator: api.FilterOperatorEqual,
 				Value:    4,
 			},
 		},
 		{
 			name: "reference count",
-			expr: filter.ReferenceCount("soldIn").LessThan(10),
-			want: api.Filter{
+			expr: &filter.Cond{
+				Target:   filter.ReferenceCount("soldIn"),
+				Operator: filter.LessThan,
+				Value:    10,
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorLessThan,
 				Target:   []string{"count(soldIn)"},
 				Value:    10,
@@ -124,12 +171,20 @@ func TestFilter(t *testing.T) {
 		{
 			name: "and",
 			expr: filter.And{
-				filter.Property[int]("length").Equal(2),
-				filter.Property[int]("width").Equal(3),
+				&filter.Cond{
+					Target:   []string{"length"},
+					Operator: filter.Equal,
+					Value:    2,
+				},
+				&filter.Cond{
+					Target:   []string{"width"},
+					Operator: filter.Equal,
+					Value:    3,
+				},
 			},
-			want: api.Filter{
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorAnd,
-				Exprs: []api.Filter{
+				Exprs: []api.FilterExpr{
 					{Operator: api.FilterOperatorEqual, Target: []string{"length"}, Value: 2},
 					{Operator: api.FilterOperatorEqual, Target: []string{"width"}, Value: 3},
 				},
@@ -138,12 +193,20 @@ func TestFilter(t *testing.T) {
 		{
 			name: "or",
 			expr: filter.Or{
-				filter.Property[int]("length").Equal(2),
-				filter.Property[int]("width").Equal(3),
+				&filter.Cond{
+					Target:   []string{"length"},
+					Operator: filter.Equal,
+					Value:    2,
+				},
+				&filter.Cond{
+					Target:   []string{"width"},
+					Operator: filter.Equal,
+					Value:    3,
+				},
 			},
-			want: api.Filter{
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorOr,
-				Exprs: []api.Filter{
+				Exprs: []api.FilterExpr{
 					{Operator: api.FilterOperatorEqual, Target: []string{"length"}, Value: 2},
 					{Operator: api.FilterOperatorEqual, Target: []string{"width"}, Value: 3},
 				},
@@ -151,18 +214,28 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "not",
-			expr: filter.Not(filter.Property[int]("length").Equal(2)),
-			want: api.Filter{
+			expr: filter.Not{
+				&filter.Cond{
+					Target:   []string{"length"},
+					Operator: filter.Equal,
+					Value:    2,
+				},
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorNot,
-				Exprs: []api.Filter{
+				Exprs: []api.FilterExpr{
 					{Operator: api.FilterOperatorEqual, Target: []string{"length"}, Value: 2},
 				},
 			},
 		},
 		{
 			name: "reference",
-			expr: filter.Property[string]("ownedBy", "name").Like(".*_doe"),
-			want: api.Filter{
+			expr: &filter.Cond{
+				Target:   []string{"ownedBy", "name"},
+				Operator: filter.Like,
+				Value:    ".*_doe",
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorLike,
 				Target:   []string{"ownedBy", "name"},
 				Value:    ".*_doe",
@@ -170,8 +243,12 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "len(property) in reference",
-			expr: filter.Len("ownedBy", "name").GreaterThan(12),
-			want: api.Filter{
+			expr: &filter.Cond{
+				Target:   filter.Len("ownedBy", "name"),
+				Operator: filter.GreaterThan,
+				Value:    12,
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorGreaterThan,
 				Target:   []string{"ownedBy", "len(name)"},
 				Value:    12,
@@ -179,8 +256,12 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			name: "reference count in reference",
-			expr: filter.ReferenceCount("ownedBy", "hasFriends").LessThan(4),
-			want: api.Filter{
+			expr: &filter.Cond{
+				Target:   filter.ReferenceCount("ownedBy", "hasFriends"),
+				Operator: filter.LessThan,
+				Value:    4,
+			},
+			want: &api.FilterExpr{
 				Operator: api.FilterOperatorLessThan,
 				Target:   []string{"ownedBy", "count(hasFriends)"},
 				Value:    4,
@@ -188,21 +269,17 @@ func TestFilter(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			checkExpr(t, tt.expr, tt.want)
+			checkExpr(t, tt.expr.Expr(), tt.want)
 		})
 	}
 }
 
 // checkExpr asserts that [filter.Expr] returns the expected operator,
 // target, test value, and sub-expressions.
-func checkExpr(t *testing.T, e filter.Expr, want api.Filter) {
-	assert.Equal(t, want.Operator, e.Operator(), "want %s, got %s", want.Operator, e.Operator())
-	assert.Equal(t, want.Target, e.Target(), "target")
-	assert.EqualValues(t, want.Value, e.Value(), "value")
-
-	exprs := e.Exprs()
-	assert.Len(t, exprs, len(want.Exprs), "sub-expressions")
-	for i := range exprs {
-		checkExpr(t, exprs[i], want.Exprs[i])
+func checkExpr(t *testing.T, got, want *api.FilterExpr) {
+	assert.Equal(t, want, got)
+	assert.Len(t, got.Exprs, len(want.Exprs), "sub-expressions")
+	for i := range got.Exprs {
+		checkExpr(t, &got.Exprs[i], &want.Exprs[i])
 	}
 }

--- a/query/hybrid.go
+++ b/query/hybrid.go
@@ -74,6 +74,7 @@ func hybridFunc(t internal.Transport, rd api.RequestDefaults) HybridFunc {
 			AutoLimit:              h.AutoLimit,
 			Offset:                 h.Offset,
 			After:                  h.After,
+			Filter:                 h.Filter,
 			ReturnVectors:          h.ReturnVectors,
 			ReturnMetadata:         h.ReturnMetadata,
 			ReturnProperties:       h.ReturnProperties,

--- a/query/hybrid.go
+++ b/query/hybrid.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/query/filter"
 )
 
 type Hybrid struct {
@@ -13,6 +14,7 @@ type Hybrid struct {
 	Offset                 int32            // Skip the first N objects in the collection.
 	AutoLimit              int32            // Return objects in the first N similarity clusters.
 	After                  uuid.UUID        // Skip all objects before the one with this ID.
+	Filter                 filter.Expr      // Filter results based on their properties.
 	ReturnMetadata         ReturnMetadata   // Select query and object metadata to return for each object.
 	ReturnVectors          []string         // List vectors to return for each object in the result set.
 	ReturnReferences       []Reference      // Select reference properties to return.

--- a/query/near_text.go
+++ b/query/near_text.go
@@ -74,6 +74,7 @@ func nearTextFunc(t internal.Transport, rd api.RequestDefaults) NearTextFunc {
 			AutoLimit:              nt.AutoLimit,
 			Offset:                 nt.Offset,
 			After:                  nt.After,
+			Filter:                 nt.Filter,
 			ReturnVectors:          nt.ReturnVectors,
 			ReturnMetadata:         nt.ReturnMetadata,
 			ReturnProperties:       nt.ReturnProperties,

--- a/query/near_text.go
+++ b/query/near_text.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/query/filter"
 )
 
 type NearText struct {
@@ -13,6 +14,7 @@ type NearText struct {
 	Offset                 int32            // Skip the first N objects in the collection.
 	AutoLimit              int32            // Return objects in the first N similarity clusters.
 	After                  uuid.UUID        // Skip all objects before the one with this ID.
+	Filter                 filter.Expr      // Filter results based on their properties.
 	ReturnMetadata         ReturnMetadata   // Select query and object metadata to return for each object.
 	ReturnVectors          []string         // List vectors to return for each object in the result set.
 	ReturnReferences       []Reference      // Select reference properties to return.

--- a/query/near_vector.go
+++ b/query/near_vector.go
@@ -54,6 +54,7 @@ func nearVectorFunc(t internal.Transport, rd api.RequestDefaults) NearVectorFunc
 			AutoLimit:              nv.AutoLimit,
 			Offset:                 nv.Offset,
 			After:                  nv.After,
+			Filter:                 nv.Filter,
 			ReturnVectors:          nv.ReturnVectors,
 			ReturnMetadata:         nv.ReturnMetadata,
 			ReturnProperties:       nv.ReturnProperties,

--- a/query/near_vector.go
+++ b/query/near_vector.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/query/filter"
 )
 
 type NearVector struct {
@@ -13,6 +14,7 @@ type NearVector struct {
 	Offset                 int32            // Skip the first N objects in the collection.
 	AutoLimit              int32            // Return objects in the first N similarity clusters.
 	After                  uuid.UUID        // Skip all objects before the one with this ID.
+	Filter                 filter.Expr      // Filter results based on their properties.
 	ReturnMetadata         ReturnMetadata   // Select query and object metadata to return for each object.
 	ReturnVectors          []string         // List vectors to return for each object in the result set.
 	ReturnReferences       []Reference      // Select reference properties to return.

--- a/query/near_vector_test.go
+++ b/query/near_vector_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
 	"github.com/weaviate/weaviate-go-client/v6/query"
+	"github.com/weaviate/weaviate-go-client/v6/query/filter"
 	"github.com/weaviate/weaviate-go-client/v6/types"
 )
 
@@ -41,6 +42,17 @@ func TestNearVector(t *testing.T) {
 				AutoLimit:  3,
 				After:      testkit.UUID,
 				Similarity: query.Distance(.456),
+				Target: &types.Vector{
+					Single: singleVector,
+				},
+				Filter: filter.And{
+					filter.Not(filter.Property[string]("album").Like(".*Blood")),
+					filter.Or{
+						filter.Len("tags").LessThanEqual(22),
+						filter.Property[string]("tags").ContainsNone("#doom", "#punk"),
+						filter.ReferenceCount("performedBy").Equal(4),
+					},
+				},
 				ReturnMetadata: query.ReturnMetadata{
 					CreatedAt:    true,
 					LastUpdateAt: true,
@@ -48,9 +60,6 @@ func TestNearVector(t *testing.T) {
 					Certainty:    true,
 					Score:        true,
 					ExplainScore: true,
-				},
-				Target: &types.Vector{
-					Single: singleVector,
 				},
 				ReturnVectors:    []string{"title_vec", "lyrics_vec"},
 				ReturnProperties: []string{"title", "duration_sec", "release_date"},
@@ -91,6 +100,39 @@ func TestNearVector(t *testing.T) {
 						Offset:          2,
 						AutoLimit:       3,
 						After:           testkit.UUID,
+						Filter: api.Filter{
+							Operator: api.FilterOperatorAnd,
+							Exprs: []api.Filter{
+								{
+									Operator: api.FilterOperatorNot,
+									Exprs: []api.Filter{{
+										Operator: api.FilterOperatorLike,
+										Target:   []string{"album"},
+										Value:    ".*Blood",
+									}},
+								},
+								{
+									Operator: api.FilterOperatorOr,
+									Exprs: []api.Filter{
+										{
+											Operator: api.FilterOperatorLessThanEqual,
+											Target:   []string{"len(tags)"},
+											Value:    int64(22),
+										},
+										{
+											Operator: api.FilterOperatorContainsNone,
+											Target:   []string{"tags"},
+											Value:    []string{"#doom", "#punk"},
+										},
+										{
+											Operator: api.FilterOperatorEqual,
+											Target:   []string{"count(performedBy)"},
+											Value:    int64(4),
+										},
+									},
+								},
+							},
+						},
 						ReturnMetadata: api.ReturnMetadata{
 							CreatedAt:    true,
 							LastUpdateAt: true,

--- a/query/near_vector_test.go
+++ b/query/near_vector_test.go
@@ -48,7 +48,7 @@ func TestNearVector(t *testing.T) {
 				Filter: filter.And{
 					filter.Not{
 						P: &filter.Cond{
-							Target:   []string{"album"},
+							Target:   "album",
 							Operator: filter.Like,
 							Value:    ".*Blood",
 						},
@@ -60,12 +60,12 @@ func TestNearVector(t *testing.T) {
 							Value:    int64(22),
 						},
 						&filter.Cond{
-							Target:   []string{"tags"},
+							Target:   "tags",
 							Operator: filter.ContainsNone,
 							Value:    []string{"#doom", "#punk"},
 						},
 						&filter.Cond{
-							Target:   filter.ReferenceCount("performedBy"),
+							Target:   filter.Reference("performedBy").Count(),
 							Operator: filter.Equal,
 							Value:    int64(4),
 						},

--- a/query/near_vector_test.go
+++ b/query/near_vector_test.go
@@ -46,11 +46,13 @@ func TestNearVector(t *testing.T) {
 					Single: singleVector,
 				},
 				Filter: filter.And{
-					filter.Not{&filter.Cond{
-						Target:   []string{"album"},
-						Operator: filter.Like,
-						Value:    ".*Blood",
-					}},
+					filter.Not{
+						P: &filter.Cond{
+							Target:   []string{"album"},
+							Operator: filter.Like,
+							Value:    ".*Blood",
+						},
+					},
 					filter.Or{
 						&filter.Cond{
 							Target:   filter.Len("tags"),

--- a/query/near_vector_test.go
+++ b/query/near_vector_test.go
@@ -46,11 +46,27 @@ func TestNearVector(t *testing.T) {
 					Single: singleVector,
 				},
 				Filter: filter.And{
-					filter.Not(filter.Property[string]("album").Like(".*Blood")),
+					filter.Not{&filter.Cond{
+						Target:   []string{"album"},
+						Operator: filter.Like,
+						Value:    ".*Blood",
+					}},
 					filter.Or{
-						filter.Len("tags").LessThanEqual(22),
-						filter.Property[string]("tags").ContainsNone("#doom", "#punk"),
-						filter.ReferenceCount("performedBy").Equal(4),
+						&filter.Cond{
+							Target:   filter.Len("tags"),
+							Operator: filter.LessThanEqual,
+							Value:    int64(22),
+						},
+						&filter.Cond{
+							Target:   []string{"tags"},
+							Operator: filter.ContainsNone,
+							Value:    []string{"#doom", "#punk"},
+						},
+						&filter.Cond{
+							Target:   filter.ReferenceCount("performedBy"),
+							Operator: filter.Equal,
+							Value:    int64(4),
+						},
 					},
 				},
 				ReturnMetadata: query.ReturnMetadata{
@@ -100,12 +116,12 @@ func TestNearVector(t *testing.T) {
 						Offset:          2,
 						AutoLimit:       3,
 						After:           testkit.UUID,
-						Filter: api.Filter{
+						Filter: api.FilterExpr{
 							Operator: api.FilterOperatorAnd,
-							Exprs: []api.Filter{
+							Exprs: []api.FilterExpr{
 								{
 									Operator: api.FilterOperatorNot,
-									Exprs: []api.Filter{{
+									Exprs: []api.FilterExpr{{
 										Operator: api.FilterOperatorLike,
 										Target:   []string{"album"},
 										Value:    ".*Blood",
@@ -113,7 +129,7 @@ func TestNearVector(t *testing.T) {
 								},
 								{
 									Operator: api.FilterOperatorOr,
-									Exprs: []api.Filter{
+									Exprs: []api.FilterExpr{
 										{
 											Operator: api.FilterOperatorLessThanEqual,
 											Target:   []string{"len(tags)"},


### PR DESCRIPTION
This PR adds support for filter expressions in all supported queries. To avoid polluting the `query` namespaces all related types / functions are provided via a dedicated `query/filter` package. The expressions are composable and allow expressing complex filtering logic concisely.

~~The syntax for reference targets should be considered experimental: we might introduce a dedicated variadic `Reference` method and reserve `Property` to just single names and/or introduce method chaining similar to how it's done in the Python client.~~

The `query/filter` package trades clever for simple: rather than hide internal filter structure behind builders, we export a simple `Cond` struct with fields for Target, Operator, and Value. The `And`, `Or`, and `Not` types offer some syntactic sugar, but only insofar as the standard language syntax permits, e.g. And is a _slice_ of filter expressions.

For now, the goal is to keep both the API surface and the implementation small; we should revisit filters before GA, ideally with some real-world code snippets at hand. 



