### PR TITLE
chore(testsuit): add WV_TEST_HOST/WV_TEST_*_PORT overrides

### DIFF
--- a/test/auth/auth_test.go
+++ b/test/auth/auth_test.go
@@ -48,7 +48,7 @@ func TestAuth_clientCredential(t *testing.T) {
 		}
 
 		clientCredentialConf := auth.ClientCredentials{ClientSecret: clientSecret, Scopes: tc.scope}
-		cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", tc.port), Scheme: "http", StartupTimeout: 60 * time.Second, AuthConfig: clientCredentialConf}
+		cfg := weaviate.Config{Host: fmt.Sprintf("%s:%v", testsuit.OIDCHost, tc.port), Scheme: "http", StartupTimeout: 60 * time.Second, AuthConfig: clientCredentialConf}
 		client, err := weaviate.NewClient(cfg)
 		assert.Nil(t, err)
 
@@ -76,7 +76,7 @@ func TestAuth_clientCredential_WrongParameters(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			clientCredentialConf := auth.ClientCredentials{ClientSecret: tc.secret, Scopes: tc.scope}
 
-			cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.OktaCCPort), Scheme: "http", StartupTimeout: 20 * time.Second, AuthConfig: clientCredentialConf}
+			cfg := weaviate.Config{Host: fmt.Sprintf("%s:%v", testsuit.OIDCHost, testsuit.OktaCCPort), Scheme: "http", StartupTimeout: 20 * time.Second, AuthConfig: clientCredentialConf}
 			client, err := weaviate.NewClient(cfg)
 			assert.NotNil(t, err)
 			assert.Nil(t, client)
@@ -90,13 +90,14 @@ func TestAuth_UserPW(t *testing.T) {
 		user    string
 		envVar  string
 		scope   []string
+		host    string
 		port    int
 		warning bool
 	}{
-		{name: "WCS", user: wcsUser, envVar: "WCS_DUMMY_CI_PW", port: testsuit.WCSPort, warning: false},
-		{name: "Okta (no scope)", user: oktaUser, envVar: "OKTA_DUMMY_CI_PW", port: testsuit.OktaUsersPort, warning: false},
-		{name: "Okta", user: oktaUser, envVar: "OKTA_DUMMY_CI_PW", port: testsuit.OktaUsersPort, scope: []string{"offline_access"}, warning: false},
-		{name: "Okta (scope without refresh)", user: oktaUser, envVar: "OKTA_DUMMY_CI_PW", port: testsuit.OktaUsersPort, scope: []string{"offline_access"}, warning: true},
+		{name: "WCS", user: wcsUser, envVar: "WCS_DUMMY_CI_PW", host: testsuit.WCSHost, port: testsuit.WCSPort, warning: false},
+		{name: "Okta (no scope)", user: oktaUser, envVar: "OKTA_DUMMY_CI_PW", host: testsuit.OIDCHost, port: testsuit.OktaUsersPort, warning: false},
+		{name: "Okta", user: oktaUser, envVar: "OKTA_DUMMY_CI_PW", host: testsuit.OIDCHost, port: testsuit.OktaUsersPort, scope: []string{"offline_access"}, warning: false},
+		{name: "Okta (scope without refresh)", user: oktaUser, envVar: "OKTA_DUMMY_CI_PW", host: testsuit.OIDCHost, port: testsuit.OktaUsersPort, scope: []string{"offline_access"}, warning: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -116,7 +117,7 @@ func TestAuth_UserPW(t *testing.T) {
 				// test accessing the buffer.
 				clientCredentialConf := auth.ResourceOwnerPasswordFlow{Username: tc.user, Password: pw, Scopes: tc.scope}
 
-				cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", tc.port), Scheme: "http", StartupTimeout: 60 * time.Second, AuthConfig: clientCredentialConf}
+				cfg := weaviate.Config{Host: fmt.Sprintf("%s:%v", tc.host, tc.port), Scheme: "http", StartupTimeout: 60 * time.Second, AuthConfig: clientCredentialConf}
 				client, err := weaviate.NewClient(cfg)
 				assert.Nil(t, err)
 
@@ -134,13 +135,13 @@ func TestAuth_UserPW(t *testing.T) {
 
 func TestAuth_UserPW_wrongPW(t *testing.T) {
 	clientCredentialConf := auth.ResourceOwnerPasswordFlow{Username: "SomeUsername", Password: "IamWrong"}
-	cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.WCSPort), Scheme: "http", StartupTimeout: 60 * time.Second, AuthConfig: clientCredentialConf}
+	cfg := weaviate.Config{Host: fmt.Sprintf("%s:%v", testsuit.WCSHost, testsuit.WCSPort), Scheme: "http", StartupTimeout: 60 * time.Second, AuthConfig: clientCredentialConf}
 	_, err := weaviate.NewClient(cfg)
 	assert.NotNil(t, err)
 }
 
 func TestNoAuthOnWeaviateWithoutAuth(t *testing.T) {
-	cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.NoAuthPort), Scheme: "http", StartupTimeout: 60 * time.Second}
+	cfg := weaviate.Config{Host: fmt.Sprintf("%s:%v", testsuit.NoAuthHost, testsuit.NoAuthPort), Scheme: "http", StartupTimeout: 60 * time.Second}
 	client, err := weaviate.NewClient(cfg)
 	assert.Nil(t, err)
 
@@ -149,7 +150,7 @@ func TestNoAuthOnWeaviateWithoutAuth(t *testing.T) {
 }
 
 func TestNoAuthOnWeaviateWithAuth(t *testing.T) {
-	cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.WCSPort), Scheme: "http", StartupTimeout: 60 * time.Second}
+	cfg := weaviate.Config{Host: fmt.Sprintf("%s:%v", testsuit.WCSHost, testsuit.WCSPort), Scheme: "http", StartupTimeout: 60 * time.Second}
 	client, err := weaviate.NewClient(cfg)
 	assert.Nil(t, err)
 
