### PR TITLE
v6: Batch delete

### DIFF
--- a/data/client.go
+++ b/data/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
+	"github.com/weaviate/weaviate-go-client/v6/query/filter"
 	"github.com/weaviate/weaviate-go-client/v6/types"
 )
 
@@ -179,6 +180,40 @@ func (c *Client) AddReferences(ctx context.Context, references ...Reference) (*A
 	}
 
 	return r, nil
+}
+
+type DeleteSelected struct {
+	// Filter selects objects which will be deleted.
+	Filter filter.Expr
+
+	// DryRun reports UUIDs that matched the filter
+	// without deleting the objects.
+	DryRun bool
+
+	Verbose bool
+}
+
+type DeleteSelectedResult api.DeleteObjectsResponse
+
+func (c *Client) DeleteSelected(ctx context.Context, options DeleteSelected) (*DeleteSelectedResult, error) {
+	req := &api.DeleteObjectsRequest{
+		RequestDefaults: c.defaults,
+		DryRun:          options.DryRun,
+		Verbose:         options.Verbose,
+	}
+
+	if options.Filter != nil {
+		if expr := options.Filter.Expr(); expr != nil {
+			req.Filter = *expr
+		}
+	}
+
+	var resp api.DeleteObjectsResponse
+	if err := c.transport.Do(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("delete selected objects: %w", err)
+	}
+
+	return (*DeleteSelectedResult)(&resp), nil
 }
 
 func apiVectors(vectors []types.Vector) []api.Vector {

--- a/data/client_test.go
+++ b/data/client_test.go
@@ -351,7 +351,7 @@ func TestClient_DeleteSelected(t *testing.T) {
 			name: "reported errors",
 			selected: data.DeleteSelected{
 				Filter: &filter.Cond{
-					Target:   []string{"reasons_to_keep"},
+					Target:   "reasons_to_keep",
 					Operator: filter.IsNull,
 				},
 				DryRun:  true,

--- a/data/client_test.go
+++ b/data/client_test.go
@@ -140,8 +140,9 @@ func TestClient_Replace(t *testing.T) {
 
 	for _, tt := range []struct {
 		name   string
-		object data.Object // Object to be replaced.
-		stub   []testkit.Stub[api.ReplaceObjectRequest, any]
+		object data.Object                   // Object to be replaced.
+		want   *types.Object[map[string]any] // Expected return value.
+		stubs  []testkit.Stub[api.ReplaceObjectRequest, any]
 		err    testkit.Error
 	}{
 		{
@@ -159,7 +160,7 @@ func TestClient_Replace(t *testing.T) {
 					},
 				},
 			},
-			stub: []testkit.Stub[api.ReplaceObjectRequest, any]{{
+			stubs: []testkit.Stub[api.ReplaceObjectRequest, any]{{
 				Request: &api.ReplaceObjectRequest{
 					RequestDefaults: rd,
 					UUID:            &testkit.UUID,
@@ -182,15 +183,15 @@ func TestClient_Replace(t *testing.T) {
 		},
 		{
 			name:   "with error",
-			object: data.Object{UUID: &testkit.UUID},
-			stub: []testkit.Stub[api.ReplaceObjectRequest, any]{
+			object: data.Object{UUID: &uuid.Nil},
+			stubs: []testkit.Stub[api.ReplaceObjectRequest, any]{
 				{Err: testkit.ErrWhaam},
 			},
 			err: testkit.ExpectError,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			transport := testkit.NewTransport(t, tt.stub)
+			transport := testkit.NewTransport(t, tt.stubs)
 			c := data.NewClient(transport, rd)
 			require.NotNil(t, c, "nil client")
 
@@ -208,15 +209,15 @@ func TestClient_Delete(t *testing.T) {
 	}
 
 	for _, tt := range []struct {
-		name string
-		uuid uuid.UUID // ID of the object to be deleted.
-		stub []testkit.Stub[api.DeleteObjectRequest, any]
-		err  testkit.Error
+		name  string
+		uuid  uuid.UUID // ID of the object to be deleted.
+		stubs []testkit.Stub[api.DeleteObjectRequest, any]
+		err   testkit.Error
 	}{
 		{
 			name: "ok",
 			uuid: testkit.UUID,
-			stub: []testkit.Stub[api.DeleteObjectRequest, any]{{
+			stubs: []testkit.Stub[api.DeleteObjectRequest, any]{{
 				Request: &api.DeleteObjectRequest{
 					RequestDefaults: rd,
 					UUID:            testkit.UUID,
@@ -226,14 +227,14 @@ func TestClient_Delete(t *testing.T) {
 		{
 			name: "with error",
 			uuid: testkit.UUID,
-			stub: []testkit.Stub[api.DeleteObjectRequest, any]{
+			stubs: []testkit.Stub[api.DeleteObjectRequest, any]{
 				{Err: testkit.ErrWhaam},
 			},
 			err: testkit.ExpectError,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			transport := testkit.NewTransport(t, tt.stub)
+			transport := testkit.NewTransport(t, tt.stubs)
 			c := data.NewClient(transport, rd)
 			require.NotNil(t, c, "nil client")
 

--- a/data/client_test.go
+++ b/data/client_test.go
@@ -5,10 +5,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate-go-client/v6/data"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+	"github.com/weaviate/weaviate-go-client/v6/query/filter"
 	"github.com/weaviate/weaviate-go-client/v6/types"
 )
 
@@ -326,6 +328,82 @@ func TestClient_AddReferences(t *testing.T) {
 			got, err := c.AddReferences(t.Context(), tt.references...)
 			tt.err.Require(t, err, "insert error")
 			require.Equal(t, tt.want, got, "returned object")
+		})
+	}
+}
+
+func TestClient_DeleteSelected(t *testing.T) {
+	rd := api.RequestDefaults{
+		CollectionName:   "DeleteSelected",
+		ConsistencyLevel: api.ConsistencyLevelOne,
+		Tenant:           "john_doe",
+	}
+
+	for _, tt := range []struct {
+		name     string
+		selected data.DeleteSelected
+		stubs    []testkit.Stub[api.DeleteObjectsRequest, api.DeleteObjectsResponse]
+		want     *data.DeleteSelectedResult
+		err      testkit.Error
+	}{
+		{
+			name: "reported errors",
+			selected: data.DeleteSelected{
+				Filter: &filter.Cond{
+					Target:   []string{"reasons_to_keep"},
+					Operator: filter.IsNull,
+				},
+				DryRun:  true,
+				Verbose: true,
+			},
+			stubs: []testkit.Stub[api.DeleteObjectsRequest, api.DeleteObjectsResponse]{
+				{
+					Request: &api.DeleteObjectsRequest{
+						RequestDefaults: rd,
+						Filter: api.FilterExpr{
+							Target:   []string{"reasons_to_keep"},
+							Operator: api.FilterOperatorIsNull,
+						},
+						DryRun:  true,
+						Verbose: true,
+					},
+					Response: api.DeleteObjectsResponse{
+						Took: 92 * time.Second,
+						Errors: map[uuid.UUID]error{
+							testkit.UUID: testkit.ErrWhaam,
+							uuid.Nil:     nil,
+						},
+					},
+				},
+			},
+			want: &data.DeleteSelectedResult{
+				Took: 92 * time.Second,
+				Errors: map[uuid.UUID]error{
+					testkit.UUID: testkit.ErrWhaam,
+					uuid.Nil:     nil,
+				},
+			},
+		},
+		{
+			name: "request error",
+			selected: data.DeleteSelected{
+				DryRun:  true,
+				Verbose: true,
+			},
+			stubs: []testkit.Stub[api.DeleteObjectsRequest, api.DeleteObjectsResponse]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := data.NewClient(transport, rd)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.DeleteSelected(t.Context(), tt.selected)
+			tt.err.Require(t, err, "delete error")
+			assert.EqualValues(t, tt.want, got, "bad result")
 		})
 	}
 }

--- a/internal/api/data.go
+++ b/internal/api/data.go
@@ -3,11 +3,13 @@ package api
 import (
 	"encoding"
 	"encoding/json"
+	"errors"
 	"maps"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/weaviate/weaviate-go-client/v6/internal"
 	proto "github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/proto/v1"
 
 	"github.com/google/uuid"
@@ -353,5 +355,67 @@ func marshalReferenceProperties(references References, dest *proto.BatchObject_P
 	}
 	dest.SingleTargetRefProps = single
 	dest.MultiTargetRefProps = multi
+	return nil
+}
+
+type DeleteObjectsRequest struct {
+	RequestDefaults
+	Filter          FilterExpr
+	Verbose, DryRun bool
+}
+
+var (
+	_ transport.Message[proto.BatchDeleteRequest, proto.BatchDeleteReply] = (*DeleteObjectsRequest)(nil)
+	_ transport.MessageMarshaler[proto.BatchDeleteRequest]                = (*DeleteObjectsRequest)(nil)
+)
+
+func (r *DeleteObjectsRequest) Method() transport.MethodFunc[proto.BatchDeleteRequest, proto.BatchDeleteReply] {
+	return proto.WeaviateClient.BatchDelete
+}
+
+func (r *DeleteObjectsRequest) Body() transport.MessageMarshaler[proto.BatchDeleteRequest] {
+	return r
+}
+
+func (r *DeleteObjectsRequest) MarshalMessage() (*proto.BatchDeleteRequest, error) {
+	return &proto.BatchDeleteRequest{
+		Collection:       r.CollectionName,
+		Tenant:           nilZero(r.Tenant),
+		ConsistencyLevel: r.ConsistencyLevel.proto(),
+		Verbose:          r.Verbose,
+		DryRun:           r.DryRun,
+		Filters:          marshalFilter(r.Filter),
+	}, nil
+}
+
+type DeleteObjectsResponse struct {
+	Took   time.Duration
+	Errors map[uuid.UUID]error
+}
+
+var _ transport.MessageUnmarshaler[proto.BatchDeleteReply] = (*DeleteObjectsResponse)(nil)
+
+func (r *DeleteObjectsResponse) UnmarshalMessage(reply *proto.BatchDeleteReply) error {
+	dev.AssertNotNil(reply, "reply")
+
+	errs := internal.MakeMap[uuid.UUID, error](int(reply.Matches))
+	for _, object := range reply.Objects {
+		id, err := uuid.FromBytes(object.Uuid)
+		if err != nil {
+			return err
+		}
+
+		var respErr error
+		if !object.Successful && object.Error != nil {
+			respErr = errors.New(*object.Error)
+		}
+
+		errs[id] = respErr
+	}
+
+	*r = DeleteObjectsResponse{
+		Took:   time.Duration(reply.Took) * time.Second,
+		Errors: errs,
+	}
 	return nil
 }

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -64,14 +64,6 @@ var (
 )
 
 func TestSearchRequest_MarshalMessage(t *testing.T) {
-	propertyTarget := func(s string) *proto.FilterTarget {
-		return &proto.FilterTarget{
-			Target: &proto.FilterTarget_Property{
-				Property: s,
-			},
-		}
-	}
-
 	// UUID is always included in the [proto.MetadataRequest].
 	testMessageMarshaler(t, []MessageMarshalerTest[proto.SearchRequest, proto.SearchReply]{
 		{
@@ -1099,6 +1091,14 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 	})
 }
 
+func propertyTarget(s string) *proto.FilterTarget {
+	return &proto.FilterTarget{
+		Target: &proto.FilterTarget_Property{
+			Property: s,
+		},
+	}
+}
+
 // TestAggregateRequest_MarshalMessage tests that api.AggregateRequest creates
 // the expected proto.AggregateRequest when its MarshalMessage is called.
 // Most of the test cases are split by property type to simplify error logs;
@@ -1488,6 +1488,51 @@ func TestInsertReferencesRequest_MarshalMessage(t *testing.T) {
 						Tenant:         "john_doe",
 					},
 				},
+			},
+		},
+	})
+}
+
+func TestDeleteObjectsRequest_MarshalMessage(t *testing.T) {
+	testMessageMarshaler(t, []MessageMarshalerTest[proto.BatchDeleteRequest, proto.BatchDeleteReply]{
+		{
+			name: "with request defaults",
+			req: &api.DeleteObjectsRequest{
+				RequestDefaults: api.RequestDefaults{
+					CollectionName:   "Songs",
+					ConsistencyLevel: api.ConsistencyLevelOne,
+					Tenant:           "john_doe",
+				},
+				Filter: api.FilterExpr{
+					Target:   []string{"album"},
+					Operator: api.FilterOperatorIsNull,
+				},
+				DryRun:  true,
+				Verbose: true,
+			},
+			want: &proto.BatchDeleteRequest{
+				Collection:       "Songs",
+				Tenant:           testkit.Ptr("john_doe"),
+				ConsistencyLevel: testkit.Ptr(proto.ConsistencyLevel_CONSISTENCY_LEVEL_ONE),
+				Filters: &proto.Filters{
+					Target:   propertyTarget("album"),
+					Operator: proto.Filters_OPERATOR_IS_NULL,
+				},
+				DryRun:  true,
+				Verbose: true,
+			},
+		},
+		{
+			name: "no tenant",
+			req: &api.DeleteObjectsRequest{
+				RequestDefaults: api.RequestDefaults{
+					CollectionName:   "Songs",
+					ConsistencyLevel: api.ConsistencyLevelOne,
+				},
+			},
+			want: &proto.BatchDeleteRequest{
+				Collection:       "Songs",
+				ConsistencyLevel: testkit.Ptr(proto.ConsistencyLevel_CONSISTENCY_LEVEL_ONE),
 			},
 		},
 	})
@@ -2395,6 +2440,38 @@ func TestInsertReferencesResponse_UnmarshalMessage(t *testing.T) {
 			reply: &proto.BatchReferencesReply{Took: 92},
 			dest:  new(api.InsertReferencesResponse),
 			want:  &api.InsertReferencesResponse{Took: 92 * time.Second},
+		},
+	})
+}
+
+func TestDeleteObjectsResponse_UnmarshalMessage(t *testing.T) {
+	testMessageUnmarshaler(t, []MessageUnmarshalerTest[proto.BatchDeleteReply]{
+		{
+			name: "has errors",
+			reply: &proto.BatchDeleteReply{
+				Took:       92,
+				Matches:    2,
+				Successful: 1,
+				Failed:     1,
+				Objects: []*proto.BatchDeleteObject{
+					{Uuid: testkit.UUID[:], Error: testkit.Ptr(testkit.ErrWhaam.Error())},
+					{Uuid: uuid.Nil[:], Successful: true, Error: nil},
+				},
+			},
+			dest: new(api.DeleteObjectsResponse),
+			want: &api.DeleteObjectsResponse{
+				Took: 92 * time.Second,
+				Errors: map[uuid.UUID]error{
+					testkit.UUID: testkit.ErrWhaam,
+					uuid.Nil:     nil,
+				},
+			},
+		},
+		{
+			name:  "no errors",
+			reply: &proto.BatchDeleteReply{Took: 92},
+			dest:  new(api.DeleteObjectsResponse),
+			want:  &api.DeleteObjectsResponse{Took: 92 * time.Second},
 		},
 	})
 }

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -310,7 +310,9 @@ func marshalFilter(f FilterExpr) *proto.Filters {
 		// Marshaling it would've been as simple as [structpb.NewValue].
 		switch v := f.Value.(type) {
 		case nil:
-			return nil // Null-ness should be checked via [FilterOperatorIsNull].
+			if f.Operator != FilterOperatorIsNull {
+				return nil // Null-ness should be checked via IsNull operator.
+			}
 		case string:
 			pf.TestValue = &proto.Filters_ValueText{ValueText: v}
 		case []string:

--- a/internal/api/transport/message.go
+++ b/internal/api/transport/message.go
@@ -33,7 +33,8 @@ type RequestMessage interface {
 	proto.SearchRequest |
 		proto.AggregateRequest |
 		proto.BatchObjectsRequest |
-		proto.BatchReferencesRequest
+		proto.BatchReferencesRequest |
+		proto.BatchDeleteRequest
 }
 
 // ReplyMessage enumerates gRPC replies supported by [proto.WeaviateClient].
@@ -41,7 +42,8 @@ type ReplyMessage interface {
 	proto.SearchReply |
 		proto.AggregateReply |
 		proto.BatchObjectsReply |
-		proto.BatchReferencesReply
+		proto.BatchReferencesReply |
+		proto.BatchDeleteReply
 }
 
 // MethodFunc is a method of the proto.WeaviateClient interface

--- a/query/over_all_test.go
+++ b/query/over_all_test.go
@@ -37,7 +37,7 @@ func TestOverAll(t *testing.T) {
 				After:     testkit.UUID,
 				Filter: filter.Not{
 					P: &filter.Cond{
-						Target:   []string{"album"},
+						Target:   "album",
 						Operator: filter.Like,
 						Value:    ".*Blood",
 					},


### PR DESCRIPTION
This PR adds support for `BatchDelete` operation, allowing users to delete objects which match the filtering criteria. 

Unlike in #386, I decided not to remove the single-target `Delete` method in favor of the batched solution. The input types are different, as Delete allows removing the object by just providing the UUID without fiddling with the filters. 

The batch delete method is called `DeleteSelected` but I'm happy to change that to `DeleteMany` or `BatchDelete`.