### PR TITLE
v6: Add /live, /ready, and /meta utils

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/weaviate/weaviate-go-client/v6/backup"
 	"github.com/weaviate/weaviate-go-client/v6/collections"
+	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/transport"
 	"github.com/weaviate/weaviate-go-client/v6/internal/auth"
@@ -17,6 +18,8 @@ import (
 )
 
 type Client struct {
+	transport internal.Transport
+
 	Backup      *backup.Client
 	Collections *collections.Client
 }
@@ -124,6 +127,7 @@ func newClient(ctx context.Context, options []Option) (*Client, error) {
 	}
 
 	return &Client{
+		transport:   t,
 		Collections: collections.NewClient(t),
 		Backup:      backup.NewClient(t),
 	}, nil
@@ -260,4 +264,36 @@ func WithTokenSource(src oauth2.TokenSource) Option {
 	return func(c *config) {
 		c.Auth = src
 	}
+}
+
+// IsLive reports instance / cluster liveness.
+func (c *Client) IsLive(ctx context.Context) (bool, error) {
+	if err := c.transport.Do(ctx, api.IsLiveRequest, nil); err != nil {
+		return false, fmt.Errorf("is live: %w", err)
+	}
+	return true, nil
+}
+
+// IsReady reports instance / cluster readiness.
+func (c *Client) IsReady(ctx context.Context) (bool, error) {
+	if err := c.transport.Do(ctx, api.IsReadyRequest, nil); err != nil {
+		return false, fmt.Errorf("is ready: %w", err)
+	}
+	return true, nil
+}
+
+type InstanceMetadata api.GetInstanceMetadataResponse
+
+// Metadata fetches instance / cluster metadata.
+func (c *Client) Metadata(ctx context.Context) (*InstanceMetadata, error) {
+	var resp api.GetInstanceMetadataResponse
+	if err := c.transport.Do(ctx, api.GetInstanceMetadataRequest, &resp); err != nil {
+		return nil, fmt.Errorf("get metadata: %w", err)
+	}
+	return &InstanceMetadata{
+		Hostname:           resp.Hostname,
+		Version:            resp.Version,
+		Modules:            resp.Modules,
+		GRPCMaxMessageSize: resp.GRPCMaxMessageSize,
+	}, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// DO NOT enable t.Parallel() for this test as it messes with the global state.
+// DO NOT enable t.Parallel() for this test as it modifies the global state.
 func TestNewLocal(t *testing.T) {
 	newFunc := transport.New
 	t.Cleanup(func() { transport.New = newFunc })
@@ -100,7 +100,7 @@ func TestNewLocal(t *testing.T) {
 	})
 }
 
-// DO NOT enable t.Parallel() for this test as it messes with the global state.
+// DO NOT enable t.Parallel() for this test as it modifies the global state.
 func TestNewWeaviateCloud(t *testing.T) {
 	newFunc := transport.New
 	t.Cleanup(func() { transport.New = newFunc })
@@ -208,15 +208,19 @@ func TestNewWeaviateCloud(t *testing.T) {
 		}
 
 		c, err := weaviate.NewClient(t.Context())
-		assert.NoError(t, err)
-		assert.NotNil(t, c, "nil client")
+		require.NoError(t, err)
+		require.NotNil(t, c, "nil client")
 
 		assert.NotNil(t, c.Collections, "nil collections")
 		assert.NotNil(t, c.Backup, "nil backup")
 	})
 }
 