@@ -177,7 +178,7 @@ func TestAuthOnWeaviateWithoutAuth(t *testing.T) {
 			defer func() {
 				log.SetOutput(os.Stderr)
 			}()
-			cfg := weaviate.Config{Host: fmt.Sprintf("localhost:%v", testsuit.NoAuthPort), Scheme: "http", StartupTimeout: 60 * time.Second, AuthConfig: tc.authConfig}
+			cfg := weaviate.Config{Host: fmt.Sprintf("%s:%v", testsuit.NoAuthHost, testsuit.NoAuthPort), Scheme: "http", StartupTimeout: 60 * time.Second, AuthConfig: tc.authConfig}
 			client, err := weaviate.NewClient(cfg)
 			assert.Nil(t, err)
 			assert.True(t, strings.Contains(buf.String(), "The client was configured to use authentication"))
@@ -189,7 +190,7 @@ func TestAuthOnWeaviateWithoutAuth(t *testing.T) {
 }
 
 func TestAuthNoWeaviateOnPort(t *testing.T) {
-	cfg := weaviate.Config{Host: "localhost:" + fmt.Sprint(testsuit.NoWeaviatePort), Scheme: "http", StartupTimeout: 0 * time.Second, AuthConfig: auth.ResourceOwnerPasswordFlow{Username: "SomeUsername", Password: "IamWrong"}}
+	cfg := weaviate.Config{Host: fmt.Sprintf("%s:%v", testsuit.BrokenHost, testsuit.BrokenPort), Scheme: "http", StartupTimeout: 0 * time.Second, AuthConfig: auth.ResourceOwnerPasswordFlow{Username: "SomeUsername", Password: "IamWrong"}}
 	_, err := weaviate.NewClient(cfg)
 	assert.NotNil(t, err)
 }
@@ -199,10 +200,11 @@ func TestAuthBearerToken(t *testing.T) {
 		name   string
 		user   string
 		envVar string
+		host   string
 		port   int
 	}{
-		{name: "WCS", user: wcsUser, envVar: "WCS_DUMMY_CI_PW", port: testsuit.WCSPort},
-		{name: "Okta", user: oktaUser, envVar: "OKTA_DUMMY_CI_PW", port: testsuit.OktaUsersPort},
+		{name: "WCS", user: wcsUser, envVar: "WCS_DUMMY_CI_PW", host: testsuit.WCSHost, port: testsuit.WCSPort},
+		{name: "Okta", user: oktaUser, envVar: "OKTA_DUMMY_CI_PW", host: testsuit.OIDCHost, port: testsuit.OktaUsersPort},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -210,7 +212,7 @@ func TestAuthBearerToken(t *testing.T) {
 			if pw == "" {
 				t.Skip("No password supplied for " + tc.name)
 			}
-			url := fmt.Sprintf("localhost:%v", tc.port)
+			url := fmt.Sprintf("%s:%v", tc.host, tc.port)
 
 			accessToken, refreshToken := getAccessToken(t, url, tc.user, pw)
 			cfg := weaviate.Config{Host: url, Scheme: "http", StartupTimeout: 60 * time.Second, AuthConfig: auth.BearerToken{AccessToken: accessToken, RefreshToken: refreshToken}}

--- a/test/client/startup_test.go
+++ b/test/client/startup_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func TestStartupTimeout_REST(t *testing.T) {
-	_, grpcPort, authEnabled := testsuit.GetPortAndAuthPw()
+	_, _, grpcHost, grpcPort, authEnabled := testsuit.GetHostsPortsAndAuthPw()
 	cfg := weaviate.Config{
-		Host:   fmt.Sprintf("localhost:%v", testsuit.NoWeaviatePort),
+		Host:   fmt.Sprintf("%s:%v", testsuit.BrokenHost, testsuit.BrokenPort),
 		Scheme: "http",
 		GrpcConfig: &grpc.Config{
-			Host: fmt.Sprintf("localhost:%v", grpcPort),
+			Host: fmt.Sprintf("%s:%v", grpcHost, grpcPort),
 		},
 		StartupTimeout: time.Second,
 	}
@@ -31,12 +31,12 @@ func TestStartupTimeout_REST(t *testing.T) {
 }
 
 func TestStartupTimeout_GRPC(t *testing.T) {
-	port, _, authEnabled := testsuit.GetPortAndAuthPw()
+	host, port, _, _, authEnabled := testsuit.GetHostsPortsAndAuthPw()
 	cfg := weaviate.Config{
-		Host:   fmt.Sprintf("localhost:%v", port),
+		Host:   fmt.Sprintf("%s:%v", host, port),
 		Scheme: "http",
 		GrpcConfig: &grpc.Config{
-			Host: fmt.Sprintf("localhost:%v", testsuit.NoWeaviateGRPCPort),
+			Host: fmt.Sprintf("%s:%v", testsuit.BrokenHost, testsuit.BrokenGRPCPort),
 		},
 		StartupTimeout: time.Second,
 	}

--- a/test/misc/misc_version_check_test.go
+++ b/test/misc/misc_version_check_test.go
@@ -24,9 +24,9 @@ func TestMisc_version_check(t *testing.T) {
 	})
 
 	t.Run("Weaviate is not live, perform live check", func(t *testing.T) {
-		port, _, _ := testsuit.GetPortAndAuthPw()
+		host, port, _, _, _ := testsuit.GetHostsPortsAndAuthPw()
 		cfg := &weaviate.Config{
-			Host:    fmt.Sprintf("localhost:%v", port),
+			Host:    fmt.Sprintf("%s:%v", host, port),
 			Scheme:  "http",
 			Headers: map[string]string{},
 		}
@@ -97,9 +97,9 @@ func TestMisc_empty_version_check(t *testing.T) {
 		}
 	})
 	t.Run("Weaviate is not live, perform live check", func(t *testing.T) {
-		port, _, _ := testsuit.GetPortAndAuthPw()
+		host, port, _, _, _ := testsuit.GetHostsPortsAndAuthPw()
 		cfg := &weaviate.Config{
-			Host:    fmt.Sprintf("localhost:%v", port),
+			Host:    fmt.Sprintf("%s:%v", host, port),
 			Scheme:  "http",
 			Headers: map[string]string{},
 		}

--- a/test/testsuit/generics.go
+++ b/test/testsuit/generics.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"slices"
+	"strconv"
 	"testing"
 
 	"github.com/weaviate/weaviate-go-client/v5/test"
@@ -23,18 +24,58 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
-const (
-	NoAuthPort         = 8080
-	NoAuthGRPCPort     = 50051
-	AzurePort          = 8081
-	OktaCCPort         = 8082
-	OktaUsersPort      = 8083
-	WCSPort            = 8085
-	WCSGRPCPort        = 50056
-	NoWeaviatePort     = 8888
-	NoWeaviateGRPCPort = 55555
-	RbacPort           = 8089
+var (
+	NoAuthHost     = envStr("WV_TEST_HOST", "localhost")
+	NoAuthPort     = envInt("WV_TEST_REST_PORT", 8080)
+	NoAuthGRPCHost = envStr("WV_TEST_HOST", "localhost")
+	NoAuthGRPCPort = envInt("WV_TEST_GRPC_PORT", 50051)
+
+	WCSHost     = envStr("WV_TEST_AUTH_HOST", "localhost")
+	WCSPort     = envInt("WV_TEST_AUTH_REST_PORT", 8085)
+	WCSGRPCHost = envStr("WV_TEST_AUTH_HOST", "localhost")
+	WCSGRPCPort = envInt("WV_TEST_AUTH_GRPC_PORT", 50056)
+
+	OIDCHost      = envStr("WV_TEST_OIDC_HOST", "localhost")
+	AzurePort     = envInt("WV_TEST_OIDC_AZURE_PORT", 8081)
+	OktaCCPort    = envInt("WV_TEST_OIDC_OKTA_CC_PORT", 8082)
+	OktaUsersPort = envInt("WV_TEST_OIDC_OKTA_USERS_PORT", 8083)
+
+	RbacHost     = envStr("WV_TEST_RBAC_HOST", "localhost")
+	RbacPort     = envInt("WV_TEST_RBAC_REST_PORT", 8089)
+	RbacGRPCPort = envInt("WV_TEST_RBAC_GRPC_PORT", 50063)
+
+	VectorHost     = envStr("WV_TEST_VECTOR_HOST", "localhost")
+	VectorPort     = envInt("WV_TEST_VECTOR_REST_PORT", 8086)
+	VectorGRPCPort = envInt("WV_TEST_VECTOR_GRPC_PORT", 50057)
+
+	ClusterHost     = envStr("WV_TEST_CLUSTER_HOST", "localhost")
+	ClusterPort     = envInt("WV_TEST_CLUSTER_REST_PORT", 8087)
+	ClusterGRPCPort = envInt("WV_TEST_CLUSTER_GRPC_PORT", 50058)
+
+	BrokenHost     = envStr("WV_TEST_BROKEN_HOST", "localhost")
+	BrokenPort     = envInt("WV_TEST_BROKEN_REST_PORT", 8888)
+	BrokenGRPCPort = envInt("WV_TEST_BROKEN_GRPC_PORT", 55555)
 )
+
+// envStr returns the value of the named environment variable, or def if unset
+// or empty.
+func envStr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// envInt returns the integer value of the named environment variable, or def
+// if unset, empty, or unparseable.
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
 
 const ENV_INTEGRATION_TESTS_AUTH = "INTEGRATION_TESTS_AUTH"
 
@@ -52,6 +93,23 @@ func GetPortAndAuthPw() (int, int, bool) {
 		grpcPort = WCSGRPCPort
 	}
 	return port, grpcPort, authEnabled
+}
+
+// GetHostsPortsAndAuthPw returns the REST host, REST port, gRPC host, gRPC
+// port, and whether auth is enabled, picking the auth-instance addresses when
+// auth is on.
+func GetHostsPortsAndAuthPw() (string, int, string, int, bool) {
+	host := NoAuthHost
+	port := NoAuthPort
+	grpcHost := NoAuthGRPCHost
+	grpcPort := NoAuthGRPCPort
+	if authEnabled {
+		host = WCSHost
+		port = WCSPort
+		grpcHost = WCSGRPCHost
+		grpcPort = WCSGRPCPort
+	}
+	return host, port, grpcHost, grpcPort, authEnabled
 }
 
 // CreateWeaviateTestSchemaFood creates a class for each semantic type (Pizza and Soup)
@@ -229,9 +287,15 @@ func CleanUpWeaviate(t *testing.T, client *weaviate.Client) {
 	}
 }
 
-// CreateTestClient running on localhost 8080
+// CreateTestClient creates a client targeting the configured test server.
 func CreateTestClient(enableGRPC bool) *weaviate.Client {
 	port, grpcPort, authEnabled := GetPortAndAuthPw()
+	host := NoAuthHost
+	grpcHost := NoAuthGRPCHost
+	if authEnabled {
+		host = WCSHost
+		grpcHost = WCSGRPCHost
+	}
 
 	headers := map[string]string{}
 	if openAIApiKey != "" {
@@ -242,13 +306,13 @@ func CreateTestClient(enableGRPC bool) *weaviate.Client {
 	}
 
 	cfg := weaviate.Config{
-		Host:    fmt.Sprintf("localhost:%v", port),
+		Host:    fmt.Sprintf("%s:%v", host, port),
 		Scheme:  "http",
 		Headers: headers,
 	}
 	if enableGRPC {
 		cfg.GrpcConfig = &grpc.Config{
-			Host: fmt.Sprintf("localhost:%v", grpcPort),
+			Host: fmt.Sprintf("%s:%v", grpcHost, grpcPort),
 		}
 	}
 

--- a/weaviate/testenv/environment.go
+++ b/weaviate/testenv/environment.go
@@ -75,12 +75,12 @@ func checkReady(initCtx context.Context, url string) error {
 //	due to syncing issues and speeds up the process
 func SetupLocalWeaviateWaitForStartup(waitForWeaviateStartup bool) error {
 	if !isExternalWeaviateRunning() {
-		port, _, authEnabled := testsuit.GetPortAndAuthPw()
+		host, port, _, _, authEnabled := testsuit.GetHostsPortsAndAuthPw()
 		if err := test.SetupWeaviate(authEnabled); err != nil {
 			return err
 		}
 		if waitForWeaviateStartup {
-			return waitForStartup(context.TODO(), fmt.Sprintf("localhost:%v", port), 1*time.Second)
+			return waitForStartup(context.TODO(), fmt.Sprintf("%s:%v", host, port), 1*time.Second)
 		}
 		return nil
 	}
@@ -123,8 +123,8 @@ func SetupLocalContainer(t *testing.T, ctx context.Context, preset test.Preset, 
 // isExternalWeaviateRunning checks if either EXTERNAL_WEAVIATE_RUNNING is set
 // or a Weaviate container is already running.
 func isExternalWeaviateRunning() bool {
-	port, _, _ := testsuit.GetPortAndAuthPw()
-	err := checkReady(context.TODO(), fmt.Sprintf("localhost:%v", port))
+	host, port, _, _, _ := testsuit.GetHostsPortsAndAuthPw()
+	err := checkReady(context.TODO(), fmt.Sprintf("%s:%v", host, port))
 	isRunning := err == nil
 
 	return envExternalWeaviateRunning || isRunning


### PR DESCRIPTION
## Summary

Add environment-variable overrides for the integration suite's host and per-service ports, matching a new ecosystem-wide convention.

- `WV_TEST_HOST` / `WV_TEST_REST_PORT` / `WV_TEST_GRPC_PORT` (primary)
- `WV_TEST_AUTH_HOST` / `WV_TEST_AUTH_REST_PORT` / `WV_TEST_AUTH_GRPC_PORT` (auth)

Defaults preserve existing behavior. Adds new exported vars `NoAuthHost`, `WCSHost`, etc. so consumers constructing `host:port` strings respect the override.

## Test plan
- [ ] CI green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)