### PR TITLE
feat: add sanity tests for BLOB_HASH property type

### DIFF
--- a/test/docker-compose-wcs.yml
+++ b/test/docker-compose-wcs.yml
@@ -38,7 +38,6 @@ services:
       ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT: 'true'
       DISABLE_TELEMETRY: 'true'
       PERSISTENCE_MEMTABLES_FLUSH_IDLE_AFTER_SECONDS: 1
-      ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT: 'true'
   contextionary:
     image: semitechnologies/contextionary:en0.16.0-v1.2.1
     environment:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -29,7 +29,6 @@ services:
       DISABLE_TELEMETRY: 'true'
       CLUSTER_HOSTNAME: 'node1'
       PERSISTENCE_MEMTABLES_FLUSH_IDLE_AFTER_SECONDS: 1
-      ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT: 'true'
   contextionary:
     image: semitechnologies/contextionary:en0.16.0-v1.2.1
     environment:

--- a/test/schema/schema_test.go
+++ b/test/schema/schema_test.go
@@ -815,6 +815,44 @@ func TestSchema_integration(t *testing.T) {
 		require.NoError(t, errRm)
 	})
 
+	t.Run("Create class with BlobHash property", func(t *testing.T) {
+		ctx := context.Background()
+		client := testsuit.CreateTestClient(false)
+
+		className := "Document"
+		schemaClass := &models.Class{
+			Class:      className,
+			Vectorizer: "none",
+			Properties: []*models.Property{
+				{
+					Name:     "title",
+					DataType: schema.DataTypeText.PropString(),
+				},
+				{
+					Name:     "content",
+					DataType: schema.DataTypeBlobHash.PropString(),
+				},
+			},
+		}
+
+		client.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+		err := client.Schema().ClassCreator().WithClass(schemaClass).Do(ctx)
+		require.NoError(t, err)
+
+		loadedClass, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+		require.NoError(t, err)
+		require.Equal(t, className, loadedClass.Class)
+		require.Len(t, loadedClass.Properties, 2)
+		assert.Equal(t, "title", loadedClass.Properties[0].Name)
+		assert.Equal(t, schema.DataTypeText.PropString(), loadedClass.Properties[0].DataType)
+		assert.Equal(t, "content", loadedClass.Properties[1].Name)
+		assert.Equal(t, schema.DataTypeBlobHash.PropString(), loadedClass.Properties[1].DataType)
+
+		// Clean up
+		errRm := client.Schema().AllDeleter().Do(ctx)
+		require.NoError(t, errRm)
+	})
+
 	t.Run("tear down weaviate", func(t *testing.T) {
 		err := testenv.TearDownLocalWeaviate()
 		if err != nil {


### PR DESCRIPTION
## Summary
- Adds a `TestSchema_integration` subtest that creates a class with a `blobHash` property and verifies it round-trips through the schema API.

Closes #377

## Test plan
- [ ] CI integration tests pass against Weaviate `1.37.2`