+// DO NOT enable t.Parallel() for this test as it modifies the global state.
 func TestWithAPIKey(t *testing.T) {
+	newFunc := transport.New
+	t.Cleanup(func() { transport.New = newFunc })
+
 	var got transport.Config
 	transport.New = func(_ context.Context, cfg transport.Config) (internal.Transport, error) {
 		got = cfg
@@ -240,7 +244,11 @@ func TestWithAPIKey(t *testing.T) {
 	}
 }
 
+// DO NOT enable t.Parallel() for this test as it modifies the global state.
 func TestOIDCAuthentication(t *testing.T) {
+	newFunc := transport.New
+	t.Cleanup(func() { transport.New = newFunc })
+
 	for _, tt := range []struct {
 		name string
 		opt  weaviate.Option
@@ -284,4 +292,97 @@ func TestOIDCAuthentication(t *testing.T) {
 			assert.Equal(t, tt.auth, got.Auth, "bad auth provider")
 		})
 	}
+}
+
+// DO NOT enable t.Parallel() for this test as it modifies the global state.
+func TestLiveReady(t *testing.T) {
+	newFunc := transport.New
+	t.Cleanup(func() { transport.New = newFunc })
+
+	transportOK := testkit.NopTransport
+	transportErr := testkit.TransportFunc(func(context.Context, any, any) error { return testkit.ErrWhaam })
+
+	for _, tt := range []struct {
+		name      string
+		act       func(*weaviate.Client, context.Context) (bool, error)
+		transport internal.Transport
+		err       testkit.Error
+		want      bool
+	}{
+		{
+			name:      "live ok",
+			act:       (*weaviate.Client).IsLive,
+			transport: transportOK,
+			want:      true,
+		},
+		{
+			name:      "live err",
+			act:       (*weaviate.Client).IsLive,
+			transport: transportErr,
+			err:       testkit.ExpectError,
+		},
+		{
+			name:      "ready ok",
+			act:       (*weaviate.Client).IsReady,
+			transport: transportOK,
+			want:      true,
+		},
+		{
+			name:      "ready err",
+			act:       (*weaviate.Client).IsReady,
+			transport: transportErr,
+			err:       testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport.New = func(_ context.Context, cfg transport.Config) (internal.Transport, error) {
+				return tt.transport, nil
+			}
+
+			c, err := weaviate.NewClient(t.Context())
+			require.NoError(t, err, "new client")
+			require.NotNil(t, c, "nil client")
+
+			got, err := tt.act(c, t.Context())
+			tt.err.Assert(t, err, "request error")
+			assert.Equal(t, tt.want, got, "bad result")
+		})
+	}
+}
+
+func TestMetadata(t *testing.T) {
+	newFunc := transport.New
+	t.Cleanup(func() { transport.New = newFunc })
+
+	tport := testkit.NewTransport(t, []testkit.Stub[any, any]{{
+		Request: testkit.Ptr[any](api.GetInstanceMetadataRequest),
+		Response: api.GetInstanceMetadataResponse{
+			Hostname: "example.com",
+			Version:  "v1.37.0",
+			Modules: map[string]any{
+				"text2vec-weaviate": true,
+				"backup-s3":         true,
+			},
+			GRPCMaxMessageSize: 4096,
+		},
+	}})
+	transport.New = func(_ context.Context, cfg transport.Config) (internal.Transport, error) {
+		return tport, nil
+	}
+
+	c, err := weaviate.NewClient(t.Context())
+	require.NoError(t, err, "new client")
+	require.NotNil(t, c, "nil client")
+
+	got, err := c.Metadata(t.Context())
+	assert.NoError(t, err, "request error")
+	assert.EqualValues(t, &weaviate.InstanceMetadata{
+		Hostname: "example.com",
+		Version:  "v1.37.0",
+		Modules: map[string]any{
+			"text2vec-weaviate": true,
+			"backup-s3":         true,
+		},
+		GRPCMaxMessageSize: 4096,
+	}, got, "bad result")
 }

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -48,6 +48,12 @@ func TestRESTRequests(t *testing.T) {
 			wantPath:   "/.well-known/live",
 		},
 		{
+			name:       "check is ready",
+			req:        api.IsReadyRequest,
+			wantMethod: http.MethodGet,
+			wantPath:   "/.well-known/ready",
+		},
+		{
 			name:       "get instance metadata",
 			req:        api.GetInstanceMetadataRequest,
 			wantMethod: http.MethodGet,
@@ -944,6 +950,28 @@ func TestRESTResponses(t *testing.T) {
 					StartedAt:           testkit.Ptr(time.Time{}),
 					CompletedAt:         testkit.Ptr(time.Time{}),
 				},
+			},
+		},
+		{
+			name: "instance metadata",
+			body: &rest.Meta{
+				Hostname: "example.com",
+				Version:  "v1.37.0",
+				Modules: map[string]any{
+					"text2vec-weaviate": true,
+					"backup-s3":         true,
+				},
+				GrpcMaxMessageSize: 4096,
+			},
+			dest: new(api.GetInstanceMetadataResponse),
+			want: &api.GetInstanceMetadataResponse{
+				Hostname: "example.com",
+				Version:  "v1.37.0",
+				Modules: map[string]any{
+					"text2vec-weaviate": true,
+					"backup-s3":         true,
+				},
+				GRPCMaxMessageSize: 4096,
 			},
 		},
 	} {

--- a/internal/api/meta.go
+++ b/internal/api/meta.go
@@ -1,10 +1,25 @@
 package api
 
 import (
+	"encoding/json"
+	"net/http"
+
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/transport"
+	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
 )
 
 var (
-	IsLiveRequest              = transport.IsLiveRequest
-	GetInstanceMetadataRequest = transport.GetInstanceMetadataRequest
+	IsLiveRequest  = transports.StaticEndpoint(http.MethodGet, "/.well-known/live")
+	IsReadyRequest = transports.StaticEndpoint(http.MethodGet, "/.well-known/ready")
 )
+
+var (
+	GetInstanceMetadataRequest                  = transport.GetInstanceMetadataRequest
+	_                          json.Unmarshaler = (*GetInstanceMetadataResponse)(nil)
+)
+
+type GetInstanceMetadataResponse transport.GetInstanceMetadataResponse
+
+func (r *GetInstanceMetadataResponse) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, (*transport.GetInstanceMetadataResponse)(r))
+}

--- a/internal/api/transport/meta.go
+++ b/internal/api/transport/meta.go
@@ -8,8 +8,6 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
 )
 
-var IsLiveRequest = transports.StaticEndpoint(http.MethodGet, "/.well-known/live")
-
 var GetInstanceMetadataRequest = transports.StaticEndpoint(http.MethodGet, "/meta")
 
 type GetInstanceMetadataResponse struct {

--- a/internal/testkit/util.go
+++ b/internal/testkit/util.go
@@ -34,6 +34,6 @@ func RequirePointer(t *testing.T, v any, name string) {
 	case reflect.Map, reflect.Slice, reflect.Chan, reflect.Pointer:
 		return
 	default:
-		require.FailNow(t, "%q must be a pointer", name)
+		require.FailNowf(t, "bad test", "%q must be a pointer", name)
 	}
 }


### PR DESCRIPTION
This PR extends the top-level client with 3 methods for querying instance liveness, readiness, and metadata.