### PR TITLE
v6(RBAC): Roles

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/transport"
 	"github.com/weaviate/weaviate-go-client/v6/internal/auth"
+	"github.com/weaviate/weaviate-go-client/v6/rbac"
 	"golang.org/x/oauth2"
 )
 
@@ -23,6 +24,7 @@ type Client struct {
 
 	Backup      *backup.Client
 	Collections *collections.Client
+	Roles       *rbac.RolesClient
 }
 
 var _ io.Closer = (*Client)(nil)
@@ -133,6 +135,7 @@ func newClient(ctx context.Context, options []Option) (*Client, error) {
 		transport:   t,
 		Collections: collections.NewClient(t),
 		Backup:      backup.NewClient(t),
+		Roles:       rbac.NewRolesClient(t),
 	}, nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -214,6 +214,7 @@ func TestNewWeaviateCloud(t *testing.T) {
 
 		assert.NotNil(t, c.Collections, "nil collections")
 		assert.NotNil(t, c.Backup, "nil backup")
+		assert.NotNil(t, c.Roles, "nil roles")
 	})
 }
 

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -573,6 +573,7 @@ func TestRESTRequests(t *testing.T) {
 						Users: []api.UserPermission{
 							{UserID: "john_doe", Create: true, Read: true},
 							{UserID: "jane_doe", Update: true, Delete: true},
+							{UserID: "jim_beam", AssignAndRevoke: true},
 						},
 					},
 				},
@@ -820,6 +821,12 @@ func TestRESTRequests(t *testing.T) {
 						"action": "delete_users",
 						"users": map[string]any{
 							"user": "jane_doe",
+						},
+					},
+					{
+						"action": "assign_and_revoke_users",
+						"users": map[string]any{
+							"user": "jim_beam",
 						},
 					},
 				},
@@ -1466,6 +1473,12 @@ func TestRESTResponses(t *testing.T) {
 							"user": "jane_doe",
 						},
 					},
+					{
+						"action": "assign_and_revoke_users",
+						"users": map[string]any{
+							"user": "jim_beam",
+						},
+					},
 				},
 			},
 			dest: new(api.Role),
@@ -1549,6 +1562,7 @@ func TestRESTResponses(t *testing.T) {
 					Users: []api.UserPermission{
 						{UserID: "john_doe", Create: true, Read: true},
 						{UserID: "jane_doe", Update: true, Delete: true},
+						{UserID: "jim_beam", AssignAndRevoke: true},
 					},
 				},
 			},

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -537,6 +537,9 @@ func TestRESTRequests(t *testing.T) {
 							{Collection: "Songs", Verbosity: api.NodeVerbosityMinimal, Read: true},
 							{Collection: "Artists", Verbosity: api.NodeVerbosityVerbose, Read: true},
 						},
+						MCP: []api.MCPPermission{
+							{Create: true, Read: true, Update: true},
+						},
 						Replication: []api.ReplicationPermission{
 							{
 								Collection: "Songs", Shard: "abc",
@@ -701,6 +704,15 @@ func TestRESTRequests(t *testing.T) {
 							"collection": "Artists",
 							"verbosity":  api.NodeVerbosityVerbose,
 						},
+					},
+					{
+						"action": "create_mcp",
+					},
+					{
+						"action": "read_mcp",
+					},
+					{
+						"action": "update_mcp",
 					},
 					{
 						"action": "create_replicate",
@@ -1338,6 +1350,15 @@ func TestRESTResponses(t *testing.T) {
 						},
 					},
 					{
+						"action": "create_mcp",
+					},
+					{
+						"action": "read_mcp",
+					},
+					{
+						"action": "update_mcp",
+					},
+					{
 						"action": "create_replicate",
 						"replicate": map[string]any{
 							"collection": "Songs",
@@ -1491,6 +1512,9 @@ func TestRESTResponses(t *testing.T) {
 					Nodes: []api.NodesPermission{
 						{Collection: "Songs", Verbosity: api.NodeVerbosityMinimal, Read: true},
 						{Collection: "Artists", Verbosity: api.NodeVerbosityVerbose, Read: true},
+					},
+					MCP: []api.MCPPermission{
+						{Create: true, Read: true, Update: true},
 					},
 					Replication: []api.ReplicationPermission{
 						{

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -510,7 +510,7 @@ func TestRESTRequests(t *testing.T) {
 							{Collection: "Songs", Manage: true},
 						},
 						Cluster: []api.ClusterPermission{{Read: true}},
-						Collections: []api.CollectionsPermission{
+						Collections: []api.CollectionPermission{
 							{Collection: "Songs", Create: true, Read: true},
 							{Collection: "Artists", Update: true, Delete: true},
 						},
@@ -524,7 +524,7 @@ func TestRESTRequests(t *testing.T) {
 								Update: true, Delete: true,
 							},
 						},
-						Groups: []api.GroupsPermission{
+						Groups: []api.GroupPermission{
 							{
 								GroupID: "external", Type: "oidc",
 								Read: true, AssignAndRevoke: true,
@@ -547,17 +547,17 @@ func TestRESTRequests(t *testing.T) {
 								Update: true, Delete: true,
 							},
 						},
-						Roles: []api.RolesPermission{
+						Roles: []api.RolePermission{
 							{
-								RoleID: "rock-n-role", Scope: api.RolesScopeAll,
+								RoleID: "rock-n-role", Scope: api.RoleScopeAll,
 								Create: true, Read: true,
 							},
 							{
-								RoleID: "rock-n-role", Scope: api.RolesScopeMatch,
+								RoleID: "rock-n-role", Scope: api.RoleScopeMatch,
 								Update: true, Delete: true,
 							},
 						},
-						Tenants: []api.TenantsPermission{
+						Tenants: []api.TenantPermission{
 							{
 								Collection: "Songs", Tenant: "john_doe",
 								Create: true, Read: true,
@@ -567,7 +567,7 @@ func TestRESTRequests(t *testing.T) {
 								Update: true, Delete: true,
 							},
 						},
-						Users: []api.UsersPermission{
+						Users: []api.UserPermission{
 							{UserID: "john_doe", Create: true, Read: true},
 							{UserID: "jane_doe", Update: true, Delete: true},
 						},
@@ -734,28 +734,28 @@ func TestRESTRequests(t *testing.T) {
 						"action": "create_roles",
 						"roles": map[string]any{
 							"role":  "rock-n-role",
-							"scope": api.RolesScopeAll,
+							"scope": api.RoleScopeAll,
 						},
 					},
 					{
 						"action": "read_roles",
 						"roles": map[string]any{
 							"role":  "rock-n-role",
-							"scope": api.RolesScopeAll,
+							"scope": api.RoleScopeAll,
 						},
 					},
 					{
 						"action": "update_roles",
 						"roles": map[string]any{
 							"role":  "rock-n-role",
-							"scope": api.RolesScopeMatch,
+							"scope": api.RoleScopeMatch,
 						},
 					},
 					{
 						"action": "delete_roles",
 						"roles": map[string]any{
 							"role":  "rock-n-role",
-							"scope": api.RolesScopeMatch,
+							"scope": api.RoleScopeMatch,
 						},
 					},
 					{
@@ -1303,28 +1303,28 @@ func TestRESTResponses(t *testing.T) {
 						"action": "create_roles",
 						"roles": map[string]any{
 							"role":  "rock-n-role",
-							"scope": api.RolesScopeAll,
+							"scope": api.RoleScopeAll,
 						},
 					},
 					{
 						"action": "read_roles",
 						"roles": map[string]any{
 							"role":  "rock-n-role",
-							"scope": api.RolesScopeAll,
+							"scope": api.RoleScopeAll,
 						},
 					},
 					{
 						"action": "update_roles",
 						"roles": map[string]any{
 							"role":  "rock-n-role",
-							"scope": api.RolesScopeMatch,
+							"scope": api.RoleScopeMatch,
 						},
 					},
 					{
 						"action": "delete_roles",
 						"roles": map[string]any{
 							"role":  "rock-n-role",
-							"scope": api.RolesScopeMatch,
+							"scope": api.RoleScopeMatch,
 						},
 					},
 					{
@@ -1399,7 +1399,7 @@ func TestRESTResponses(t *testing.T) {
 						{Collection: "Songs", Manage: true},
 					},
 					Cluster: []api.ClusterPermission{{Read: true}},
-					Collections: []api.CollectionsPermission{
+					Collections: []api.CollectionPermission{
 						{Collection: "Songs", Create: true, Read: true},
 						{Collection: "Artists", Update: true, Delete: true},
 					},
@@ -1413,7 +1413,7 @@ func TestRESTResponses(t *testing.T) {
 							Update: true, Delete: true,
 						},
 					},
-					Groups: []api.GroupsPermission{
+					Groups: []api.GroupPermission{
 						{
 							GroupID: "external", Type: "oidc",
 							Read: true, AssignAndRevoke: true,
@@ -1436,17 +1436,17 @@ func TestRESTResponses(t *testing.T) {
 							Update: true, Delete: true,
 						},
 					},
-					Roles: []api.RolesPermission{
+					Roles: []api.RolePermission{
 						{
-							RoleID: "rock-n-role", Scope: api.RolesScopeAll,
+							RoleID: "rock-n-role", Scope: api.RoleScopeAll,
 							Create: true, Read: true,
 						},
 						{
-							RoleID: "rock-n-role", Scope: api.RolesScopeMatch,
+							RoleID: "rock-n-role", Scope: api.RoleScopeMatch,
 							Update: true, Delete: true,
 						},
 					},
-					Tenants: []api.TenantsPermission{
+					Tenants: []api.TenantPermission{
 						{
 							Collection: "Songs", Tenant: "john_doe",
 							Create: true, Read: true,
@@ -1456,7 +1456,7 @@ func TestRESTResponses(t *testing.T) {
 							Update: true, Delete: true,
 						},
 					},
-					Users: []api.UsersPermission{
+					Users: []api.UserPermission{
 						{UserID: "john_doe", Create: true, Read: true},
 						{UserID: "jane_doe", Update: true, Delete: true},
 					},

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -831,6 +831,72 @@ func TestRESTRequests(t *testing.T) {
 			wantMethod: http.MethodGet,
 			wantPath:   "/authz/roles",
 		},
+		{
+			name:       "get assigned users",
+			req:        api.GetAssignedUsersRequest("rock-n-role"),
+			wantMethod: http.MethodGet,
+			wantPath:   "/authz/roles/rock-n-role/users",
+		},
+		{
+			name:       "get user assignments",
+			req:        api.GetUserAssignmentsRequest("rock-n-role"),
+			wantMethod: http.MethodGet,
+			wantPath:   "/authz/roles/rock-n-role/user-assignments",
+		},
+		{
+			name:       "get group assignments",
+			req:        api.GetGroupAssignmentsRequest("rock-n-role"),
+			wantMethod: http.MethodGet,
+			wantPath:   "/authz/roles/rock-n-role/group-assignments",
+		},
+		{
+			name: "add permissions to role",
+			req: &api.AddPermissionsRequest{
+				RoleID: "rock-n-role",
+				Permissions: api.Permissions{
+					Cluster: []api.ClusterPermission{
+						{Read: true},
+					},
+				},
+			},
+			wantMethod: http.MethodPost,
+			wantPath:   "/authz/roles/rock-n-role/add-permissions",
+			wantBody: map[string]any{
+				"permissions": []map[string]any{
+					{"action": "read_cluster"},
+				},
+			},
+		},
+		{
+			name: "remove permissions from role",
+			req: &api.RemovePermissionsRequest{
+				RoleID: "rock-n-role",
+				Permissions: api.Permissions{
+					Cluster: []api.ClusterPermission{
+						{Read: true},
+					},
+				},
+			},
+			wantMethod: http.MethodPost,
+			wantPath:   "/authz/roles/rock-n-role/remove-permissions",
+			wantBody: map[string]any{
+				"permissions": []map[string]any{
+					{"action": "read_cluster"},
+				},
+			},
+		},
+		{
+			name: "check role has permission",
+			req: &api.HasPermissionRequest{
+				RoleID:  "rock-n-role",
+				Cluster: api.ClusterPermission{Read: true},
+			},
+			wantMethod: http.MethodPost,
+			wantPath:   "/authz/roles/rock-n-role/has-permission",
+			wantBody: map[string]any{
+				"action": "read_cluster",
+			},
+		},
 	}) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Implements(t, (*transports.Endpoint)(nil), tt.req)
@@ -1461,6 +1527,36 @@ func TestRESTResponses(t *testing.T) {
 						{UserID: "jane_doe", Update: true, Delete: true},
 					},
 				},
+			},
+		},
+		{
+			name: "role has permission",
+			body: testkit.Ptr(true),
+			dest: new(api.HasPermissionResponse),
+			want: testkit.Ptr[api.HasPermissionResponse](true),
+		},
+		{
+			name: "user assignment",
+			body: map[string]any{
+				"userId":   "john_doe",
+				"userType": "db_env",
+			},
+			dest: new(api.UserAssignment),
+			want: &api.UserAssignment{
+				ID:   "john_doe",
+				Type: "db_env",
+			},
+		},
+		{
+			name: "group assignment",
+			body: map[string]any{
+				"groupId":   "external",
+				"groupType": "oidc",
+			},
+			dest: new(api.GroupAssignment),
+			want: &api.GroupAssignment{
+				ID:   "external",
+				Type: "oidc",
 			},
 		},
 	} {

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -1176,209 +1176,209 @@ func TestRESTResponses(t *testing.T) {
 							"alias":      "Musicians",
 						},
 					},
-					// 	{
-					// 		"action": "manage_backups",
-					// 		"backups": map[string]any{
-					// 			"collection": "Songs",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "read_cluster",
-					// 	},
-					// 	{
-					// 		"action": "create_collections",
-					// 		"collections": map[string]any{
-					// 			"collection": "Songs",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "read_collections",
-					// 		"collections": map[string]any{
-					// 			"collection": "Songs",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "update_collections",
-					// 		"collections": map[string]any{
-					// 			"collection": "Artists",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "delete_collections",
-					// 		"collections": map[string]any{
-					// 			"collection": "Artists",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "create_data",
-					// 		"data": map[string]any{
-					// 			"collection": "Songs",
-					// 			"tenant":     "john_doe",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "read_data",
-					// 		"data": map[string]any{
-					// 			"collection": "Songs",
-					// 			"tenant":     "john_doe",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "update_data",
-					// 		"data": map[string]any{
-					// 			"collection": "Artists",
-					// 			"object":     "12345678-.*",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "delete_data",
-					// 		"data": map[string]any{
-					// 			"collection": "Artists",
-					// 			"object":     "12345678-.*",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "read_groups",
-					// 		"groups": map[string]any{
-					// 			"group":     "external",
-					// 			"groupType": "oidc",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "assign_and_revoke_groups",
-					// 		"groups": map[string]any{
-					// 			"group":     "external",
-					// 			"groupType": "oidc",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "manage_namespaces",
-					// 		"namespaces": map[string]any{
-					// 			"namespace": "sandbox",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "read_nodes",
-					// 		"nodes": map[string]any{
-					// 			"collection": "Songs",
-					// 			"verbosity":  api.NodeVerbosityMinimal,
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "read_nodes",
-					// 		"nodes": map[string]any{
-					// 			"collection": "Artists",
-					// 			"verbosity":  api.NodeVerbosityVerbose,
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "create_replicate",
-					// 		"replicate": map[string]any{
-					// 			"collection": "Songs",
-					// 			"shard":      "abc",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "read_replicate",
-					// 		"replicate": map[string]any{
-					// 			"collection": "Songs",
-					// 			"shard":      "abc",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "update_replicate",
-					// 		"replicate": map[string]any{
-					// 			"collection": "Songs",
-					// 			"shard":      "xyz",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "delete_replicate",
-					// 		"replicate": map[string]any{
-					// 			"collection": "Songs",
-					// 			"shard":      "xyz",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "create_roles",
-					// 		"roles": map[string]any{
-					// 			"role":  "rock-n-role",
-					// 			"scope": api.RolesScopeAll,
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "read_roles",
-					// 		"roles": map[string]any{
-					// 			"role":  "rock-n-role",
-					// 			"scope": api.RolesScopeAll,
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "update_roles",
-					// 		"roles": map[string]any{
-					// 			"role":  "rock-n-role",
-					// 			"scope": api.RolesScopeMatch,
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "delete_roles",
-					// 		"roles": map[string]any{
-					// 			"role":  "rock-n-role",
-					// 			"scope": api.RolesScopeMatch,
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "create_tenants",
-					// 		"tenants": map[string]any{
-					// 			"collection": "Songs",
-					// 			"tenant":     "john_doe",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "read_tenants",
-					// 		"tenants": map[string]any{
-					// 			"collection": "Songs",
-					// 			"tenant":     "john_doe",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "update_tenants",
-					// 		"tenants": map[string]any{
-					// 			"collection": "Artists",
-					// 			"tenant":     "*",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "delete_tenants",
-					// 		"tenants": map[string]any{
-					// 			"collection": "Artists",
-					// 			"tenant":     "*",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "create_users",
-					// 		"users": map[string]any{
-					// 			"user": "john_doe",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "read_users",
-					// 		"users": map[string]any{
-					// 			"user": "john_doe",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "update_users",
-					// 		"users": map[string]any{
-					// 			"user": "jane_doe",
-					// 		},
-					// 	},
-					// 	{
-					// 		"action": "delete_users",
-					// 		"users": map[string]any{
-					// 			"user": "jane_doe",
-					// 		},
-					// 	},
+					{
+						"action": "manage_backups",
+						"backups": map[string]any{
+							"collection": "Songs",
+						},
+					},
+					{
+						"action": "read_cluster",
+					},
+					{
+						"action": "create_collections",
+						"collections": map[string]any{
+							"collection": "Songs",
+						},
+					},
+					{
+						"action": "read_collections",
+						"collections": map[string]any{
+							"collection": "Songs",
+						},
+					},
+					{
+						"action": "update_collections",
+						"collections": map[string]any{
+							"collection": "Artists",
+						},
+					},
+					{
+						"action": "delete_collections",
+						"collections": map[string]any{
+							"collection": "Artists",
+						},
+					},
+					{
+						"action": "create_data",
+						"data": map[string]any{
+							"collection": "Songs",
+							"tenant":     "john_doe",
+						},
+					},
+					{
+						"action": "read_data",
+						"data": map[string]any{
+							"collection": "Songs",
+							"tenant":     "john_doe",
+						},
+					},
+					{
+						"action": "update_data",
+						"data": map[string]any{
+							"collection": "Artists",
+							"object":     "12345678-.*",
+						},
+					},
+					{
+						"action": "delete_data",
+						"data": map[string]any{
+							"collection": "Artists",
+							"object":     "12345678-.*",
+						},
+					},
+					{
+						"action": "read_groups",
+						"groups": map[string]any{
+							"group":     "external",
+							"groupType": "oidc",
+						},
+					},
+					{
+						"action": "assign_and_revoke_groups",
+						"groups": map[string]any{
+							"group":     "external",
+							"groupType": "oidc",
+						},
+					},
+					{
+						"action": "manage_namespaces",
+						"namespaces": map[string]any{
+							"namespace": "sandbox",
+						},
+					},
+					{
+						"action": "read_nodes",
+						"nodes": map[string]any{
+							"collection": "Songs",
+							"verbosity":  api.NodeVerbosityMinimal,
+						},
+					},
+					{
+						"action": "read_nodes",
+						"nodes": map[string]any{
+							"collection": "Artists",
+							"verbosity":  api.NodeVerbosityVerbose,
+						},
+					},
+					{
+						"action": "create_replicate",
+						"replicate": map[string]any{
+							"collection": "Songs",
+							"shard":      "abc",
+						},
+					},
+					{
+						"action": "read_replicate",
+						"replicate": map[string]any{
+							"collection": "Songs",
+							"shard":      "abc",
+						},
+					},
+					{
+						"action": "update_replicate",
+						"replicate": map[string]any{
+							"collection": "Songs",
+							"shard":      "xyz",
+						},
+					},
+					{
+						"action": "delete_replicate",
+						"replicate": map[string]any{
+							"collection": "Songs",
+							"shard":      "xyz",
+						},
+					},
+					{
+						"action": "create_roles",
+						"roles": map[string]any{
+							"role":  "rock-n-role",
+							"scope": api.RolesScopeAll,
+						},
+					},
+					{
+						"action": "read_roles",
+						"roles": map[string]any{
+							"role":  "rock-n-role",
+							"scope": api.RolesScopeAll,
+						},
+					},
+					{
+						"action": "update_roles",
+						"roles": map[string]any{
+							"role":  "rock-n-role",
+							"scope": api.RolesScopeMatch,
+						},
+					},
+					{
+						"action": "delete_roles",
+						"roles": map[string]any{
+							"role":  "rock-n-role",
+							"scope": api.RolesScopeMatch,
+						},
+					},
+					{
+						"action": "create_tenants",
+						"tenants": map[string]any{
+							"collection": "Songs",
+							"tenant":     "john_doe",
+						},
+					},
+					{
+						"action": "read_tenants",
+						"tenants": map[string]any{
+							"collection": "Songs",
+							"tenant":     "john_doe",
+						},
+					},
+					{
+						"action": "update_tenants",
+						"tenants": map[string]any{
+							"collection": "Artists",
+							"tenant":     "*",
+						},
+					},
+					{
+						"action": "delete_tenants",
+						"tenants": map[string]any{
+							"collection": "Artists",
+							"tenant":     "*",
+						},
+					},
+					{
+						"action": "create_users",
+						"users": map[string]any{
+							"user": "john_doe",
+						},
+					},
+					{
+						"action": "read_users",
+						"users": map[string]any{
+							"user": "john_doe",
+						},
+					},
+					{
+						"action": "update_users",
+						"users": map[string]any{
+							"user": "jane_doe",
+						},
+					},
+					{
+						"action": "delete_users",
+						"users": map[string]any{
+							"user": "jane_doe",
+						},
+					},
 				},
 			},
 			dest: new(api.Role),
@@ -1395,71 +1395,71 @@ func TestRESTResponses(t *testing.T) {
 							Update: true, Delete: true,
 						},
 					},
-					// Backups: []api.BackupsPermission{
-					// 	{Collection: "Songs", Manage: true},
-					// },
-					// Cluster: []api.ClusterPermission{{Read: true}},
-					// Collections: []api.CollectionsPermission{
-					// 	{Collection: "Songs", Create: true, Read: true},
-					// 	{Collection: "Artists", Update: true, Delete: true},
-					// },
-					// Data: []api.DataPermission{
-					// 	{
-					// 		Collection: "Songs", Tenant: "john_doe",
-					// 		Create: true, Read: true,
-					// 	},
-					// 	{
-					// 		Collection: "Artists", Object: "12345678-.*",
-					// 		Update: true, Delete: true,
-					// 	},
-					// },
-					// Groups: []api.GroupsPermission{
-					// 	{
-					// 		GroupID: "external", Type: "oidc",
-					// 		Read: true, AssignAndRevoke: true,
-					// 	},
-					// },
-					// Namespaces: []api.NamespacePermission{
-					// 	{Namespace: "sandbox", Manage: true},
-					// },
-					// Nodes: []api.NodesPermission{
-					// 	{Collection: "Songs", Verbosity: api.NodeVerbosityMinimal, Read: true},
-					// 	{Collection: "Artists", Verbosity: api.NodeVerbosityVerbose, Read: true},
-					// },
-					// Replication: []api.ReplicationPermission{
-					// 	{
-					// 		Collection: "Songs", Shard: "abc",
-					// 		Create: true, Read: true,
-					// 	},
-					// 	{
-					// 		Collection: "Songs", Shard: "xyz",
-					// 		Update: true, Delete: true,
-					// 	},
-					// },
-					// Roles: []api.RolesPermission{
-					// 	{
-					// 		RoleID: "rock-n-role", Scope: api.RolesScopeAll,
-					// 		Create: true, Read: true,
-					// 	},
-					// 	{
-					// 		RoleID: "rock-n-role", Scope: api.RolesScopeMatch,
-					// 		Update: true, Delete: true,
-					// 	},
-					// },
-					// Tenants: []api.TenantsPermission{
-					// 	{
-					// 		Collection: "Songs", Tenant: "john_doe",
-					// 		Create: true, Read: true,
-					// 	},
-					// 	{
-					// 		Collection: "Artists", Tenant: "*",
-					// 		Update: true, Delete: true,
-					// 	},
-					// },
-					// Users: []api.UsersPermission{
-					// 	{UserID: "john_doe", Create: true, Read: true},
-					// 	{UserID: "jane_doe", Update: true, Delete: true},
-					// },
+					Backups: []api.BackupsPermission{
+						{Collection: "Songs", Manage: true},
+					},
+					Cluster: []api.ClusterPermission{{Read: true}},
+					Collections: []api.CollectionsPermission{
+						{Collection: "Songs", Create: true, Read: true},
+						{Collection: "Artists", Update: true, Delete: true},
+					},
+					Data: []api.DataPermission{
+						{
+							Collection: "Songs", Tenant: "john_doe",
+							Create: true, Read: true,
+						},
+						{
+							Collection: "Artists", Object: "12345678-.*",
+							Update: true, Delete: true,
+						},
+					},
+					Groups: []api.GroupsPermission{
+						{
+							GroupID: "external", Type: "oidc",
+							Read: true, AssignAndRevoke: true,
+						},
+					},
+					Namespaces: []api.NamespacePermission{
+						{Namespace: "sandbox", Manage: true},
+					},
+					Nodes: []api.NodesPermission{
+						{Collection: "Songs", Verbosity: api.NodeVerbosityMinimal, Read: true},
+						{Collection: "Artists", Verbosity: api.NodeVerbosityVerbose, Read: true},
+					},
+					Replication: []api.ReplicationPermission{
+						{
+							Collection: "Songs", Shard: "abc",
+							Create: true, Read: true,
+						},
+						{
+							Collection: "Songs", Shard: "xyz",
+							Update: true, Delete: true,
+						},
+					},
+					Roles: []api.RolesPermission{
+						{
+							RoleID: "rock-n-role", Scope: api.RolesScopeAll,
+							Create: true, Read: true,
+						},
+						{
+							RoleID: "rock-n-role", Scope: api.RolesScopeMatch,
+							Update: true, Delete: true,
+						},
+					},
+					Tenants: []api.TenantsPermission{
+						{
+							Collection: "Songs", Tenant: "john_doe",
+							Create: true, Read: true,
+						},
+						{
+							Collection: "Artists", Tenant: "*",
+							Update: true, Delete: true,
+						},
+					},
+					Users: []api.UsersPermission{
+						{UserID: "john_doe", Create: true, Read: true},
+						{UserID: "jane_doe", Update: true, Delete: true},
+					},
 				},
 			},
 		},

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -662,14 +662,12 @@ func TestRESTRequests(t *testing.T) {
 						"action": "update_data",
 						"data": map[string]any{
 							"collection": "Artists",
-							"object":     "12345678-.*",
 						},
 					},
 					{
 						"action": "delete_data",
 						"data": map[string]any{
 							"collection": "Artists",
-							"object":     "12345678-.*",
 						},
 					},
 					{
@@ -1312,14 +1310,12 @@ func TestRESTResponses(t *testing.T) {
 						"action": "update_data",
 						"data": map[string]any{
 							"collection": "Artists",
-							"object":     "12345678-.*",
 						},
 					},
 					{
 						"action": "delete_data",
 						"data": map[string]any{
 							"collection": "Artists",
-							"object":     "12345678-.*",
 						},
 					},
 					{

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -520,8 +520,8 @@ func TestRESTRequests(t *testing.T) {
 								Create: true, Read: true,
 							},
 							{
-								Collection: "Artists", Object: "12345678-.*",
-								Update: true, Delete: true,
+								Collection: "Artists",
+								Update:     true, Delete: true,
 							},
 						},
 						Groups: []api.GroupPermission{
@@ -1509,8 +1509,8 @@ func TestRESTResponses(t *testing.T) {
 							Create: true, Read: true,
 						},
 						{
-							Collection: "Artists", Object: "12345678-.*",
-							Update: true, Delete: true,
+							Collection: "Artists",
+							Update:     true, Delete: true,
 						},
 					},
 					Groups: []api.GroupPermission{

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -490,6 +490,347 @@ func TestRESTRequests(t *testing.T) {
 			wantMethod: http.MethodDelete,
 			wantPath:   "/backups/filesystem/bak-1/restore",
 		},
+		{
+			name: "create role",
+			req: &api.CreateRoleRequest{
+				Role: api.Role{
+					ID: "rock-n-role",
+					Permissions: api.Permissions{
+						Aliases: []api.AliasPermission{
+							{
+								Collection: "Songs", Alias: "Records",
+								Create: true, Read: true,
+							},
+							{
+								Collection: "Artists", Alias: "Musicians",
+								Update: true, Delete: true,
+							},
+						},
+						Backups: []api.BackupsPermission{
+							{Collection: "Songs", Manage: true},
+						},
+						Cluster: []api.ClusterPermission{{Read: true}},
+						Collections: []api.CollectionsPermission{
+							{Collection: "Songs", Create: true, Read: true},
+							{Collection: "Artists", Update: true, Delete: true},
+						},
+						Data: []api.DataPermission{
+							{
+								Collection: "Songs", Tenant: "john_doe",
+								Create: true, Read: true,
+							},
+							{
+								Collection: "Artists", Object: "12345678-.*",
+								Update: true, Delete: true,
+							},
+						},
+						Groups: []api.GroupsPermission{
+							{
+								GroupID: "external", Type: "oidc",
+								Read: true, AssignAndRevoke: true,
+							},
+						},
+						Namespaces: []api.NamespacePermission{
+							{Namespace: "sandbox", Manage: true},
+						},
+						Nodes: []api.NodesPermission{
+							{Collection: "Songs", Verbosity: api.NodeVerbosityMinimal, Read: true},
+							{Collection: "Artists", Verbosity: api.NodeVerbosityVerbose, Read: true},
+						},
+						Replication: []api.ReplicationPermission{
+							{
+								Collection: "Songs", Shard: "abc",
+								Create: true, Read: true,
+							},
+							{
+								Collection: "Songs", Shard: "xyz",
+								Update: true, Delete: true,
+							},
+						},
+						Roles: []api.RolesPermission{
+							{
+								RoleID: "rock-n-role", Scope: api.RolesScopeAll,
+								Create: true, Read: true,
+							},
+							{
+								RoleID: "rock-n-role", Scope: api.RolesScopeMatch,
+								Update: true, Delete: true,
+							},
+						},
+						Tenants: []api.TenantsPermission{
+							{
+								Collection: "Songs", Tenant: "john_doe",
+								Create: true, Read: true,
+							},
+							{
+								Collection: "Artists", Tenant: "*",
+								Update: true, Delete: true,
+							},
+						},
+						Users: []api.UsersPermission{
+							{UserID: "john_doe", Create: true, Read: true},
+							{UserID: "jane_doe", Update: true, Delete: true},
+						},
+					},
+				},
+			},
+			wantMethod: http.MethodPost,
+			wantPath:   "/authz/roles",
+			wantBody: map[string]any{
+				"name": "rock-n-role",
+				"permissions": []map[string]any{
+					{
+						"action": "create_aliases",
+						"aliases": map[string]any{
+							"collection": "Songs",
+							"alias":      "Records",
+						},
+					},
+					{
+						"action": "read_aliases",
+						"aliases": map[string]any{
+							"collection": "Songs",
+							"alias":      "Records",
+						},
+					},
+					{
+						"action": "update_aliases",
+						"aliases": map[string]any{
+							"collection": "Artists",
+							"alias":      "Musicians",
+						},
+					},
+					{
+						"action": "delete_aliases",
+						"aliases": map[string]any{
+							"collection": "Artists",
+							"alias":      "Musicians",
+						},
+					},
+					{
+						"action": "manage_backups",
+						"backups": map[string]any{
+							"collection": "Songs",
+						},
+					},
+					{
+						"action": "read_cluster",
+					},
+					{
+						"action": "create_collections",
+						"collections": map[string]any{
+							"collection": "Songs",
+						},
+					},
+					{
+						"action": "read_collections",
+						"collections": map[string]any{
+							"collection": "Songs",
+						},
+					},
+					{
+						"action": "update_collections",
+						"collections": map[string]any{
+							"collection": "Artists",
+						},
+					},
+					{
+						"action": "delete_collections",
+						"collections": map[string]any{
+							"collection": "Artists",
+						},
+					},
+					{
+						"action": "create_data",
+						"data": map[string]any{
+							"collection": "Songs",
+							"tenant":     "john_doe",
+						},
+					},
+					{
+						"action": "read_data",
+						"data": map[string]any{
+							"collection": "Songs",
+							"tenant":     "john_doe",
+						},
+					},
+					{
+						"action": "update_data",
+						"data": map[string]any{
+							"collection": "Artists",
+							"object":     "12345678-.*",
+						},
+					},
+					{
+						"action": "delete_data",
+						"data": map[string]any{
+							"collection": "Artists",
+							"object":     "12345678-.*",
+						},
+					},
+					{
+						"action": "read_groups",
+						"groups": map[string]any{
+							"group":     "external",
+							"groupType": "oidc",
+						},
+					},
+					{
+						"action": "assign_and_revoke_groups",
+						"groups": map[string]any{
+							"group":     "external",
+							"groupType": "oidc",
+						},
+					},
+					{
+						"action": "manage_namespaces",
+						"namespaces": map[string]any{
+							"namespace": "sandbox",
+						},
+					},
+					{
+						"action": "read_nodes",
+						"nodes": map[string]any{
+							"collection": "Songs",
+							"verbosity":  api.NodeVerbosityMinimal,
+						},
+					},
+					{
+						"action": "read_nodes",
+						"nodes": map[string]any{
+							"collection": "Artists",
+							"verbosity":  api.NodeVerbosityVerbose,
+						},
+					},
+					{
+						"action": "create_replicate",
+						"replicate": map[string]any{
+							"collection": "Songs",
+							"shard":      "abc",
+						},
+					},
+					{
+						"action": "read_replicate",
+						"replicate": map[string]any{
+							"collection": "Songs",
+							"shard":      "abc",
+						},
+					},
+					{
+						"action": "update_replicate",
+						"replicate": map[string]any{
+							"collection": "Songs",
+							"shard":      "xyz",
+						},
+					},
+					{
+						"action": "delete_replicate",
+						"replicate": map[string]any{
+							"collection": "Songs",
+							"shard":      "xyz",
+						},
+					},
+					{
+						"action": "create_roles",
+						"roles": map[string]any{
+							"role":  "rock-n-role",
+							"scope": api.RolesScopeAll,
+						},
+					},
+					{
+						"action": "read_roles",
+						"roles": map[string]any{
+							"role":  "rock-n-role",
+							"scope": api.RolesScopeAll,
+						},
+					},
+					{
+						"action": "update_roles",
+						"roles": map[string]any{
+							"role":  "rock-n-role",
+							"scope": api.RolesScopeMatch,
+						},
+					},
+					{
+						"action": "delete_roles",
+						"roles": map[string]any{
+							"role":  "rock-n-role",
+							"scope": api.RolesScopeMatch,
+						},
+					},
+					{
+						"action": "create_tenants",
+						"tenants": map[string]any{
+							"collection": "Songs",
+							"tenant":     "john_doe",
+						},
+					},
+					{
+						"action": "read_tenants",
+						"tenants": map[string]any{
+							"collection": "Songs",
+							"tenant":     "john_doe",
+						},
+					},
+					{
+						"action": "update_tenants",
+						"tenants": map[string]any{
+							"collection": "Artists",
+							"tenant":     "*",
+						},
+					},
+					{
+						"action": "delete_tenants",
+						"tenants": map[string]any{
+							"collection": "Artists",
+							"tenant":     "*",
+						},
+					},
+					{
+						"action": "create_users",
+						"users": map[string]any{
+							"user": "john_doe",
+						},
+					},
+					{
+						"action": "read_users",
+						"users": map[string]any{
+							"user": "john_doe",
+						},
+					},
+					{
+						"action": "update_users",
+						"users": map[string]any{
+							"user": "jane_doe",
+						},
+					},
+					{
+						"action": "delete_users",
+						"users": map[string]any{
+							"user": "jane_doe",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "get role",
+			req:        api.GetRoleRequest("rock-n-role"),
+			wantMethod: http.MethodGet,
+			wantPath:   "/authz/roles/rock-n-role",
+		},
+		{
+			name:       "delete role",
+			req:        api.DeleteRoleRequest("rock-n-role"),
+			wantMethod: http.MethodDelete,
+			wantPath:   "/authz/roles/rock-n-role",
+		},
+		{
+			name:       "list roles",
+			req:        api.ListRolesRequest,
+			wantMethod: http.MethodGet,
+			wantPath:   "/authz/roles",
+		},
 	}) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Implements(t, (*transports.Endpoint)(nil), tt.req)
@@ -800,6 +1141,326 @@ func TestRESTResponses(t *testing.T) {
 					"backup-s3":         true,
 				},
 				GRPCMaxMessageSize: 4096,
+			},
+		},
+		{
+			name: "get role response",
+			body: map[string]any{
+				"name": "rock-n-role",
+				"permissions": []map[string]any{
+					{
+						"action": "create_aliases",
+						"aliases": map[string]any{
+							"collection": "Songs",
+							"alias":      "Records",
+						},
+					},
+					{
+						"action": "read_aliases",
+						"aliases": map[string]any{
+							"collection": "Songs",
+							"alias":      "Records",
+						},
+					},
+					{
+						"action": "update_aliases",
+						"aliases": map[string]any{
+							"collection": "Artists",
+							"alias":      "Musicians",
+						},
+					},
+					{
+						"action": "delete_aliases",
+						"aliases": map[string]any{
+							"collection": "Artists",
+							"alias":      "Musicians",
+						},
+					},
+					// 	{
+					// 		"action": "manage_backups",
+					// 		"backups": map[string]any{
+					// 			"collection": "Songs",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "read_cluster",
+					// 	},
+					// 	{
+					// 		"action": "create_collections",
+					// 		"collections": map[string]any{
+					// 			"collection": "Songs",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "read_collections",
+					// 		"collections": map[string]any{
+					// 			"collection": "Songs",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "update_collections",
+					// 		"collections": map[string]any{
+					// 			"collection": "Artists",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "delete_collections",
+					// 		"collections": map[string]any{
+					// 			"collection": "Artists",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "create_data",
+					// 		"data": map[string]any{
+					// 			"collection": "Songs",
+					// 			"tenant":     "john_doe",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "read_data",
+					// 		"data": map[string]any{
+					// 			"collection": "Songs",
+					// 			"tenant":     "john_doe",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "update_data",
+					// 		"data": map[string]any{
+					// 			"collection": "Artists",
+					// 			"object":     "12345678-.*",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "delete_data",
+					// 		"data": map[string]any{
+					// 			"collection": "Artists",
+					// 			"object":     "12345678-.*",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "read_groups",
+					// 		"groups": map[string]any{
+					// 			"group":     "external",
+					// 			"groupType": "oidc",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "assign_and_revoke_groups",
+					// 		"groups": map[string]any{
+					// 			"group":     "external",
+					// 			"groupType": "oidc",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "manage_namespaces",
+					// 		"namespaces": map[string]any{
+					// 			"namespace": "sandbox",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "read_nodes",
+					// 		"nodes": map[string]any{
+					// 			"collection": "Songs",
+					// 			"verbosity":  api.NodeVerbosityMinimal,
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "read_nodes",
+					// 		"nodes": map[string]any{
+					// 			"collection": "Artists",
+					// 			"verbosity":  api.NodeVerbosityVerbose,
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "create_replicate",
+					// 		"replicate": map[string]any{
+					// 			"collection": "Songs",
+					// 			"shard":      "abc",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "read_replicate",
+					// 		"replicate": map[string]any{
+					// 			"collection": "Songs",
+					// 			"shard":      "abc",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "update_replicate",
+					// 		"replicate": map[string]any{
+					// 			"collection": "Songs",
+					// 			"shard":      "xyz",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "delete_replicate",
+					// 		"replicate": map[string]any{
+					// 			"collection": "Songs",
+					// 			"shard":      "xyz",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "create_roles",
+					// 		"roles": map[string]any{
+					// 			"role":  "rock-n-role",
+					// 			"scope": api.RolesScopeAll,
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "read_roles",
+					// 		"roles": map[string]any{
+					// 			"role":  "rock-n-role",
+					// 			"scope": api.RolesScopeAll,
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "update_roles",
+					// 		"roles": map[string]any{
+					// 			"role":  "rock-n-role",
+					// 			"scope": api.RolesScopeMatch,
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "delete_roles",
+					// 		"roles": map[string]any{
+					// 			"role":  "rock-n-role",
+					// 			"scope": api.RolesScopeMatch,
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "create_tenants",
+					// 		"tenants": map[string]any{
+					// 			"collection": "Songs",
+					// 			"tenant":     "john_doe",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "read_tenants",
+					// 		"tenants": map[string]any{
+					// 			"collection": "Songs",
+					// 			"tenant":     "john_doe",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "update_tenants",
+					// 		"tenants": map[string]any{
+					// 			"collection": "Artists",
+					// 			"tenant":     "*",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "delete_tenants",
+					// 		"tenants": map[string]any{
+					// 			"collection": "Artists",
+					// 			"tenant":     "*",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "create_users",
+					// 		"users": map[string]any{
+					// 			"user": "john_doe",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "read_users",
+					// 		"users": map[string]any{
+					// 			"user": "john_doe",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "update_users",
+					// 		"users": map[string]any{
+					// 			"user": "jane_doe",
+					// 		},
+					// 	},
+					// 	{
+					// 		"action": "delete_users",
+					// 		"users": map[string]any{
+					// 			"user": "jane_doe",
+					// 		},
+					// 	},
+				},
+			},
+			dest: new(api.Role),
+			want: &api.Role{
+				ID: "rock-n-role",
+				Permissions: api.Permissions{
+					Aliases: []api.AliasPermission{
+						{
+							Collection: "Songs", Alias: "Records",
+							Create: true, Read: true,
+						},
+						{
+							Collection: "Artists", Alias: "Musicians",
+							Update: true, Delete: true,
+						},
+					},
+					// Backups: []api.BackupsPermission{
+					// 	{Collection: "Songs", Manage: true},
+					// },
+					// Cluster: []api.ClusterPermission{{Read: true}},
+					// Collections: []api.CollectionsPermission{
+					// 	{Collection: "Songs", Create: true, Read: true},
+					// 	{Collection: "Artists", Update: true, Delete: true},
+					// },
+					// Data: []api.DataPermission{
+					// 	{
+					// 		Collection: "Songs", Tenant: "john_doe",
+					// 		Create: true, Read: true,
+					// 	},
+					// 	{
+					// 		Collection: "Artists", Object: "12345678-.*",
+					// 		Update: true, Delete: true,
+					// 	},
+					// },
+					// Groups: []api.GroupsPermission{
+					// 	{
+					// 		GroupID: "external", Type: "oidc",
+					// 		Read: true, AssignAndRevoke: true,
+					// 	},
+					// },
+					// Namespaces: []api.NamespacePermission{
+					// 	{Namespace: "sandbox", Manage: true},
+					// },
+					// Nodes: []api.NodesPermission{
+					// 	{Collection: "Songs", Verbosity: api.NodeVerbosityMinimal, Read: true},
+					// 	{Collection: "Artists", Verbosity: api.NodeVerbosityVerbose, Read: true},
+					// },
+					// Replication: []api.ReplicationPermission{
+					// 	{
+					// 		Collection: "Songs", Shard: "abc",
+					// 		Create: true, Read: true,
+					// 	},
+					// 	{
+					// 		Collection: "Songs", Shard: "xyz",
+					// 		Update: true, Delete: true,
+					// 	},
+					// },
+					// Roles: []api.RolesPermission{
+					// 	{
+					// 		RoleID: "rock-n-role", Scope: api.RolesScopeAll,
+					// 		Create: true, Read: true,
+					// 	},
+					// 	{
+					// 		RoleID: "rock-n-role", Scope: api.RolesScopeMatch,
+					// 		Update: true, Delete: true,
+					// 	},
+					// },
+					// Tenants: []api.TenantsPermission{
+					// 	{
+					// 		Collection: "Songs", Tenant: "john_doe",
+					// 		Create: true, Read: true,
+					// 	},
+					// 	{
+					// 		Collection: "Artists", Tenant: "*",
+					// 		Update: true, Delete: true,
+					// 	},
+					// },
+					// Users: []api.UsersPermission{
+					// 	{UserID: "john_doe", Create: true, Read: true},
+					// 	{UserID: "jane_doe", Update: true, Delete: true},
+					// },
+				},
 			},
 		},
 	} {

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -129,10 +129,11 @@ type (
 	UserPermission struct {
 		UserID string `json:"user,omitempty"`
 
-		Create bool `json:"-"`
-		Read   bool `json:"-"`
-		Update bool `json:"-"`
-		Delete bool `json:"-"`
+		Create          bool `json:"-"`
+		Read            bool `json:"-"`
+		Update          bool `json:"-"`
+		Delete          bool `json:"-"`
+		AssignAndRevoke bool `json:"-"`
 	}
 )
 
@@ -345,6 +346,8 @@ func (r *HasPermissionRequest) MarshalJSON() ([]byte, error) {
 		action, data = rest.UpdateUsers, r.Users
 	case r.Users.Delete:
 		action, data = rest.DeleteUsers, r.Users
+	case r.Users.AssignAndRevoke:
+		action, data = rest.AssignAndRevokeUsers, r.Users
 	}
 
 	permission := map[string]any{"action": action}
@@ -522,6 +525,9 @@ func (ps *Permissions) MarshalJSON() ([]byte, error) {
 		if p.Delete {
 			add(rest.DeleteUsers, p)
 		}
+		if p.AssignAndRevoke {
+			add(rest.AssignAndRevokeUsers, p)
+		}
 	}
 
 	return json.Marshal(permissions)
@@ -640,6 +646,8 @@ func (r *Role) UnmarshalJSON(data []byte) error {
 			find(lookup, p.Action, p.User, &r.Users).Update = true
 		case rest.DeleteUsers:
 			find(lookup, p.Action, p.User, &r.Users).Delete = true
+		case rest.AssignAndRevokeUsers:
+			find(lookup, p.Action, p.User, &r.Users).AssignAndRevoke = true
 		}
 	}
 

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -45,10 +45,15 @@ func (r *CreateRoleRequest) Method() string { return http.MethodPost }
 func (r *CreateRoleRequest) Path() string   { return "/authz/roles" }
 func (r *CreateRoleRequest) Body() any      { return &r.Role }
 
+// GetRoleRequest fetches the role by it's ID.
+// Use with [ResourceExistsResponse] or [Role] response types.
 var GetRoleRequest = transports.IdentityEndpoint[string](http.MethodGet, "/authz/roles/%s")
 
+// ListRolesRequest fetches all roles defined in the cluster.
+// Use with []Role response type.
 var ListRolesRequest = transports.StaticEndpoint(http.MethodGet, "/authz/roles")
 
+// DeleteRoleRequest deletes a role by it's ID.
 var DeleteRoleRequest = transports.IdentityEndpoint[string](http.MethodDelete, "/authz/roles/%s")
 
 type Permission struct {
@@ -167,9 +172,14 @@ const (
 	RoleScopeMatch = RoleScope(rest.PermissionRolesScopeMatch)
 )
 
+// MarshalJSON flattens role's permissions, creating an individual
+// entry for every action.
 func (r *Role) MarshalJSON() ([]byte, error) {
 	permissions := make([]map[string]any, 0)
 
+	// Add permission with given action and resources.
+	// The last part of the action string is the resource kind,
+	// e.g. "aliases" in "create_aliases" or "groups" in "assign_and_revoke_groups".
 	add := func(action rest.PermissionAction, data any) {
 		permission := map[string]any{"action": action}
 		if data != nil {
@@ -329,6 +339,7 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// UnmarshalJSON groups role's permissions by resources.
 func (r *Role) UnmarshalJSON(data []byte) error {
 	var role struct {
 		ID          string `json:"name"`
@@ -355,91 +366,107 @@ func (r *Role) UnmarshalJSON(data []byte) error {
 
 	*r = Role{ID: role.ID}
 
+	// Set of permissions with unique resource identifiers.
+	// The key is a concatenation of <kind> and <data>, such
+	// that mulitple permissions for the same resource are
+	// represented as a single instance. The value is the
+	// permission itself, e.g. [AliasPermission].
 	lookup := make(map[string]any)
 	for _, p := range role.Permissions {
-		var kind string
-		if parts := strings.Split(string(p.Action), "_"); len(parts) != 0 {
-			kind = parts[len(parts)-1]
-		} else {
-			continue
-		}
-
 		switch p.Action {
 		case rest.CreateAliases:
-			find(lookup, kind, p.Alias, &r.Aliases).Create = true
+			find(lookup, p.Action, p.Alias, &r.Aliases).Create = true
 		case rest.ReadAliases:
-			find(lookup, kind, p.Alias, &r.Aliases).Read = true
+			find(lookup, p.Action, p.Alias, &r.Aliases).Read = true
 		case rest.UpdateAliases:
-			find(lookup, kind, p.Alias, &r.Aliases).Update = true
+			find(lookup, p.Action, p.Alias, &r.Aliases).Update = true
 		case rest.DeleteAliases:
-			find(lookup, kind, p.Alias, &r.Aliases).Delete = true
+			find(lookup, p.Action, p.Alias, &r.Aliases).Delete = true
 		case rest.ManageBackups:
-			find(lookup, kind, p.Backup, &r.Backups).Manage = true
+			find(lookup, p.Action, p.Backup, &r.Backups).Manage = true
 		case rest.ReadCluster:
-			find(lookup, kind, p.Cluster, &r.Cluster).Read = true
+			find(lookup, p.Action, p.Cluster, &r.Cluster).Read = true
 		case rest.CreateCollections:
-			find(lookup, kind, p.Collection, &r.Collections).Create = true
+			find(lookup, p.Action, p.Collection, &r.Collections).Create = true
 		case rest.ReadCollections:
-			find(lookup, kind, p.Collection, &r.Collections).Read = true
+			find(lookup, p.Action, p.Collection, &r.Collections).Read = true
 		case rest.UpdateCollections:
-			find(lookup, kind, p.Collection, &r.Collections).Update = true
+			find(lookup, p.Action, p.Collection, &r.Collections).Update = true
 		case rest.DeleteCollections:
-			find(lookup, kind, p.Collection, &r.Collections).Delete = true
+			find(lookup, p.Action, p.Collection, &r.Collections).Delete = true
 		case rest.CreateData:
-			find(lookup, kind, p.Data, &r.Data).Create = true
+			find(lookup, p.Action, p.Data, &r.Data).Create = true
 		case rest.ReadData:
-			find(lookup, kind, p.Data, &r.Data).Read = true
+			find(lookup, p.Action, p.Data, &r.Data).Read = true
 		case rest.UpdateData:
-			find(lookup, kind, p.Data, &r.Data).Update = true
+			find(lookup, p.Action, p.Data, &r.Data).Update = true
 		case rest.DeleteData:
-			find(lookup, kind, p.Data, &r.Data).Delete = true
+			find(lookup, p.Action, p.Data, &r.Data).Delete = true
 		case rest.ReadGroups:
-			find(lookup, kind, p.Group, &r.Groups).Read = true
+			find(lookup, p.Action, p.Group, &r.Groups).Read = true
 		case rest.AssignAndRevokeGroups:
-			find(lookup, kind, p.Group, &r.Groups).AssignAndRevoke = true
+			find(lookup, p.Action, p.Group, &r.Groups).AssignAndRevoke = true
 		case rest.ManageNamespaces:
-			find(lookup, kind, p.Namespace, &r.Namespaces).Manage = true
+			find(lookup, p.Action, p.Namespace, &r.Namespaces).Manage = true
 		case rest.ReadNodes:
-			find(lookup, kind, p.Node, &r.Nodes).Read = true
+			find(lookup, p.Action, p.Node, &r.Nodes).Read = true
 		case rest.CreateReplicate:
-			find(lookup, kind, p.Replication, &r.Replication).Create = true
+			find(lookup, p.Action, p.Replication, &r.Replication).Create = true
 		case rest.ReadReplicate:
-			find(lookup, kind, p.Replication, &r.Replication).Read = true
+			find(lookup, p.Action, p.Replication, &r.Replication).Read = true
 		case rest.UpdateReplicate:
-			find(lookup, kind, p.Replication, &r.Replication).Update = true
+			find(lookup, p.Action, p.Replication, &r.Replication).Update = true
 		case rest.DeleteReplicate:
-			find(lookup, kind, p.Replication, &r.Replication).Delete = true
+			find(lookup, p.Action, p.Replication, &r.Replication).Delete = true
 		case rest.CreateRoles:
-			find(lookup, kind, p.Role, &r.Roles).Create = true
+			find(lookup, p.Action, p.Role, &r.Roles).Create = true
 		case rest.ReadRoles:
-			find(lookup, kind, p.Role, &r.Roles).Read = true
+			find(lookup, p.Action, p.Role, &r.Roles).Read = true
 		case rest.UpdateRoles:
-			find(lookup, kind, p.Role, &r.Roles).Update = true
+			find(lookup, p.Action, p.Role, &r.Roles).Update = true
 		case rest.DeleteRoles:
-			find(lookup, kind, p.Role, &r.Roles).Delete = true
+			find(lookup, p.Action, p.Role, &r.Roles).Delete = true
 		case rest.CreateTenants:
-			find(lookup, kind, p.Tenant, &r.Tenants).Create = true
+			find(lookup, p.Action, p.Tenant, &r.Tenants).Create = true
 		case rest.ReadTenants:
-			find(lookup, kind, p.Tenant, &r.Tenants).Read = true
+			find(lookup, p.Action, p.Tenant, &r.Tenants).Read = true
 		case rest.UpdateTenants:
-			find(lookup, kind, p.Tenant, &r.Tenants).Update = true
+			find(lookup, p.Action, p.Tenant, &r.Tenants).Update = true
 		case rest.DeleteTenants:
-			find(lookup, kind, p.Tenant, &r.Tenants).Delete = true
+			find(lookup, p.Action, p.Tenant, &r.Tenants).Delete = true
 		case rest.CreateUsers:
-			find(lookup, kind, p.User, &r.Users).Create = true
+			find(lookup, p.Action, p.User, &r.Users).Create = true
 		case rest.ReadUsers:
-			find(lookup, kind, p.User, &r.Users).Read = true
+			find(lookup, p.Action, p.User, &r.Users).Read = true
 		case rest.UpdateUsers:
-			find(lookup, kind, p.User, &r.Users).Update = true
+			find(lookup, p.Action, p.User, &r.Users).Update = true
 		case rest.DeleteUsers:
-			find(lookup, kind, p.User, &r.Users).Delete = true
+			find(lookup, p.Action, p.User, &r.Users).Delete = true
 		}
 	}
 
 	return nil
 }
 
-func find[T any](lookup map[string]any, kind string, data json.RawMessage, dest *[]T) *T {
+// find retrieves the data for the permission for the given resource.
+// The key is a concatenation of permission <kind> and <data>. The kind
+// is assumed to be the last part of the action, as per the namind convention.
+// If no permission for the given key exists, one is created by unmarshaling
+// data into a new instance of T and is appended to the dest.
+//
+// If kind could not be found (action contains no "_") or data cannot be
+// unmarshaled, find returns new(T), such that it is always safe to use
+// the return value without a nil-check. Some permissions might not have
+// any resource description, i.e. data is empty; for these, the unmarshaling
+// is skipped, and a zero value of T is appended to dest.
+func find[T any](lookup map[string]any, action rest.PermissionAction, data json.RawMessage, dest *[]T) *T {
+	var kind string
+	if parts := strings.Split(string(action), "_"); len(parts) != 0 {
+		kind = parts[len(parts)-1]
+	} else {
+		return new(T)
+	}
+
 	key := kind + string(data)
 	addr, ok := lookup[key]
 	if !ok {
@@ -452,7 +479,6 @@ func find[T any](lookup map[string]any, kind string, data json.RawMessage, dest 
 		*dest = append(*dest, t)
 		addr = &(*dest)[len(*dest)-1]
 		lookup[key] = addr
-
 	}
 	return addr.(*T)
 }

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -85,7 +85,7 @@ type (
 
 		Manage bool `json:"-"`
 	}
-	NodeVerbosity   rest.PermissionNodesVerbosity // api.NodeVerbosity
+	NodeVerbosity   rest.PermissionNodesVerbosity
 	NodesPermission struct {
 		Collection string        `json:"collection,omitempty"`
 		Verbosity  NodeVerbosity `json:"verbosity,omitempty"`
@@ -662,7 +662,7 @@ func permissionKind(action rest.PermissionAction) string {
 
 // find retrieves the data for the permission for the given resource.
 // The key is a concatenation of permission <kind> and <data>. The kind
-// is assumed to be the last part of the action, as per the namind convention.
+// is assumed to be the last part of the action, as per the naming convention.
 // If no permission for the given key exists, one is created by unmarshaling
 // data into a new instance of T and is appended to the dest.
 //

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -169,241 +169,154 @@ const (
 
 func (r *Role) MarshalJSON() ([]byte, error) {
 	permissions := make([]map[string]any, 0)
+
+	add := func(action rest.PermissionAction, data any) {
+		permission := map[string]any{"action": action}
+		if data != nil {
+			var kind string
+			if parts := strings.Split(string(action), "_"); len(parts) != 0 {
+				kind = parts[len(parts)-1]
+				permission[kind] = data
+			}
+		}
+		permissions = append(permissions, permission)
+	}
+
 	for _, p := range r.Permissions.Aliases {
 		if p.Create {
-			permissions = append(permissions, map[string]any{
-				"action":  rest.CreateAliases,
-				"aliases": p,
-			})
+			add(rest.CreateAliases, p)
 		}
 		if p.Read {
-			permissions = append(permissions, map[string]any{
-				"action":  rest.ReadAliases,
-				"aliases": p,
-			})
+			add(rest.ReadAliases, p)
 		}
 		if p.Update {
-			permissions = append(permissions, map[string]any{
-				"action":  rest.UpdateAliases,
-				"aliases": p,
-			})
+			add(rest.UpdateAliases, p)
 		}
 		if p.Delete {
-			permissions = append(permissions, map[string]any{
-				"action":  rest.DeleteAliases,
-				"aliases": p,
-			})
+			add(rest.DeleteAliases, p)
 		}
 	}
 
 	for _, p := range r.Permissions.Backups {
 		if p.Manage {
-			permissions = append(permissions, map[string]any{
-				"action":  rest.ManageBackups,
-				"backups": p,
-			})
+			add(rest.ManageBackups, p)
 		}
 	}
 
 	for _, p := range r.Permissions.Cluster {
 		if p.Read {
-			permissions = append(permissions, map[string]any{
-				"action": rest.ReadCluster,
-			})
+			add(rest.ReadCluster, nil)
 		}
 	}
 
 	for _, p := range r.Permissions.Collections {
 		if p.Create {
-			permissions = append(permissions, map[string]any{
-				"action":      rest.CreateCollections,
-				"collections": p,
-			})
+			add(rest.CreateCollections, p)
 		}
 		if p.Read {
-			permissions = append(permissions, map[string]any{
-				"action":      rest.ReadCollections,
-				"collections": p,
-			})
+			add(rest.ReadCollections, p)
 		}
 		if p.Update {
-			permissions = append(permissions, map[string]any{
-				"action":      rest.UpdateCollections,
-				"collections": p,
-			})
+			add(rest.UpdateCollections, p)
 		}
 		if p.Delete {
-			permissions = append(permissions, map[string]any{
-				"action":      rest.DeleteCollections,
-				"collections": p,
-			})
+			add(rest.DeleteCollections, p)
 		}
 	}
 
 	for _, p := range r.Permissions.Data {
 		if p.Create {
-			permissions = append(permissions, map[string]any{
-				"action": rest.CreateData,
-				"data":   p,
-			})
+			add(rest.CreateData, p)
 		}
 		if p.Read {
-			permissions = append(permissions, map[string]any{
-				"action": rest.ReadData,
-				"data":   p,
-			})
+			add(rest.ReadData, p)
 		}
 		if p.Update {
-			permissions = append(permissions, map[string]any{
-				"action": rest.UpdateData,
-				"data":   p,
-			})
+			add(rest.UpdateData, p)
 		}
 		if p.Delete {
-			permissions = append(permissions, map[string]any{
-				"action": rest.DeleteData,
-				"data":   p,
-			})
+			add(rest.DeleteData, p)
 		}
 	}
+
 	for _, p := range r.Permissions.Groups {
 		if p.Read {
-			permissions = append(permissions, map[string]any{
-				"action": rest.ReadGroups,
-				"groups": p,
-			})
+			add(rest.ReadGroups, p)
 		}
 		if p.AssignAndRevoke {
-			permissions = append(permissions, map[string]any{
-				"action": rest.AssignAndRevokeGroups,
-				"groups": p,
-			})
+			add(rest.AssignAndRevokeGroups, p)
 		}
 	}
 
 	for _, p := range r.Permissions.Namespaces {
 		if p.Manage {
-			permissions = append(permissions, map[string]any{
-				"action":     rest.ManageNamespaces,
-				"namespaces": p,
-			})
+			add(rest.ManageNamespaces, p)
 		}
 	}
 
 	for _, p := range r.Permissions.Nodes {
 		if p.Read {
-			permissions = append(permissions, map[string]any{
-				"action": rest.ReadNodes,
-				"nodes":  p,
-			})
+			add(rest.ReadNodes, p)
 		}
 	}
 
 	for _, p := range r.Permissions.Replication {
 		if p.Create {
-			permissions = append(permissions, map[string]any{
-				"action":    rest.CreateReplicate,
-				"replicate": p,
-			})
+			add(rest.CreateReplicate, p)
 		}
 		if p.Read {
-			permissions = append(permissions, map[string]any{
-				"action":    rest.ReadReplicate,
-				"replicate": p,
-			})
+			add(rest.ReadReplicate, p)
 		}
 		if p.Update {
-			permissions = append(permissions, map[string]any{
-				"action":    rest.UpdateReplicate,
-				"replicate": p,
-			})
+			add(rest.UpdateReplicate, p)
 		}
 		if p.Delete {
-			permissions = append(permissions, map[string]any{
-				"action":    rest.DeleteReplicate,
-				"replicate": p,
-			})
+			add(rest.DeleteReplicate, p)
 		}
 	}
 
 	for _, p := range r.Permissions.Roles {
 		if p.Create {
-			permissions = append(permissions, map[string]any{
-				"action": rest.CreateRoles,
-				"roles":  p,
-			})
+			add(rest.CreateRoles, p)
 		}
 		if p.Read {
-			permissions = append(permissions, map[string]any{
-				"action": rest.ReadRoles,
-				"roles":  p,
-			})
+			add(rest.ReadRoles, p)
 		}
 		if p.Update {
-			permissions = append(permissions, map[string]any{
-				"action": rest.UpdateRoles,
-				"roles":  p,
-			})
+			add(rest.UpdateRoles, p)
 		}
 		if p.Delete {
-			permissions = append(permissions, map[string]any{
-				"action": rest.DeleteRoles,
-				"roles":  p,
-			})
+			add(rest.DeleteRoles, p)
 		}
 	}
 
 	for _, p := range r.Permissions.Tenants {
 		if p.Create {
-			permissions = append(permissions, map[string]any{
-				"action":  rest.CreateTenants,
-				"tenants": p,
-			})
+			add(rest.CreateTenants, p)
 		}
 		if p.Read {
-			permissions = append(permissions, map[string]any{
-				"action":  rest.ReadTenants,
-				"tenants": p,
-			})
+			add(rest.ReadTenants, p)
 		}
 		if p.Update {
-			permissions = append(permissions, map[string]any{
-				"action":  rest.UpdateTenants,
-				"tenants": p,
-			})
+			add(rest.UpdateTenants, p)
 		}
 		if p.Delete {
-			permissions = append(permissions, map[string]any{
-				"action":  rest.DeleteTenants,
-				"tenants": p,
-			})
+			add(rest.DeleteTenants, p)
 		}
 	}
 
 	for _, p := range r.Permissions.Users {
 		if p.Create {
-			permissions = append(permissions, map[string]any{
-				"action": rest.CreateUsers,
-				"users":  p,
-			})
+			add(rest.CreateUsers, p)
 		}
 		if p.Read {
-			permissions = append(permissions, map[string]any{
-				"action": rest.ReadUsers,
-				"users":  p,
-			})
+			add(rest.ReadUsers, p)
 		}
 		if p.Update {
-			permissions = append(permissions, map[string]any{
-				"action": rest.UpdateUsers,
-				"users":  p,
-			})
+			add(rest.UpdateUsers, p)
 		}
 		if p.Delete {
-			permissions = append(permissions, map[string]any{
-				"action": rest.DeleteUsers,
-				"users":  p,
-			})
+			add(rest.DeleteUsers, p)
 		}
 	}
 

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -10,8 +10,8 @@ import (
 )
 
 type Role struct {
-	ID          string
-	Permissions Permissions
+	ID string
+	Permissions
 }
 
 var (
@@ -23,15 +23,15 @@ type Permissions struct {
 	Aliases     []AliasPermission
 	Backups     []BackupsPermission
 	Cluster     []ClusterPermission
-	Collections []CollectionsPermission
+	Collections []CollectionPermission
 	Data        []DataPermission
-	Groups      []GroupsPermission
+	Groups      []GroupPermission
 	Namespaces  []NamespacePermission
 	Nodes       []NodesPermission
 	Replication []ReplicationPermission
-	Roles       []RolesPermission
-	Tenants     []TenantsPermission
-	Users       []UsersPermission
+	Roles       []RolePermission
+	Tenants     []TenantPermission
+	Users       []UserPermission
 }
 
 type CreateRoleRequest struct {
@@ -55,15 +55,15 @@ type Permission struct {
 	Alias       AliasPermission
 	Backups     BackupsPermission
 	Cluster     ClusterPermission
-	Collections CollectionsPermission
+	Collections CollectionPermission
 	Data        DataPermission
-	Groups      GroupsPermission
+	Groups      GroupPermission
 	Namespaces  NamespacePermission
 	Nodes       NodesPermission
 	Replication ReplicationPermission
-	Roles       RolesPermission
-	Tenants     TenantsPermission
-	Users       UsersPermission
+	Roles       RolePermission
+	Tenants     TenantPermission
+	Users       UserPermission
 }
 
 type (
@@ -84,7 +84,7 @@ type (
 	ClusterPermission struct {
 		Read bool `json:"-"`
 	}
-	CollectionsPermission struct {
+	CollectionPermission struct {
 		Collection string `json:"collection,omitempty"`
 
 		Create bool `json:"-"`
@@ -102,7 +102,7 @@ type (
 		Update bool `json:"-"`
 		Delete bool `json:"-"`
 	}
-	GroupsPermission struct {
+	GroupPermission struct {
 		GroupID string `json:"group,omitempty"`
 		Type    string `json:"groupType,omitempty"`
 
@@ -114,10 +114,10 @@ type (
 
 		Manage bool `json:"-"`
 	}
-	NodesVerbosity  rest.PermissionNodesVerbosity // api.NodeVerbosity
+	NodeVerbosity   rest.PermissionNodesVerbosity // api.NodeVerbosity
 	NodesPermission struct {
-		Collection string         `json:"collection,omitempty"`
-		Verbosity  NodesVerbosity `json:"verbosity,omitempty"`
+		Collection string        `json:"collection,omitempty"`
+		Verbosity  NodeVerbosity `json:"verbosity,omitempty"`
 
 		Read bool `json:"-"`
 	}
@@ -130,17 +130,17 @@ type (
 		Update bool `json:"-"`
 		Delete bool `json:"-"`
 	}
-	RolesScope      rest.PermissionRolesScope
-	RolesPermission struct {
-		RoleID string     `json:"role,omitempty"`
-		Scope  RolesScope `json:"scope,omitempty"`
+	RoleScope      rest.PermissionRolesScope
+	RolePermission struct {
+		RoleID string    `json:"role,omitempty"`
+		Scope  RoleScope `json:"scope,omitempty"`
 
 		Create bool `json:"-"`
 		Read   bool `json:"-"`
 		Update bool `json:"-"`
 		Delete bool `json:"-"`
 	}
-	TenantsPermission struct {
+	TenantPermission struct {
 		Collection string `json:"collection,omitempty"`
 		Tenant     string `json:"tenant,omitempty"`
 
@@ -149,7 +149,7 @@ type (
 		Update bool `json:"-"`
 		Delete bool `json:"-"`
 	}
-	UsersPermission struct {
+	UserPermission struct {
 		UserID string `json:"user,omitempty"`
 
 		Create bool `json:"-"`
@@ -160,11 +160,11 @@ type (
 )
 
 const (
-	NodeVerbosityMinimal = NodesVerbosity(rest.Minimal)
-	NodeVerbosityVerbose = NodesVerbosity(rest.Verbose)
+	NodeVerbosityMinimal = NodeVerbosity(rest.Minimal)
+	NodeVerbosityVerbose = NodeVerbosity(rest.Verbose)
 
-	RolesScopeAll   = RolesScope(rest.PermissionRolesScopeAll)
-	RolesScopeMatch = RolesScope(rest.PermissionRolesScopeMatch)
+	RoleScopeAll   = RoleScope(rest.PermissionRolesScopeAll)
+	RoleScopeMatch = RoleScope(rest.PermissionRolesScopeMatch)
 )
 
 func (r *Role) MarshalJSON() ([]byte, error) {
@@ -182,7 +182,7 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		permissions = append(permissions, permission)
 	}
 
-	for _, p := range r.Permissions.Aliases {
+	for _, p := range r.Aliases {
 		if p.Create {
 			add(rest.CreateAliases, p)
 		}
@@ -197,19 +197,19 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	for _, p := range r.Permissions.Backups {
+	for _, p := range r.Backups {
 		if p.Manage {
 			add(rest.ManageBackups, p)
 		}
 	}
 
-	for _, p := range r.Permissions.Cluster {
+	for _, p := range r.Cluster {
 		if p.Read {
 			add(rest.ReadCluster, nil)
 		}
 	}
 
-	for _, p := range r.Permissions.Collections {
+	for _, p := range r.Collections {
 		if p.Create {
 			add(rest.CreateCollections, p)
 		}
@@ -224,7 +224,7 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	for _, p := range r.Permissions.Data {
+	for _, p := range r.Data {
 		if p.Create {
 			add(rest.CreateData, p)
 		}
@@ -239,7 +239,7 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	for _, p := range r.Permissions.Groups {
+	for _, p := range r.Groups {
 		if p.Read {
 			add(rest.ReadGroups, p)
 		}
@@ -248,19 +248,19 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	for _, p := range r.Permissions.Namespaces {
+	for _, p := range r.Namespaces {
 		if p.Manage {
 			add(rest.ManageNamespaces, p)
 		}
 	}
 
-	for _, p := range r.Permissions.Nodes {
+	for _, p := range r.Nodes {
 		if p.Read {
 			add(rest.ReadNodes, p)
 		}
 	}
 
-	for _, p := range r.Permissions.Replication {
+	for _, p := range r.Replication {
 		if p.Create {
 			add(rest.CreateReplicate, p)
 		}
@@ -275,7 +275,7 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	for _, p := range r.Permissions.Roles {
+	for _, p := range r.Roles {
 		if p.Create {
 			add(rest.CreateRoles, p)
 		}
@@ -290,7 +290,7 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	for _, p := range r.Permissions.Tenants {
+	for _, p := range r.Tenants {
 		if p.Create {
 			add(rest.CreateTenants, p)
 		}
@@ -305,7 +305,7 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	for _, p := range r.Permissions.Users {
+	for _, p := range r.Users {
 		if p.Create {
 			add(rest.CreateUsers, p)
 		}
@@ -346,7 +346,7 @@ func (r *Role) UnmarshalJSON(data []byte) error {
 			Role        json.RawMessage       `json:"roles"`
 			Tenant      json.RawMessage       `json:"tenants"`
 			User        json.RawMessage       `json:"users"`
-		}
+		} `json:"permissions"`
 	}
 
 	if err := json.Unmarshal(data, &role); err != nil {
@@ -356,7 +356,6 @@ func (r *Role) UnmarshalJSON(data []byte) error {
 	*r = Role{ID: role.ID}
 
 	lookup := make(map[string]any)
-	ps := &r.Permissions
 	for _, p := range role.Permissions {
 		var kind string
 		if parts := strings.Split(string(p.Action), "_"); len(parts) != 0 {
@@ -367,73 +366,73 @@ func (r *Role) UnmarshalJSON(data []byte) error {
 
 		switch p.Action {
 		case rest.CreateAliases:
-			find(lookup, kind, p.Alias, &ps.Aliases).Create = true
+			find(lookup, kind, p.Alias, &r.Aliases).Create = true
 		case rest.ReadAliases:
-			find(lookup, kind, p.Alias, &ps.Aliases).Read = true
+			find(lookup, kind, p.Alias, &r.Aliases).Read = true
 		case rest.UpdateAliases:
-			find(lookup, kind, p.Alias, &ps.Aliases).Update = true
+			find(lookup, kind, p.Alias, &r.Aliases).Update = true
 		case rest.DeleteAliases:
-			find(lookup, kind, p.Alias, &ps.Aliases).Delete = true
+			find(lookup, kind, p.Alias, &r.Aliases).Delete = true
 		case rest.ManageBackups:
-			find(lookup, kind, p.Backup, &ps.Backups).Manage = true
+			find(lookup, kind, p.Backup, &r.Backups).Manage = true
 		case rest.ReadCluster:
-			find(lookup, kind, p.Cluster, &ps.Cluster).Read = true
+			find(lookup, kind, p.Cluster, &r.Cluster).Read = true
 		case rest.CreateCollections:
-			find(lookup, kind, p.Collection, &ps.Collections).Create = true
+			find(lookup, kind, p.Collection, &r.Collections).Create = true
 		case rest.ReadCollections:
-			find(lookup, kind, p.Collection, &ps.Collections).Read = true
+			find(lookup, kind, p.Collection, &r.Collections).Read = true
 		case rest.UpdateCollections:
-			find(lookup, kind, p.Collection, &ps.Collections).Update = true
+			find(lookup, kind, p.Collection, &r.Collections).Update = true
 		case rest.DeleteCollections:
-			find(lookup, kind, p.Collection, &ps.Collections).Delete = true
+			find(lookup, kind, p.Collection, &r.Collections).Delete = true
 		case rest.CreateData:
-			find(lookup, kind, p.Data, &ps.Data).Create = true
+			find(lookup, kind, p.Data, &r.Data).Create = true
 		case rest.ReadData:
-			find(lookup, kind, p.Data, &ps.Data).Read = true
+			find(lookup, kind, p.Data, &r.Data).Read = true
 		case rest.UpdateData:
-			find(lookup, kind, p.Data, &ps.Data).Update = true
+			find(lookup, kind, p.Data, &r.Data).Update = true
 		case rest.DeleteData:
-			find(lookup, kind, p.Data, &ps.Data).Delete = true
+			find(lookup, kind, p.Data, &r.Data).Delete = true
 		case rest.ReadGroups:
-			find(lookup, kind, p.Group, &ps.Groups).Read = true
+			find(lookup, kind, p.Group, &r.Groups).Read = true
 		case rest.AssignAndRevokeGroups:
-			find(lookup, kind, p.Group, &ps.Groups).AssignAndRevoke = true
+			find(lookup, kind, p.Group, &r.Groups).AssignAndRevoke = true
 		case rest.ManageNamespaces:
-			find(lookup, kind, p.Namespace, &ps.Namespaces).Manage = true
+			find(lookup, kind, p.Namespace, &r.Namespaces).Manage = true
 		case rest.ReadNodes:
-			find(lookup, kind, p.Node, &ps.Nodes).Read = true
+			find(lookup, kind, p.Node, &r.Nodes).Read = true
 		case rest.CreateReplicate:
-			find(lookup, kind, p.Replication, &ps.Replication).Create = true
+			find(lookup, kind, p.Replication, &r.Replication).Create = true
 		case rest.ReadReplicate:
-			find(lookup, kind, p.Replication, &ps.Replication).Read = true
+			find(lookup, kind, p.Replication, &r.Replication).Read = true
 		case rest.UpdateReplicate:
-			find(lookup, kind, p.Replication, &ps.Replication).Update = true
+			find(lookup, kind, p.Replication, &r.Replication).Update = true
 		case rest.DeleteReplicate:
-			find(lookup, kind, p.Replication, &ps.Replication).Delete = true
+			find(lookup, kind, p.Replication, &r.Replication).Delete = true
 		case rest.CreateRoles:
-			find(lookup, kind, p.Role, &ps.Roles).Create = true
+			find(lookup, kind, p.Role, &r.Roles).Create = true
 		case rest.ReadRoles:
-			find(lookup, kind, p.Role, &ps.Roles).Read = true
+			find(lookup, kind, p.Role, &r.Roles).Read = true
 		case rest.UpdateRoles:
-			find(lookup, kind, p.Role, &ps.Roles).Update = true
+			find(lookup, kind, p.Role, &r.Roles).Update = true
 		case rest.DeleteRoles:
-			find(lookup, kind, p.Role, &ps.Roles).Delete = true
+			find(lookup, kind, p.Role, &r.Roles).Delete = true
 		case rest.CreateTenants:
-			find(lookup, kind, p.Tenant, &ps.Tenants).Create = true
+			find(lookup, kind, p.Tenant, &r.Tenants).Create = true
 		case rest.ReadTenants:
-			find(lookup, kind, p.Tenant, &ps.Tenants).Read = true
+			find(lookup, kind, p.Tenant, &r.Tenants).Read = true
 		case rest.UpdateTenants:
-			find(lookup, kind, p.Tenant, &ps.Tenants).Update = true
+			find(lookup, kind, p.Tenant, &r.Tenants).Update = true
 		case rest.DeleteTenants:
-			find(lookup, kind, p.Tenant, &ps.Tenants).Delete = true
+			find(lookup, kind, p.Tenant, &r.Tenants).Delete = true
 		case rest.CreateUsers:
-			find(lookup, kind, p.User, &ps.Users).Create = true
+			find(lookup, kind, p.User, &r.Users).Create = true
 		case rest.ReadUsers:
-			find(lookup, kind, p.User, &ps.Users).Read = true
+			find(lookup, kind, p.User, &r.Users).Read = true
 		case rest.UpdateUsers:
-			find(lookup, kind, p.User, &ps.Users).Update = true
+			find(lookup, kind, p.User, &r.Users).Update = true
 		case rest.DeleteUsers:
-			find(lookup, kind, p.User, &ps.Users).Delete = true
+			find(lookup, kind, p.User, &r.Users).Delete = true
 		}
 	}
 

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -29,6 +29,7 @@ type Permissions struct {
 	Groups      []GroupPermission
 	Namespaces  []NamespacePermission
 	Nodes       []NodesPermission
+	MCP         []MCPPermission
 	Replication []ReplicationPermission
 	Roles       []RolePermission
 	Tenants     []TenantPermission
@@ -91,6 +92,11 @@ type (
 		Verbosity  NodeVerbosity `json:"verbosity,omitempty"`
 
 		Read bool `json:"-"`
+	}
+	MCPPermission struct {
+		Create bool
+		Read   bool
+		Update bool
 	}
 	ReplicationPermission struct {
 		Collection string `json:"collection,omitempty"`
@@ -230,6 +236,7 @@ type HasPermissionRequest struct {
 	Groups      GroupPermission
 	Namespaces  NamespacePermission
 	Nodes       NodesPermission
+	MCP         MCPPermission
 	Replication ReplicationPermission
 	Roles       RolePermission
 	Tenants     TenantPermission
@@ -300,6 +307,12 @@ func (r *HasPermissionRequest) MarshalJSON() ([]byte, error) {
 		action, data = rest.ManageNamespaces, r.Namespaces
 	case r.Nodes.Read:
 		action, data = rest.ReadNodes, r.Nodes
+	case r.MCP.Create:
+		action = rest.CreateMcp
+	case r.MCP.Read:
+		action = rest.ReadMcp
+	case r.MCP.Update:
+		action = rest.UpdateMcp
 	case r.Replication.Create:
 		action, data = rest.CreateReplicate, r.Replication
 	case r.Replication.Read:
@@ -439,6 +452,18 @@ func (ps *Permissions) MarshalJSON() ([]byte, error) {
 		}
 	}
 
+	for _, p := range ps.MCP {
+		if p.Create {
+			add(rest.CreateMcp, nil)
+		}
+		if p.Read {
+			add(rest.ReadMcp, nil)
+		}
+		if p.Update {
+			add(rest.UpdateMcp, nil)
+		}
+	}
+
 	for _, p := range ps.Replication {
 		if p.Create {
 			add(rest.CreateReplicate, p)
@@ -519,6 +544,7 @@ func (r *Role) UnmarshalJSON(data []byte) error {
 			Group       json.RawMessage       `json:"groups"`
 			Namespace   json.RawMessage       `json:"namespaces"`
 			Node        json.RawMessage       `json:"nodes"`
+			MCP         json.RawMessage       `json:"mcp"`
 			Replication json.RawMessage       `json:"replicate"`
 			Role        json.RawMessage       `json:"roles"`
 			Tenant      json.RawMessage       `json:"tenants"`
@@ -576,6 +602,12 @@ func (r *Role) UnmarshalJSON(data []byte) error {
 			find(lookup, p.Action, p.Namespace, &r.Namespaces).Manage = true
 		case rest.ReadNodes:
 			find(lookup, p.Action, p.Node, &r.Nodes).Read = true
+		case rest.CreateMcp:
+			find(lookup, p.Action, p.MCP, &r.MCP).Create = true
+		case rest.ReadMcp:
+			find(lookup, p.Action, p.MCP, &r.MCP).Read = true
+		case rest.UpdateMcp:
+			find(lookup, p.Action, p.MCP, &r.MCP).Update = true
 		case rest.CreateReplicate:
 			find(lookup, p.Action, p.Replication, &r.Replication).Create = true
 		case rest.ReadReplicate:

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -182,8 +182,8 @@ type (
 		Type string `json:"userType"`
 	}
 	GroupAssignment struct {
-		ID   string `json:"userId"`
-		Type string `json:"userType"`
+		ID   string `json:"groupId"`
+		Type string `json:"groupType"`
 	}
 )
 
@@ -335,8 +335,10 @@ func (r *HasPermissionRequest) MarshalJSON() ([]byte, error) {
 	}
 
 	permission := map[string]any{"action": action}
-	if kind := permissionKind(action); kind != "" {
-		permission[kind] = data
+	if data != nil {
+		if kind := permissionKind(action); kind != "" {
+			permission[kind] = data
+		}
 	}
 	return json.Marshal(permission)
 }

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -67,7 +67,6 @@ type (
 	DataPermission struct {
 		Collection string `json:"collection,omitempty"`
 		Tenant     string `json:"tenant,omitempty"`
-		Object     string `json:"object,omitempty"`
 
 		Create bool `json:"-"`
 		Read   bool `json:"-"`

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/rest"
 	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
@@ -416,51 +417,130 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 }
 
 func (r *Role) UnmarshalJSON(data []byte) error {
-	var role rest.Role
+	var role struct {
+		ID          string `json:"name"`
+		Permissions []struct {
+			Action      rest.PermissionAction `json:"action"`
+			Alias       json.RawMessage       `json:"aliases"`
+			Backup      json.RawMessage       `json:"backups"`
+			Cluster     json.RawMessage       `json:"cluster"`
+			Collection  json.RawMessage       `json:"collections"`
+			Data        json.RawMessage       `json:"data"`
+			Group       json.RawMessage       `json:"groups"`
+			Namespace   json.RawMessage       `json:"namespaces"`
+			Node        json.RawMessage       `json:"nodes"`
+			Replication json.RawMessage       `json:"replicate"`
+			Role        json.RawMessage       `json:"roles"`
+			Tenant      json.RawMessage       `json:"tenants"`
+			User        json.RawMessage       `json:"users"`
+		}
+	}
+
 	if err := json.Unmarshal(data, &role); err != nil {
 		return err
 	}
 
-	*r = Role{ID: role.Name}
+	*r = Role{ID: role.ID}
 
 	lookup := make(map[string]any)
+	ps := &r.Permissions
 	for _, p := range role.Permissions {
+		var kind string
+		if parts := strings.Split(string(p.Action), "_"); len(parts) != 0 {
+			kind = parts[len(parts)-1]
+		} else {
+			continue
+		}
+
 		switch p.Action {
 		case rest.CreateAliases:
-			merge(lookup, "aliases"+p.Aliases.Collection+p.Aliases.Alias, &r.Permissions.Aliases, func(dest *AliasPermission) {
-				dest.Collection = p.Aliases.Collection
-				dest.Alias = p.Aliases.Alias
-				dest.Create = true
-			})
+			find(lookup, kind, p.Alias, &ps.Aliases).Create = true
 		case rest.ReadAliases:
-			merge(lookup, "aliases"+p.Aliases.Collection+p.Aliases.Alias, &r.Permissions.Aliases, func(dest *AliasPermission) {
-				dest.Collection = p.Aliases.Collection
-				dest.Alias = p.Aliases.Alias
-				dest.Read = true
-			})
+			find(lookup, kind, p.Alias, &ps.Aliases).Read = true
 		case rest.UpdateAliases:
-			merge(lookup, "aliases"+p.Aliases.Collection+p.Aliases.Alias, &r.Permissions.Aliases, func(dest *AliasPermission) {
-				dest.Collection = p.Aliases.Collection
-				dest.Alias = p.Aliases.Alias
-				dest.Update = true
-			})
+			find(lookup, kind, p.Alias, &ps.Aliases).Update = true
 		case rest.DeleteAliases:
-			merge(lookup, "aliases"+p.Aliases.Collection+p.Aliases.Alias, &r.Permissions.Aliases, func(dest *AliasPermission) {
-				dest.Collection = p.Aliases.Collection
-				dest.Alias = p.Aliases.Alias
-				dest.Delete = true
-			})
+			find(lookup, kind, p.Alias, &ps.Aliases).Delete = true
+		case rest.ManageBackups:
+			find(lookup, kind, p.Backup, &ps.Backups).Manage = true
+		case rest.ReadCluster:
+			find(lookup, kind, p.Cluster, &ps.Cluster).Read = true
+		case rest.CreateCollections:
+			find(lookup, kind, p.Collection, &ps.Collections).Create = true
+		case rest.ReadCollections:
+			find(lookup, kind, p.Collection, &ps.Collections).Read = true
+		case rest.UpdateCollections:
+			find(lookup, kind, p.Collection, &ps.Collections).Update = true
+		case rest.DeleteCollections:
+			find(lookup, kind, p.Collection, &ps.Collections).Delete = true
+		case rest.CreateData:
+			find(lookup, kind, p.Data, &ps.Data).Create = true
+		case rest.ReadData:
+			find(lookup, kind, p.Data, &ps.Data).Read = true
+		case rest.UpdateData:
+			find(lookup, kind, p.Data, &ps.Data).Update = true
+		case rest.DeleteData:
+			find(lookup, kind, p.Data, &ps.Data).Delete = true
+		case rest.ReadGroups:
+			find(lookup, kind, p.Group, &ps.Groups).Read = true
+		case rest.AssignAndRevokeGroups:
+			find(lookup, kind, p.Group, &ps.Groups).AssignAndRevoke = true
+		case rest.ManageNamespaces:
+			find(lookup, kind, p.Namespace, &ps.Namespaces).Manage = true
+		case rest.ReadNodes:
+			find(lookup, kind, p.Node, &ps.Nodes).Read = true
+		case rest.CreateReplicate:
+			find(lookup, kind, p.Replication, &ps.Replication).Create = true
+		case rest.ReadReplicate:
+			find(lookup, kind, p.Replication, &ps.Replication).Read = true
+		case rest.UpdateReplicate:
+			find(lookup, kind, p.Replication, &ps.Replication).Update = true
+		case rest.DeleteReplicate:
+			find(lookup, kind, p.Replication, &ps.Replication).Delete = true
+		case rest.CreateRoles:
+			find(lookup, kind, p.Role, &ps.Roles).Create = true
+		case rest.ReadRoles:
+			find(lookup, kind, p.Role, &ps.Roles).Read = true
+		case rest.UpdateRoles:
+			find(lookup, kind, p.Role, &ps.Roles).Update = true
+		case rest.DeleteRoles:
+			find(lookup, kind, p.Role, &ps.Roles).Delete = true
+		case rest.CreateTenants:
+			find(lookup, kind, p.Tenant, &ps.Tenants).Create = true
+		case rest.ReadTenants:
+			find(lookup, kind, p.Tenant, &ps.Tenants).Read = true
+		case rest.UpdateTenants:
+			find(lookup, kind, p.Tenant, &ps.Tenants).Update = true
+		case rest.DeleteTenants:
+			find(lookup, kind, p.Tenant, &ps.Tenants).Delete = true
+		case rest.CreateUsers:
+			find(lookup, kind, p.User, &ps.Users).Create = true
+		case rest.ReadUsers:
+			find(lookup, kind, p.User, &ps.Users).Read = true
+		case rest.UpdateUsers:
+			find(lookup, kind, p.User, &ps.Users).Update = true
+		case rest.DeleteUsers:
+			find(lookup, kind, p.User, &ps.Users).Delete = true
 		}
 	}
+
 	return nil
 }
 
-func merge[T any](lookup map[string]any, key string, slice *[]T, set func(*T)) {
+func find[T any](lookup map[string]any, kind string, data json.RawMessage, dest *[]T) *T {
+	key := kind + string(data)
 	addr, ok := lookup[key]
 	if !ok {
-		*slice = append(*slice, *new(T))
-		addr = &(*slice)[len(*slice)-1]
+		var t T
+		if len(data) > 0 {
+			if err := json.Unmarshal(data, &t); err != nil {
+				return new(T)
+			}
+		}
+		*dest = append(*dest, t)
+		addr = &(*dest)[len(*dest)-1]
 		lookup[key] = addr
+
 	}
-	set(addr.(*T))
+	return addr.(*T)
 }

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -1,0 +1,466 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/rest"
+	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
+)
+
+type Role struct {
+	ID          string
+	Permissions Permissions
+}
+
+var (
+	_ json.Marshaler   = (*Role)(nil)
+	_ json.Unmarshaler = (*Role)(nil)
+)
+
+type Permissions struct {
+	Aliases     []AliasPermission
+	Backups     []BackupsPermission
+	Cluster     []ClusterPermission
+	Collections []CollectionsPermission
+	Data        []DataPermission
+	Groups      []GroupsPermission
+	Namespaces  []NamespacePermission
+	Nodes       []NodesPermission
+	Replication []ReplicationPermission
+	Roles       []RolesPermission
+	Tenants     []TenantsPermission
+	Users       []UsersPermission
+}
+
+type CreateRoleRequest struct {
+	transports.BaseEndpoint
+	Role Role
+}
+
+var _ transports.Endpoint = (*CreateRoleRequest)(nil)
+
+func (r *CreateRoleRequest) Method() string { return http.MethodPost }
+func (r *CreateRoleRequest) Path() string   { return "/authz/roles" }
+func (r *CreateRoleRequest) Body() any      { return &r.Role }
+
+var GetRoleRequest = transports.IdentityEndpoint[string](http.MethodGet, "/authz/roles/%s")
+
+var ListRolesRequest = transports.StaticEndpoint(http.MethodGet, "/authz/roles")
+
+var DeleteRoleRequest = transports.IdentityEndpoint[string](http.MethodDelete, "/authz/roles/%s")
+
+type Permission struct {
+	Alias       AliasPermission
+	Backups     BackupsPermission
+	Cluster     ClusterPermission
+	Collections CollectionsPermission
+	Data        DataPermission
+	Groups      GroupsPermission
+	Namespaces  NamespacePermission
+	Nodes       NodesPermission
+	Replication ReplicationPermission
+	Roles       RolesPermission
+	Tenants     TenantsPermission
+	Users       UsersPermission
+}
+
+type (
+	AliasPermission struct {
+		Collection string `json:"collection,omitempty"`
+		Alias      string `json:"alias,omitempty"`
+
+		Create bool `json:"-"`
+		Read   bool `json:"-"`
+		Update bool `json:"-"`
+		Delete bool `json:"-"`
+	}
+	BackupsPermission struct {
+		Collection string `json:"collection,omitempty"`
+
+		Manage bool `json:"-"`
+	}
+	ClusterPermission struct {
+		Read bool `json:"-"`
+	}
+	CollectionsPermission struct {
+		Collection string `json:"collection,omitempty"`
+
+		Create bool `json:"-"`
+		Read   bool `json:"-"`
+		Update bool `json:"-"`
+		Delete bool `json:"-"`
+	}
+	DataPermission struct {
+		Collection string `json:"collection,omitempty"`
+		Tenant     string `json:"tenant,omitempty"`
+		Object     string `json:"object,omitempty"`
+
+		Create bool `json:"-"`
+		Read   bool `json:"-"`
+		Update bool `json:"-"`
+		Delete bool `json:"-"`
+	}
+	GroupsPermission struct {
+		GroupID string `json:"group,omitempty"`
+		Type    string `json:"groupType,omitempty"`
+
+		Read            bool `json:"-"`
+		AssignAndRevoke bool `json:"-"`
+	}
+	NamespacePermission struct {
+		Namespace string `json:"namespace,omitempty"`
+
+		Manage bool `json:"-"`
+	}
+	NodesVerbosity  rest.PermissionNodesVerbosity // api.NodeVerbosity
+	NodesPermission struct {
+		Collection string         `json:"collection,omitempty"`
+		Verbosity  NodesVerbosity `json:"verbosity,omitempty"`
+
+		Read bool `json:"-"`
+	}
+	ReplicationPermission struct {
+		Collection string `json:"collection,omitempty"`
+		Shard      string `json:"shard,omitempty"`
+
+		Create bool `json:"-"`
+		Read   bool `json:"-"`
+		Update bool `json:"-"`
+		Delete bool `json:"-"`
+	}
+	RolesScope      rest.PermissionRolesScope
+	RolesPermission struct {
+		RoleID string     `json:"role,omitempty"`
+		Scope  RolesScope `json:"scope,omitempty"`
+
+		Create bool `json:"-"`
+		Read   bool `json:"-"`
+		Update bool `json:"-"`
+		Delete bool `json:"-"`
+	}
+	TenantsPermission struct {
+		Collection string `json:"collection,omitempty"`
+		Tenant     string `json:"tenant,omitempty"`
+
+		Create bool `json:"-"`
+		Read   bool `json:"-"`
+		Update bool `json:"-"`
+		Delete bool `json:"-"`
+	}
+	UsersPermission struct {
+		UserID string `json:"user,omitempty"`
+
+		Create bool `json:"-"`
+		Read   bool `json:"-"`
+		Update bool `json:"-"`
+		Delete bool `json:"-"`
+	}
+)
+
+const (
+	NodeVerbosityMinimal = NodesVerbosity(rest.Minimal)
+	NodeVerbosityVerbose = NodesVerbosity(rest.Verbose)
+
+	RolesScopeAll   = RolesScope(rest.PermissionRolesScopeAll)
+	RolesScopeMatch = RolesScope(rest.PermissionRolesScopeMatch)
+)
+
+func (r *Role) MarshalJSON() ([]byte, error) {
+	permissions := make([]map[string]any, 0)
+	for _, p := range r.Permissions.Aliases {
+		if p.Create {
+			permissions = append(permissions, map[string]any{
+				"action":  rest.CreateAliases,
+				"aliases": p,
+			})
+		}
+		if p.Read {
+			permissions = append(permissions, map[string]any{
+				"action":  rest.ReadAliases,
+				"aliases": p,
+			})
+		}
+		if p.Update {
+			permissions = append(permissions, map[string]any{
+				"action":  rest.UpdateAliases,
+				"aliases": p,
+			})
+		}
+		if p.Delete {
+			permissions = append(permissions, map[string]any{
+				"action":  rest.DeleteAliases,
+				"aliases": p,
+			})
+		}
+	}
+
+	for _, p := range r.Permissions.Backups {
+		if p.Manage {
+			permissions = append(permissions, map[string]any{
+				"action":  rest.ManageBackups,
+				"backups": p,
+			})
+		}
+	}
+
+	for _, p := range r.Permissions.Cluster {
+		if p.Read {
+			permissions = append(permissions, map[string]any{
+				"action": rest.ReadCluster,
+			})
+		}
+	}
+
+	for _, p := range r.Permissions.Collections {
+		if p.Create {
+			permissions = append(permissions, map[string]any{
+				"action":      rest.CreateCollections,
+				"collections": p,
+			})
+		}
+		if p.Read {
+			permissions = append(permissions, map[string]any{
+				"action":      rest.ReadCollections,
+				"collections": p,
+			})
+		}
+		if p.Update {
+			permissions = append(permissions, map[string]any{
+				"action":      rest.UpdateCollections,
+				"collections": p,
+			})
+		}
+		if p.Delete {
+			permissions = append(permissions, map[string]any{
+				"action":      rest.DeleteCollections,
+				"collections": p,
+			})
+		}
+	}
+
+	for _, p := range r.Permissions.Data {
+		if p.Create {
+			permissions = append(permissions, map[string]any{
+				"action": rest.CreateData,
+				"data":   p,
+			})
+		}
+		if p.Read {
+			permissions = append(permissions, map[string]any{
+				"action": rest.ReadData,
+				"data":   p,
+			})
+		}
+		if p.Update {
+			permissions = append(permissions, map[string]any{
+				"action": rest.UpdateData,
+				"data":   p,
+			})
+		}
+		if p.Delete {
+			permissions = append(permissions, map[string]any{
+				"action": rest.DeleteData,
+				"data":   p,
+			})
+		}
+	}
+	for _, p := range r.Permissions.Groups {
+		if p.Read {
+			permissions = append(permissions, map[string]any{
+				"action": rest.ReadGroups,
+				"groups": p,
+			})
+		}
+		if p.AssignAndRevoke {
+			permissions = append(permissions, map[string]any{
+				"action": rest.AssignAndRevokeGroups,
+				"groups": p,
+			})
+		}
+	}
+
+	for _, p := range r.Permissions.Namespaces {
+		if p.Manage {
+			permissions = append(permissions, map[string]any{
+				"action":     rest.ManageNamespaces,
+				"namespaces": p,
+			})
+		}
+	}
+
+	for _, p := range r.Permissions.Nodes {
+		if p.Read {
+			permissions = append(permissions, map[string]any{
+				"action": rest.ReadNodes,
+				"nodes":  p,
+			})
+		}
+	}
+
+	for _, p := range r.Permissions.Replication {
+		if p.Create {
+			permissions = append(permissions, map[string]any{
+				"action":    rest.CreateReplicate,
+				"replicate": p,
+			})
+		}
+		if p.Read {
+			permissions = append(permissions, map[string]any{
+				"action":    rest.ReadReplicate,
+				"replicate": p,
+			})
+		}
+		if p.Update {
+			permissions = append(permissions, map[string]any{
+				"action":    rest.UpdateReplicate,
+				"replicate": p,
+			})
+		}
+		if p.Delete {
+			permissions = append(permissions, map[string]any{
+				"action":    rest.DeleteReplicate,
+				"replicate": p,
+			})
+		}
+	}
+
+	for _, p := range r.Permissions.Roles {
+		if p.Create {
+			permissions = append(permissions, map[string]any{
+				"action": rest.CreateRoles,
+				"roles":  p,
+			})
+		}
+		if p.Read {
+			permissions = append(permissions, map[string]any{
+				"action": rest.ReadRoles,
+				"roles":  p,
+			})
+		}
+		if p.Update {
+			permissions = append(permissions, map[string]any{
+				"action": rest.UpdateRoles,
+				"roles":  p,
+			})
+		}
+		if p.Delete {
+			permissions = append(permissions, map[string]any{
+				"action": rest.DeleteRoles,
+				"roles":  p,
+			})
+		}
+	}
+
+	for _, p := range r.Permissions.Tenants {
+		if p.Create {
+			permissions = append(permissions, map[string]any{
+				"action":  rest.CreateTenants,
+				"tenants": p,
+			})
+		}
+		if p.Read {
+			permissions = append(permissions, map[string]any{
+				"action":  rest.ReadTenants,
+				"tenants": p,
+			})
+		}
+		if p.Update {
+			permissions = append(permissions, map[string]any{
+				"action":  rest.UpdateTenants,
+				"tenants": p,
+			})
+		}
+		if p.Delete {
+			permissions = append(permissions, map[string]any{
+				"action":  rest.DeleteTenants,
+				"tenants": p,
+			})
+		}
+	}
+
+	for _, p := range r.Permissions.Users {
+		if p.Create {
+			permissions = append(permissions, map[string]any{
+				"action": rest.CreateUsers,
+				"users":  p,
+			})
+		}
+		if p.Read {
+			permissions = append(permissions, map[string]any{
+				"action": rest.ReadUsers,
+				"users":  p,
+			})
+		}
+		if p.Update {
+			permissions = append(permissions, map[string]any{
+				"action": rest.UpdateUsers,
+				"users":  p,
+			})
+		}
+		if p.Delete {
+			permissions = append(permissions, map[string]any{
+				"action": rest.DeleteUsers,
+				"users":  p,
+			})
+		}
+	}
+
+	return json.Marshal(&struct {
+		ID          string           `json:"name"`
+		Permissions []map[string]any `json:"permissions"`
+	}{
+		ID:          r.ID,
+		Permissions: permissions,
+	})
+}
+
+func (r *Role) UnmarshalJSON(data []byte) error {
+	var role rest.Role
+	if err := json.Unmarshal(data, &role); err != nil {
+		return err
+	}
+
+	*r = Role{ID: role.Name}
+
+	lookup := make(map[string]any)
+	for _, p := range role.Permissions {
+		switch p.Action {
+		case rest.CreateAliases:
+			merge(lookup, "aliases"+p.Aliases.Collection+p.Aliases.Alias, &r.Permissions.Aliases, func(dest *AliasPermission) {
+				dest.Collection = p.Aliases.Collection
+				dest.Alias = p.Aliases.Alias
+				dest.Create = true
+			})
+		case rest.ReadAliases:
+			merge(lookup, "aliases"+p.Aliases.Collection+p.Aliases.Alias, &r.Permissions.Aliases, func(dest *AliasPermission) {
+				dest.Collection = p.Aliases.Collection
+				dest.Alias = p.Aliases.Alias
+				dest.Read = true
+			})
+		case rest.UpdateAliases:
+			merge(lookup, "aliases"+p.Aliases.Collection+p.Aliases.Alias, &r.Permissions.Aliases, func(dest *AliasPermission) {
+				dest.Collection = p.Aliases.Collection
+				dest.Alias = p.Aliases.Alias
+				dest.Update = true
+			})
+		case rest.DeleteAliases:
+			merge(lookup, "aliases"+p.Aliases.Collection+p.Aliases.Alias, &r.Permissions.Aliases, func(dest *AliasPermission) {
+				dest.Collection = p.Aliases.Collection
+				dest.Alias = p.Aliases.Alias
+				dest.Delete = true
+			})
+		}
+	}
+	return nil
+}
+
+func merge[T any](lookup map[string]any, key string, slice *[]T, set func(*T)) {
+	addr, ok := lookup[key]
+	if !ok {
+		*slice = append(*slice, *new(T))
+		addr = &(*slice)[len(*slice)-1]
+		lookup[key] = addr
+	}
+	set(addr.(*T))
+}

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/rest"
@@ -10,8 +11,8 @@ import (
 )
 
 type Role struct {
-	ID string
-	Permissions
+	ID          string `json:"name"`
+	Permissions `json:"permissions"`
 }
 
 var (
@@ -34,42 +35,7 @@ type Permissions struct {
 	Users       []UserPermission
 }
 
-type CreateRoleRequest struct {
-	transports.BaseEndpoint
-	Role Role
-}
-
-var _ transports.Endpoint = (*CreateRoleRequest)(nil)
-
-func (r *CreateRoleRequest) Method() string { return http.MethodPost }
-func (r *CreateRoleRequest) Path() string   { return "/authz/roles" }
-func (r *CreateRoleRequest) Body() any      { return &r.Role }
-
-// GetRoleRequest fetches the role by it's ID.
-// Use with [ResourceExistsResponse] or [Role] response types.
-var GetRoleRequest = transports.IdentityEndpoint[string](http.MethodGet, "/authz/roles/%s")
-
-// ListRolesRequest fetches all roles defined in the cluster.
-// Use with []Role response type.
-var ListRolesRequest = transports.StaticEndpoint(http.MethodGet, "/authz/roles")
-
-// DeleteRoleRequest deletes a role by it's ID.
-var DeleteRoleRequest = transports.IdentityEndpoint[string](http.MethodDelete, "/authz/roles/%s")
-
-type Permission struct {
-	Alias       AliasPermission
-	Backups     BackupsPermission
-	Cluster     ClusterPermission
-	Collections CollectionPermission
-	Data        DataPermission
-	Groups      GroupPermission
-	Namespaces  NamespacePermission
-	Nodes       NodesPermission
-	Replication ReplicationPermission
-	Roles       RolePermission
-	Tenants     TenantPermission
-	Users       UserPermission
-}
+var _ json.Marshaler = (*Permissions)(nil)
 
 type (
 	AliasPermission struct {
@@ -172,9 +138,212 @@ const (
 	RoleScopeMatch = RoleScope(rest.PermissionRolesScopeMatch)
 )
 
-// MarshalJSON flattens role's permissions, creating an individual
-// entry for every action.
+type CreateRoleRequest struct {
+	transports.BaseEndpoint
+	Role Role
+}
+
+var _ transports.Endpoint = (*CreateRoleRequest)(nil)
+
+func (r *CreateRoleRequest) Method() string { return http.MethodPost }
+func (r *CreateRoleRequest) Path() string   { return "/authz/roles" }
+func (r *CreateRoleRequest) Body() any      { return &r.Role }
+
+// GetRoleRequest fetches the role by it's ID.
+// Use with [ResourceExistsResponse] or [Role] response types.
+var GetRoleRequest = transports.IdentityEndpoint[string](http.MethodGet, "/authz/roles/%s")
+
+// ListRolesRequest fetches all roles defined in the cluster.
+// Use with []Role response type.
+var ListRolesRequest = transports.StaticEndpoint(http.MethodGet, "/authz/roles")
+
+// DeleteRoleRequest deletes a role by it's ID.
+var DeleteRoleRequest = transports.IdentityEndpoint[string](http.MethodDelete, "/authz/roles/%s")
+
+// GetAssignedUsersRequest retrieves IDs of users this role is assigned to.
+// Use with [GetAssignedUsersResponse].
+var GetAssignedUsersRequest = transports.IdentityEndpoint[string](http.MethodGet, "/authz/roles/%s/users")
+
+type GetAssignedUsersResponse []string
+
+// GetUserAssignmentsRequest retrieves IDs and type of users this role is assigned to.
+// Use with [UserAssignment].
+var GetUserAssignmentsRequest = transports.IdentityEndpoint[string](http.MethodGet, "/authz/roles/%s/user-assignments")
+
+// GetUserAssignmentsRequest retrieves IDs and type of groups this role is assigned to.
+// Use with [GroupAssignment].
+var GetGroupAssignmentsRequest = transports.IdentityEndpoint[string](http.MethodGet, "/authz/roles/%s/group-assignments")
+
+// oapi-codegen does not generate inline response types.
+// https://github.com/oapi-codegen/oapi-codegen/issues/513
+type (
+	UserAssignment struct {
+		ID   string `json:"userId"`
+		Type string `json:"userType"`
+	}
+	GroupAssignment struct {
+		ID   string `json:"userId"`
+		Type string `json:"userType"`
+	}
+)
+
+// AddPermissionsRequest adds permissions to a role.
+type AddPermissionsRequest struct {
+	transports.BaseEndpoint
+	RoleID      string      `json:"-"`
+	Permissions Permissions `json:"permissions"`
+}
+
+var _ transports.Endpoint = (*AddPermissionsRequest)(nil)
+
+func (*AddPermissionsRequest) Method() string { return http.MethodPost }
+func (r *AddPermissionsRequest) Path() string {
+	return "/authz/roles/" + url.PathEscape(r.RoleID) + "/add-permissions"
+}
+func (r *AddPermissionsRequest) Body() any { return &r }
+
+// RemovePermissionsRequest removes permissions from a role.
+type RemovePermissionsRequest struct {
+	transports.BaseEndpoint
+	RoleID      string      `json:"-"`
+	Permissions Permissions `json:"permissions"`
+}
+
+var _ transports.Endpoint = (*RemovePermissionsRequest)(nil)
+
+func (*RemovePermissionsRequest) Method() string { return http.MethodPost }
+func (r *RemovePermissionsRequest) Path() string {
+	return "/authz/roles/" + url.PathEscape(r.RoleID) + "/remove-permissions"
+}
+func (r *RemovePermissionsRequest) Body() any { return &r }
+
+// HasPermissionRequest checks if a role contains a permission.
+type HasPermissionRequest struct {
+	transports.BaseEndpoint
+
+	RoleID      string
+	Alias       AliasPermission
+	Backups     BackupsPermission
+	Cluster     ClusterPermission
+	Collections CollectionPermission
+	Data        DataPermission
+	Groups      GroupPermission
+	Namespaces  NamespacePermission
+	Nodes       NodesPermission
+	Replication ReplicationPermission
+	Roles       RolePermission
+	Tenants     TenantPermission
+	Users       UserPermission
+}
+
+var (
+	_ transports.Endpoint = (*HasPermissionRequest)(nil)
+	_ json.Marshaler      = (*HasPermissionRequest)(nil)
+)
+
+func (*HasPermissionRequest) Method() string { return http.MethodPost }
+func (r *HasPermissionRequest) Path() string {
+	return "/authz/roles/" + url.PathEscape(r.RoleID) + "/has-permission"
+}
+func (r *HasPermissionRequest) Body() any { return &r }
+
 func (r *Role) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ID          string       `json:"name"`
+		Permissions *Permissions `json:"permissions"`
+	}{
+		ID:          r.ID,
+		Permissions: &r.Permissions,
+	})
+}
+
+type HasPermissionResponse bool
+
+func (r *HasPermissionRequest) MarshalJSON() ([]byte, error) {
+	var action rest.PermissionAction
+	var data any
+
+	switch {
+	case r.Alias.Create:
+		action, data = rest.CreateAliases, r.Alias
+	case r.Alias.Read:
+		action, data = rest.ReadAliases, r.Alias
+	case r.Alias.Update:
+		action, data = rest.UpdateAliases, r.Alias
+	case r.Alias.Delete:
+		action, data = rest.DeleteAliases, r.Alias
+	case r.Backups.Manage:
+		action, data = rest.ManageBackups, r.Backups
+	case r.Cluster.Read:
+		action, data = rest.ReadCluster, nil
+	case r.Collections.Create:
+		action, data = rest.CreateCollections, r.Collections
+	case r.Collections.Read:
+		action, data = rest.ReadCollections, r.Collections
+	case r.Collections.Update:
+		action, data = rest.UpdateCollections, r.Collections
+	case r.Collections.Delete:
+		action, data = rest.DeleteCollections, r.Collections
+	case r.Data.Create:
+		action, data = rest.CreateData, r.Data
+	case r.Data.Read:
+		action, data = rest.ReadData, r.Data
+	case r.Data.Update:
+		action, data = rest.UpdateData, r.Data
+	case r.Data.Delete:
+		action, data = rest.DeleteData, r.Data
+	case r.Groups.Read:
+		action, data = rest.ReadGroups, r.Groups
+	case r.Groups.AssignAndRevoke:
+		action, data = rest.AssignAndRevokeGroups, r.Groups
+	case r.Namespaces.Manage:
+		action, data = rest.ManageNamespaces, r.Namespaces
+	case r.Nodes.Read:
+		action, data = rest.ReadNodes, r.Nodes
+	case r.Replication.Create:
+		action, data = rest.CreateReplicate, r.Replication
+	case r.Replication.Read:
+		action, data = rest.ReadReplicate, r.Replication
+	case r.Replication.Update:
+		action, data = rest.UpdateReplicate, r.Replication
+	case r.Replication.Delete:
+		action, data = rest.DeleteReplicate, r.Replication
+	case r.Roles.Create:
+		action, data = rest.CreateRoles, r.Roles
+	case r.Roles.Read:
+		action, data = rest.ReadRoles, r.Roles
+	case r.Roles.Update:
+		action, data = rest.UpdateRoles, r.Roles
+	case r.Roles.Delete:
+		action, data = rest.DeleteRoles, r.Roles
+	case r.Tenants.Create:
+		action, data = rest.CreateTenants, r.Tenants
+	case r.Tenants.Read:
+		action, data = rest.ReadTenants, r.Tenants
+	case r.Tenants.Update:
+		action, data = rest.UpdateTenants, r.Tenants
+	case r.Tenants.Delete:
+		action, data = rest.DeleteTenants, r.Tenants
+	case r.Users.Create:
+		action, data = rest.CreateUsers, r.Users
+	case r.Users.Read:
+		action, data = rest.ReadUsers, r.Users
+	case r.Users.Update:
+		action, data = rest.UpdateUsers, r.Users
+	case r.Users.Delete:
+		action, data = rest.DeleteUsers, r.Users
+	}
+
+	permission := map[string]any{"action": action}
+	if kind := permissionKind(action); kind != "" {
+		permission[kind] = data
+	}
+	return json.Marshal(permission)
+}
+
+// MarshalJSON flattens permissions into an array,
+// creating an individual entry for every action.
+func (ps *Permissions) MarshalJSON() ([]byte, error) {
 	permissions := make([]map[string]any, 0)
 
 	// Add permission with given action and resources.
@@ -183,16 +352,14 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 	add := func(action rest.PermissionAction, data any) {
 		permission := map[string]any{"action": action}
 		if data != nil {
-			var kind string
-			if parts := strings.Split(string(action), "_"); len(parts) != 0 {
-				kind = parts[len(parts)-1]
+			if kind := permissionKind(action); kind != "" {
 				permission[kind] = data
 			}
 		}
 		permissions = append(permissions, permission)
 	}
 
-	for _, p := range r.Aliases {
+	for _, p := range ps.Aliases {
 		if p.Create {
 			add(rest.CreateAliases, p)
 		}
@@ -207,19 +374,19 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	for _, p := range r.Backups {
+	for _, p := range ps.Backups {
 		if p.Manage {
 			add(rest.ManageBackups, p)
 		}
 	}
 
-	for _, p := range r.Cluster {
+	for _, p := range ps.Cluster {
 		if p.Read {
 			add(rest.ReadCluster, nil)
 		}
 	}
 
-	for _, p := range r.Collections {
+	for _, p := range ps.Collections {
 		if p.Create {
 			add(rest.CreateCollections, p)
 		}
@@ -234,7 +401,7 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	for _, p := range r.Data {
+	for _, p := range ps.Data {
 		if p.Create {
 			add(rest.CreateData, p)
 		}
@@ -249,7 +416,7 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	for _, p := range r.Groups {
+	for _, p := range ps.Groups {
 		if p.Read {
 			add(rest.ReadGroups, p)
 		}
@@ -258,19 +425,19 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	for _, p := range r.Namespaces {
+	for _, p := range ps.Namespaces {
 		if p.Manage {
 			add(rest.ManageNamespaces, p)
 		}
 	}
 
-	for _, p := range r.Nodes {
+	for _, p := range ps.Nodes {
 		if p.Read {
 			add(rest.ReadNodes, p)
 		}
 	}
 
-	for _, p := range r.Replication {
+	for _, p := range ps.Replication {
 		if p.Create {
 			add(rest.CreateReplicate, p)
 		}
@@ -285,7 +452,7 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	for _, p := range r.Roles {
+	for _, p := range ps.Roles {
 		if p.Create {
 			add(rest.CreateRoles, p)
 		}
@@ -300,7 +467,7 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	for _, p := range r.Tenants {
+	for _, p := range ps.Tenants {
 		if p.Create {
 			add(rest.CreateTenants, p)
 		}
@@ -315,7 +482,7 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	for _, p := range r.Users {
+	for _, p := range ps.Users {
 		if p.Create {
 			add(rest.CreateUsers, p)
 		}
@@ -330,17 +497,14 @@ func (r *Role) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	return json.Marshal(&struct {
-		ID          string           `json:"name"`
-		Permissions []map[string]any `json:"permissions"`
-	}{
-		ID:          r.ID,
-		Permissions: permissions,
-	})
+	return json.Marshal(permissions)
 }
 
 // UnmarshalJSON groups role's permissions by resources.
 func (r *Role) UnmarshalJSON(data []byte) error {
+	// [rest.Role] does not easily lend itself to merging,
+	// we get more control by using our own data type and
+	// unmarshaling concrete permissions lazily.
 	var role struct {
 		ID          string `json:"name"`
 		Permissions []struct {
@@ -448,6 +612,13 @@ func (r *Role) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func permissionKind(action rest.PermissionAction) string {
+	if parts := strings.Split(string(action), "_"); len(parts) != 0 {
+		return parts[len(parts)-1]
+	}
+	return ""
+}
+
 // find retrieves the data for the permission for the given resource.
 // The key is a concatenation of permission <kind> and <data>. The kind
 // is assumed to be the last part of the action, as per the namind convention.
@@ -460,10 +631,8 @@ func (r *Role) UnmarshalJSON(data []byte) error {
 // any resource description, i.e. data is empty; for these, the unmarshaling
 // is skipped, and a zero value of T is appended to dest.
 func find[T any](lookup map[string]any, action rest.PermissionAction, data json.RawMessage, dest *[]T) *T {
-	var kind string
-	if parts := strings.Split(string(action), "_"); len(parts) != 0 {
-		kind = parts[len(parts)-1]
-	} else {
+	kind := permissionKind(action)
+	if kind == "" {
 		return new(T)
 	}
 

--- a/internal/transports/rest.go
+++ b/internal/transports/rest.go
@@ -229,6 +229,7 @@ func IdentityEndpoint[I any](method, pathFmt string) func(I) any {
 
 // identityEndpoint implements [Endpoint] for endpoints that use some ID parameter
 // in the request path, e.g. 'DELETE /users/<user-id>' or 'GET /artist/<artist-id>/songs'.
+// String IDs will be URL-encoded via [url.PathEscape] so using a raw value is safe.
 // See [IdentityEndpoint] for more details.
 type identityEndpoint[I any] struct {
 	BaseEndpoint
@@ -238,8 +239,14 @@ type identityEndpoint[I any] struct {
 
 var _ Endpoint = (*identityEndpoint[any])(nil)
 
-func (r *identityEndpoint[T]) Method() string { return r.method }
-func (r *identityEndpoint[T]) Path() string   { return fmt.Sprintf(r.pathFmt, r.id) }
+func (r *identityEndpoint[I]) Method() string { return r.method }
+func (r *identityEndpoint[I]) Path() string {
+	id := any(r.id)
+	if s, ok := id.(string); ok {
+		id = url.PathEscape(s)
+	}
+	return fmt.Sprintf(r.pathFmt, id)
+}
 
 // StaticEndpoint creates a new static endpoint with a method and a path.
 func StaticEndpoint(method, path string) *staticEndpoint {

--- a/internal/transports/rest_test.go
+++ b/internal/transports/rest_test.go
@@ -272,9 +272,9 @@ func TestBaseEndoint(t *testing.T) {
 
 func TestIdentityEndpoint(t *testing.T) {
 	t.Run("string", func(t *testing.T) {
-		id := "test-id"
+		id := "test id"
 		pathFmt := "/string/%s"
-		wantPath := fmt.Sprintf(pathFmt, id)
+		wantPath := "/string/test%20id" // url-encoded
 
 		factory := transports.IdentityEndpoint[string](http.MethodGet, pathFmt)
 		req := factory(id)

--- a/rbac/roles.go
+++ b/rbac/roles.go
@@ -1,0 +1,80 @@
+package rbac
+
+import (
+	"context"
+
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+)
+
+type RolesClient struct {
+	transport internal.Transport
+}
+
+type Role struct {
+	ID string
+	Permissions
+}
+
+type Permissions struct {
+	Alias       []AliasPermission
+	Backups     []BackupsPermission
+	Cluster     []ClusterPermission
+	Collections []CollectionsPermission
+	Data        []DataPermission
+	Groups      []GroupsPermission
+	Nodes       []NodesPermission
+	Replication []ReplicationPermission
+	Roles       []RolesPermission
+	Tenants     []TenantsPermission
+	Users       []UsersPermission
+}
+
+type (
+	AliasPermission       api.AliasPermission
+	BackupsPermission     api.BackupsPermission
+	ClusterPermission     api.ClusterPermission
+	CollectionsPermission api.CollectionsPermission
+	DataPermission        api.DataPermission
+	GroupsPermission      api.GroupsPermission
+	NodesVerbosity        api.NodesVerbosity
+	NodesPermission       api.NodesPermission
+	ReplicationPermission api.ReplicationPermission
+	RolesScope            api.RolesScope
+	RolesPermission       api.RolesPermission
+	TenantsPermission     api.TenantsPermission
+	UsersPermission       api.UsersPermission
+)
+
+func (rc *RolesClient) Create(context.Context, Role) error                      { return nil }
+func (rc *RolesClient) Exists(ctx context.Context, roleID string) (bool, error) { return false, nil }
+func (rc *RolesClient) Get(ctx context.Context, roleID string) (*Role, error)   { return nil, nil }
+func (rc *RolesClient) List(ctx context.Context) ([]Role, error)                { return nil, nil }
+func (rc *RolesClient) Delete(ctx context.Context, roleID string) error         { return nil }
+
+func (rc *RolesClient) AddPermissions(context.Context, Permissions) error    { return nil }
+func (rc *RolesClient) RemovePermissions(context.Context, Permissions) error { return nil }
+
+type Permission struct {
+	Alias       AliasPermission
+	Backups     BackupsPermission
+	Cluster     ClusterPermission
+	Collections CollectionsPermission
+	Data        DataPermission
+	Groups      GroupsPermission
+	Nodes       NodesPermission
+	Replication ReplicationPermission
+	Roles       RolesPermission
+	Tenants     TenantsPermission
+	Users       UsersPermission
+}
+
+func (rc *RolesClient) HasPermission(context.Context) (bool, error) { return false, nil }
+
+func (rc *RolesClient) AssignedUserIDs(context.Context) ([]string, error) { return nil, nil }
+
+func (rc *RolesClient) UserAssignments(context.Context) ([]map[string]string, error) { return nil, nil }
+
+func (rc *RolesClient) GroupAssignments(context.Context) ([]map[string]string, error) {
+	return nil, nil
+}

--- a/rbac/roles.go
+++ b/rbac/roles.go
@@ -32,6 +32,7 @@ type Permissions struct {
 	Groups      []GroupPermission
 	Namespaces  []NamespacePermission
 	Nodes       []NodesPermission
+	MCP         []MCPPermission
 	Replication []ReplicationPermission
 	Roles       []RolePermission
 	Tenants     []TenantPermission
@@ -53,6 +54,7 @@ type (
 		Read bool
 	}
 	NamespacePermission   api.NamespacePermission
+	MCPPermission         api.MCPPermission
 	ReplicationPermission api.ReplicationPermission
 	RoleScope             api.RoleScope
 	RolePermission        struct {
@@ -276,6 +278,9 @@ func marshalPermissions(ps *Permissions) api.Permissions {
 			Verbosity:  api.NodeVerbosity(p.Verbosity),
 		})
 	}
+	for _, p := range ps.MCP {
+		out.MCP = append(out.MCP, api.MCPPermission(p))
+	}
 	for _, p := range ps.Replication {
 		out.Replication = append(out.Replication, api.ReplicationPermission(p))
 	}
@@ -322,6 +327,9 @@ func unmarshalRole(r *api.Role) *Role {
 			Collection: p.Collection,
 			Verbosity:  NodeVerbosity(p.Verbosity),
 		})
+	}
+	for _, p := range r.MCP {
+		role.MCP = append(role.MCP, MCPPermission(p))
 	}
 	for _, p := range r.Replication {
 		role.Replication = append(role.Replication, ReplicationPermission(p))

--- a/rbac/roles.go
+++ b/rbac/roles.go
@@ -2,6 +2,7 @@ package rbac
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
@@ -17,40 +18,144 @@ type Role struct {
 }
 
 type Permissions struct {
-	Alias       []AliasPermission
+	Aliases     []AliasPermission
 	Backups     []BackupsPermission
 	Cluster     []ClusterPermission
-	Collections []CollectionsPermission
+	Collections []CollectionPermission
 	Data        []DataPermission
-	Groups      []GroupsPermission
+	Groups      []GroupPermission
+	Namespaces  []NamespacePermission
 	Nodes       []NodesPermission
 	Replication []ReplicationPermission
-	Roles       []RolesPermission
-	Tenants     []TenantsPermission
-	Users       []UsersPermission
+	Roles       []RolePermission
+	Tenants     []TenantPermission
+	Users       []UserPermission
 }
 
 type (
-	AliasPermission       api.AliasPermission
-	BackupsPermission     api.BackupsPermission
-	ClusterPermission     api.ClusterPermission
-	CollectionsPermission api.CollectionsPermission
-	DataPermission        api.DataPermission
-	GroupsPermission      api.GroupsPermission
-	NodesVerbosity        api.NodesVerbosity
-	NodesPermission       api.NodesPermission
+	AliasPermission      api.AliasPermission
+	BackupsPermission    api.BackupsPermission
+	ClusterPermission    api.ClusterPermission
+	CollectionPermission api.CollectionPermission
+	DataPermission       api.DataPermission
+	GroupPermission      api.GroupPermission
+	NodeVerbosity        api.NodeVerbosity
+	NodesPermission      struct {
+		Collection string
+		Verbosity  NodeVerbosity
+
+		Read bool
+	}
+	NamespacePermission   api.NamespacePermission
 	ReplicationPermission api.ReplicationPermission
-	RolesScope            api.RolesScope
-	RolesPermission       api.RolesPermission
-	TenantsPermission     api.TenantsPermission
-	UsersPermission       api.UsersPermission
+	RoleScope             api.RoleScope
+	RolePermission        struct {
+		RoleID string
+		Scope  RoleScope
+
+		Create bool
+		Read   bool
+		Update bool
+		Delete bool
+	}
+	TenantPermission api.TenantPermission
+	UserPermission   api.UserPermission
 )
 
-func (rc *RolesClient) Create(context.Context, Role) error                      { return nil }
-func (rc *RolesClient) Exists(ctx context.Context, roleID string) (bool, error) { return false, nil }
-func (rc *RolesClient) Get(ctx context.Context, roleID string) (*Role, error)   { return nil, nil }
-func (rc *RolesClient) List(ctx context.Context) ([]Role, error)                { return nil, nil }
-func (rc *RolesClient) Delete(ctx context.Context, roleID string) error         { return nil }
+const (
+	NodeVerbosityMinimal = NodeVerbosity(api.NodeVerbosityMinimal)
+	NodeVerbosityVerbose = NodeVerbosity(api.NodeVerbosityVerbose)
+
+	RoleScopeAll   = RoleScope(api.RoleScopeAll)
+	RoleScopeMatch = RoleScope(api.RoleScopeMatch)
+)
+
+func (rc *RolesClient) Create(ctx context.Context, r Role) error {
+	role := api.Role{ID: r.ID}
+	for _, p := range r.Aliases {
+		role.Aliases = append(role.Aliases, api.AliasPermission(p))
+	}
+	for _, p := range r.Backups {
+		role.Backups = append(role.Backups, api.BackupsPermission(p))
+	}
+	for _, p := range r.Cluster {
+		role.Cluster = append(role.Cluster, api.ClusterPermission(p))
+	}
+	for _, p := range r.Collections {
+		role.Collections = append(role.Collections, api.CollectionPermission(p))
+	}
+	for _, p := range r.Data {
+		role.Data = append(role.Data, api.DataPermission(p))
+	}
+	for _, p := range r.Groups {
+		role.Groups = append(role.Groups, api.GroupPermission(p))
+	}
+	for _, p := range r.Namespaces {
+		role.Namespaces = append(role.Namespaces, api.NamespacePermission(p))
+	}
+	for _, p := range r.Nodes {
+		role.Nodes = append(role.Nodes, api.NodesPermission{
+			Collection: p.Collection,
+			Verbosity:  api.NodeVerbosity(p.Verbosity),
+		})
+	}
+	for _, p := range r.Replication {
+		role.Replication = append(role.Replication, api.ReplicationPermission(p))
+	}
+	for _, p := range r.Roles {
+		role.Roles = append(role.Roles, api.RolePermission{
+			RoleID: p.RoleID,
+			Scope:  api.RoleScope(p.Scope),
+		})
+	}
+	for _, p := range r.Tenants {
+		role.Tenants = append(role.Tenants, api.TenantPermission(p))
+	}
+	for _, p := range r.Users {
+		role.Users = append(role.Users, api.UserPermission(p))
+	}
+
+	req := &api.CreateRoleRequest{Role: role}
+	if err := rc.transport.Do(ctx, req, nil); err != nil {
+		return fmt.Errorf("create role: %w", err)
+	}
+	return nil
+}
+
+func (rc *RolesClient) Exists(ctx context.Context, roleID string) (bool, error) {
+	var resp api.ResourceExistsResponse
+	if err := rc.transport.Do(ctx, api.GetRoleRequest(roleID), &resp); err != nil {
+		return false, fmt.Errorf("check role exists: %w", err)
+	}
+	return resp.Bool(), nil
+}
+
+func (rc *RolesClient) Get(ctx context.Context, roleID string) (*Role, error) {
+	var resp api.Role
+	if err := rc.transport.Do(ctx, api.GetRoleRequest(roleID), &resp); err != nil {
+		return nil, fmt.Errorf("get role: %w", err)
+	}
+	return unmarshalRole(&resp), nil
+}
+
+func (rc *RolesClient) List(ctx context.Context) ([]Role, error) {
+	var resp []api.Role
+	if err := rc.transport.Do(ctx, api.ListRolesRequest, &resp); err != nil {
+		return nil, fmt.Errorf("list role: %w", err)
+	}
+	var roles []Role
+	for i := range resp {
+		roles = append(roles, *unmarshalRole(&resp[i]))
+	}
+	return roles, nil
+}
+
+func (rc *RolesClient) Delete(ctx context.Context, roleID string) error {
+	if err := rc.transport.Do(ctx, api.DeleteRoleRequest(roleID), nil); err != nil {
+		return fmt.Errorf("delete role: %w", err)
+	}
+	return nil
+}
 
 func (rc *RolesClient) AddPermissions(context.Context, Permissions) error    { return nil }
 func (rc *RolesClient) RemovePermissions(context.Context, Permissions) error { return nil }
@@ -59,14 +164,14 @@ type Permission struct {
 	Alias       AliasPermission
 	Backups     BackupsPermission
 	Cluster     ClusterPermission
-	Collections CollectionsPermission
+	Collections CollectionPermission
 	Data        DataPermission
-	Groups      GroupsPermission
+	Groups      GroupPermission
 	Nodes       NodesPermission
 	Replication ReplicationPermission
-	Roles       RolesPermission
-	Tenants     TenantsPermission
-	Users       UsersPermission
+	Roles       RolePermission
+	Tenants     TenantPermission
+	Users       UserPermission
 }
 
 func (rc *RolesClient) HasPermission(context.Context) (bool, error) { return false, nil }
@@ -77,4 +182,51 @@ func (rc *RolesClient) UserAssignments(context.Context) ([]map[string]string, er
 
 func (rc *RolesClient) GroupAssignments(context.Context) ([]map[string]string, error) {
 	return nil, nil
+}
+
+func unmarshalRole(r *api.Role) *Role {
+	role := Role{ID: r.ID}
+	for _, p := range r.Aliases {
+		role.Aliases = append(role.Aliases, AliasPermission(p))
+	}
+	for _, p := range r.Backups {
+		role.Backups = append(role.Backups, BackupsPermission(p))
+	}
+	for _, p := range r.Cluster {
+		role.Cluster = append(role.Cluster, ClusterPermission(p))
+	}
+	for _, p := range r.Collections {
+		role.Collections = append(role.Collections, CollectionPermission(p))
+	}
+	for _, p := range r.Data {
+		role.Data = append(role.Data, DataPermission(p))
+	}
+	for _, p := range r.Groups {
+		role.Groups = append(role.Groups, GroupPermission(p))
+	}
+	for _, p := range r.Namespaces {
+		role.Namespaces = append(role.Namespaces, NamespacePermission(p))
+	}
+	for _, p := range r.Nodes {
+		role.Nodes = append(role.Nodes, NodesPermission{
+			Collection: p.Collection,
+			Verbosity:  NodeVerbosity(p.Verbosity),
+		})
+	}
+	for _, p := range r.Replication {
+		role.Replication = append(role.Replication, ReplicationPermission(p))
+	}
+	for _, p := range r.Roles {
+		role.Roles = append(role.Roles, RolePermission{
+			RoleID: p.RoleID,
+			Scope:  RoleScope(p.Scope),
+		})
+	}
+	for _, p := range r.Tenants {
+		role.Tenants = append(role.Tenants, TenantPermission(p))
+	}
+	for _, p := range r.Users {
+		role.Users = append(role.Users, UserPermission(p))
+	}
+	return &role
 }

--- a/rbac/roles.go
+++ b/rbac/roles.go
@@ -71,57 +71,19 @@ const (
 )
 
 func (rc *RolesClient) Create(ctx context.Context, r Role) error {
-	role := api.Role{ID: r.ID}
-	for _, p := range r.Aliases {
-		role.Aliases = append(role.Aliases, api.AliasPermission(p))
+	req := &api.CreateRoleRequest{
+		Role: api.Role{
+			ID:          r.ID,
+			Permissions: marshalPermissions(&r.Permissions),
+		},
 	}
-	for _, p := range r.Backups {
-		role.Backups = append(role.Backups, api.BackupsPermission(p))
-	}
-	for _, p := range r.Cluster {
-		role.Cluster = append(role.Cluster, api.ClusterPermission(p))
-	}
-	for _, p := range r.Collections {
-		role.Collections = append(role.Collections, api.CollectionPermission(p))
-	}
-	for _, p := range r.Data {
-		role.Data = append(role.Data, api.DataPermission(p))
-	}
-	for _, p := range r.Groups {
-		role.Groups = append(role.Groups, api.GroupPermission(p))
-	}
-	for _, p := range r.Namespaces {
-		role.Namespaces = append(role.Namespaces, api.NamespacePermission(p))
-	}
-	for _, p := range r.Nodes {
-		role.Nodes = append(role.Nodes, api.NodesPermission{
-			Collection: p.Collection,
-			Verbosity:  api.NodeVerbosity(p.Verbosity),
-		})
-	}
-	for _, p := range r.Replication {
-		role.Replication = append(role.Replication, api.ReplicationPermission(p))
-	}
-	for _, p := range r.Roles {
-		role.Roles = append(role.Roles, api.RolePermission{
-			RoleID: p.RoleID,
-			Scope:  api.RoleScope(p.Scope),
-		})
-	}
-	for _, p := range r.Tenants {
-		role.Tenants = append(role.Tenants, api.TenantPermission(p))
-	}
-	for _, p := range r.Users {
-		role.Users = append(role.Users, api.UserPermission(p))
-	}
-
-	req := &api.CreateRoleRequest{Role: role}
 	if err := rc.transport.Do(ctx, req, nil); err != nil {
 		return fmt.Errorf("create role: %w", err)
 	}
 	return nil
 }
 
+// Exists returns true and nil error if role with the given roleID exists.
 func (rc *RolesClient) Exists(ctx context.Context, roleID string) (bool, error) {
 	var resp api.ResourceExistsResponse
 	if err := rc.transport.Do(ctx, api.GetRoleRequest(roleID), &resp); err != nil {
@@ -130,6 +92,7 @@ func (rc *RolesClient) Exists(ctx context.Context, roleID string) (bool, error) 
 	return resp.Bool(), nil
 }
 
+// Get fetches a role with the given roleID.
 func (rc *RolesClient) Get(ctx context.Context, roleID string) (*Role, error) {
 	var resp api.Role
 	if err := rc.transport.Do(ctx, api.GetRoleRequest(roleID), &resp); err != nil {
@@ -138,6 +101,7 @@ func (rc *RolesClient) Get(ctx context.Context, roleID string) (*Role, error) {
 	return unmarshalRole(&resp), nil
 }
 
+// List fetches all roles defined in the cluster.
 func (rc *RolesClient) List(ctx context.Context) ([]Role, error) {
 	var resp []api.Role
 	if err := rc.transport.Do(ctx, api.ListRolesRequest, &resp); err != nil {
@@ -150,6 +114,7 @@ func (rc *RolesClient) List(ctx context.Context) ([]Role, error) {
 	return roles, nil
 }
 
+// Delete deletes a role with the given roleID.
 func (rc *RolesClient) Delete(ctx context.Context, roleID string) error {
 	if err := rc.transport.Do(ctx, api.DeleteRoleRequest(roleID), nil); err != nil {
 		return fmt.Errorf("delete role: %w", err)
@@ -157,10 +122,35 @@ func (rc *RolesClient) Delete(ctx context.Context, roleID string) error {
 	return nil
 }
 
-func (rc *RolesClient) AddPermissions(context.Context, Permissions) error    { return nil }
-func (rc *RolesClient) RemovePermissions(context.Context, Permissions) error { return nil }
+type AddPermissions Role
 
-type Permission struct {
+func (rc *RolesClient) AddPermissions(ctx context.Context, options AddPermissions) error {
+	req := &api.AddPermissionsRequest{
+		RoleID:      options.ID,
+		Permissions: marshalPermissions(&options.Permissions),
+	}
+	if err := rc.transport.Do(ctx, &req, nil); err != nil {
+		return fmt.Errorf("add role permissions: %w", err)
+	}
+	return nil
+}
+
+type RemovePermissions Role
+
+func (rc *RolesClient) RemovePermissions(ctx context.Context, options RemovePermissions) error {
+	req := &api.RemovePermissionsRequest{
+		RoleID:      options.ID,
+		Permissions: marshalPermissions(&options.Permissions),
+	}
+	if err := rc.transport.Do(ctx, &req, nil); err != nil {
+		return fmt.Errorf("remove role permissions: %w", err)
+	}
+	return nil
+}
+
+type HasPermission struct {
+	RoleID string
+
 	Alias       AliasPermission
 	Backups     BackupsPermission
 	Cluster     ClusterPermission
@@ -174,14 +164,119 @@ type Permission struct {
 	Users       UserPermission
 }
 
-func (rc *RolesClient) HasPermission(context.Context) (bool, error) { return false, nil }
+// HasPermission checks if a role contains a permission.
+// Only one permission can be checked in a single call.
+func (rc *RolesClient) HasPermission(ctx context.Context, roleID string, options HasPermission) (bool, error) {
+	req := &api.HasPermissionRequest{
+		RoleID:      options.RoleID,
+		Alias:       api.AliasPermission(options.Alias),
+		Backups:     api.BackupsPermission(options.Backups),
+		Cluster:     api.ClusterPermission(options.Cluster),
+		Collections: api.CollectionPermission(options.Collections),
+		Data:        api.DataPermission(options.Data),
+		Groups:      api.GroupPermission(options.Groups),
+		Nodes: api.NodesPermission{
+			Collection: options.Nodes.Collection,
+			Verbosity:  api.NodeVerbosity(options.Nodes.Verbosity),
+		},
+		Replication: api.ReplicationPermission(options.Replication),
+		Roles: api.RolePermission{
+			RoleID: options.Roles.RoleID,
+			Scope:  api.RoleScope(options.Roles.Scope),
+		},
+		Tenants: api.TenantPermission(options.Tenants),
+		Users:   api.UserPermission(options.Users),
+	}
+	var resp api.HasPermissionResponse
+	if err := rc.transport.Do(ctx, req, &resp); err != nil {
+		return false, fmt.Errorf("check role has permission: %w", err)
+	}
+	return bool(resp), nil
+}
 
-func (rc *RolesClient) AssignedUserIDs(context.Context) ([]string, error) { return nil, nil }
+func (rc *RolesClient) AssignedUserIDs(ctx context.Context, roleID string) ([]string, error) {
+	var resp api.GetAssignedUsersResponse
+	if err := rc.transport.Do(ctx, api.GetAssignedUsersRequest(roleID), &resp); err != nil {
+		return nil, fmt.Errorf("get assigned users: %w", err)
+	}
+	return []string(resp), nil
+}
 
-func (rc *RolesClient) UserAssignments(context.Context) ([]map[string]string, error) { return nil, nil }
+type UserAssignment api.UserAssignment
 
-func (rc *RolesClient) GroupAssignments(context.Context) ([]map[string]string, error) {
-	return nil, nil
+func (rc *RolesClient) UserAssignments(ctx context.Context, roleID string) ([]UserAssignment, error) {
+	var resp []api.UserAssignment
+	if err := rc.transport.Do(ctx, api.GetUserAssignmentsRequest(roleID), &resp); err != nil {
+		return nil, fmt.Errorf("get user assignments: %w", err)
+	}
+
+	out := make([]UserAssignment, len(resp))
+	for i := range resp {
+		out[i] = UserAssignment(resp[i])
+	}
+	return out, nil
+}
+
+type GroupAssignment api.GroupAssignment
+
+func (rc *RolesClient) GroupAssignments(ctx context.Context, roleID string) ([]GroupAssignment, error) {
+	var resp []api.GroupAssignment
+	if err := rc.transport.Do(ctx, api.GetGroupAssignmentsRequest(roleID), &resp); err != nil {
+		return nil, fmt.Errorf("get group assignments: %w", err)
+	}
+
+	out := make([]GroupAssignment, len(resp))
+	for i := range resp {
+		out[i] = GroupAssignment(resp[i])
+	}
+	return out, nil
+}
+
+func marshalPermissions(ps *Permissions) api.Permissions {
+	var out api.Permissions
+	for _, p := range ps.Aliases {
+		out.Aliases = append(out.Aliases, api.AliasPermission(p))
+	}
+	for _, p := range ps.Backups {
+		out.Backups = append(out.Backups, api.BackupsPermission(p))
+	}
+	for _, p := range ps.Cluster {
+		out.Cluster = append(out.Cluster, api.ClusterPermission(p))
+	}
+	for _, p := range ps.Collections {
+		out.Collections = append(out.Collections, api.CollectionPermission(p))
+	}
+	for _, p := range ps.Data {
+		out.Data = append(out.Data, api.DataPermission(p))
+	}
+	for _, p := range ps.Groups {
+		out.Groups = append(out.Groups, api.GroupPermission(p))
+	}
+	for _, p := range ps.Namespaces {
+		out.Namespaces = append(out.Namespaces, api.NamespacePermission(p))
+	}
+	for _, p := range ps.Nodes {
+		out.Nodes = append(out.Nodes, api.NodesPermission{
+			Collection: p.Collection,
+			Verbosity:  api.NodeVerbosity(p.Verbosity),
+		})
+	}
+	for _, p := range ps.Replication {
+		out.Replication = append(out.Replication, api.ReplicationPermission(p))
+	}
+	for _, p := range ps.Roles {
+		out.Roles = append(out.Roles, api.RolePermission{
+			RoleID: p.RoleID,
+			Scope:  api.RoleScope(p.Scope),
+		})
+	}
+	for _, p := range ps.Tenants {
+		out.Tenants = append(out.Tenants, api.TenantPermission(p))
+	}
+	for _, p := range ps.Users {
+		out.Users = append(out.Users, api.UserPermission(p))
+	}
+	return out
 }
 
 func unmarshalRole(r *api.Role) *Role {

--- a/rbac/roles.go
+++ b/rbac/roles.go
@@ -168,39 +168,27 @@ type HasPermission struct {
 	Alias       AliasPermission
 	Backups     BackupsPermission
 	Cluster     ClusterPermission
-	Collections CollectionPermission
+	Collection  CollectionPermission
 	Data        DataPermission
-	Groups      GroupPermission
+	Group       GroupPermission
+	MCP         MCPPermission
+	Namespaces  NamespacePermission
 	Nodes       NodesPermission
 	Replication ReplicationPermission
-	Roles       RolePermission
-	Tenants     TenantPermission
-	Users       UserPermission
+	Role        RolePermission
+	Tenant      TenantPermission
+	User        UserPermission
 }
 
 // HasPermission checks if a role contains a permission.
 // Only one permission can be checked in a single call.
 func (rc *RolesClient) HasPermission(ctx context.Context, options HasPermission) (bool, error) {
-	req := &api.HasPermissionRequest{
-		RoleID:      options.RoleID,
-		Alias:       api.AliasPermission(options.Alias),
-		Backups:     api.BackupsPermission(options.Backups),
-		Cluster:     api.ClusterPermission(options.Cluster),
-		Collections: api.CollectionPermission(options.Collections),
-		Data:        api.DataPermission(options.Data),
-		Groups:      api.GroupPermission(options.Groups),
-		Nodes: api.NodesPermission{
-			Collection: options.Nodes.Collection,
-			Verbosity:  api.NodeVerbosity(options.Nodes.Verbosity),
-		},
-		Replication: api.ReplicationPermission(options.Replication),
-		Roles: api.RolePermission{
-			RoleID: options.Roles.RoleID,
-			Scope:  api.RoleScope(options.Roles.Scope),
-		},
-		Tenants: api.TenantPermission(options.Tenants),
-		Users:   api.UserPermission(options.Users),
+	req, err := marshalHasPermission(options)
+	if err != nil {
+		return false, err
 	}
+	req.RoleID = options.RoleID
+
 	var resp api.HasPermissionResponse
 	if err := rc.transport.Do(ctx, req, &resp); err != nil {
 		return false, fmt.Errorf("check role has permission: %w", err)
@@ -347,4 +335,162 @@ func unmarshalRole(r *api.Role) *Role {
 		role.Users = append(role.Users, UserPermission(p))
 	}
 	return &role
+}
+
+// marshalHasPermission returns [api.HasPermissionRequest] with exacly 1 permission
+// (action + data) pair set and returns an error if more permissions are set in has.
+// This validation happens at this step, because internal/api expects the request
+// to be valid and will only send a single permission, even if more have been set,
+// so the server cannot perform this validation.
+//
+// NOTE(dyma): we might want to introduce some Validator interface in the transport
+// layer, which every request object can optionally implement, so that all validation
+// is done right before we marshal the request and dispatch to the actual transport.
+func marshalHasPermission(has HasPermission) (*api.HasPermissionRequest, error) {
+	var count int
+	for _, check := range []bool{
+		has.Alias.Create,
+	} {
+		if check {
+			count++
+		}
+	}
+	if has.Alias.Create {
+		count++
+	}
+	if has.Alias.Read {
+		count++
+	}
+	if has.Alias.Update {
+		count++
+	}
+	if has.Alias.Delete {
+		count++
+	}
+	if has.Backups.Manage {
+		count++
+	}
+	if has.Cluster.Read {
+		count++
+	}
+	if has.Collection.Create {
+		count++
+	}
+	if has.Collection.Read {
+		count++
+	}
+	if has.Collection.Update {
+		count++
+	}
+	if has.Collection.Delete {
+		count++
+	}
+	if has.Data.Create {
+		count++
+	}
+	if has.Data.Read {
+		count++
+	}
+	if has.Data.Update {
+		count++
+	}
+	if has.Data.Delete {
+		count++
+	}
+	if has.Group.Read {
+		count++
+	}
+	if has.Group.AssignAndRevoke {
+		count++
+	}
+	if has.Namespaces.Manage {
+		count++
+	}
+	if has.Nodes.Read {
+		count++
+	}
+	if has.MCP.Create {
+		count++
+	}
+	if has.MCP.Read {
+		count++
+	}
+	if has.MCP.Update {
+		count++
+	}
+	if has.Replication.Create {
+		count++
+	}
+	if has.Replication.Read {
+		count++
+	}
+	if has.Replication.Update {
+		count++
+	}
+	if has.Replication.Delete {
+		count++
+	}
+	if has.Role.Create {
+		count++
+	}
+	if has.Role.Read {
+		count++
+	}
+	if has.Role.Update {
+		count++
+	}
+	if has.Role.Delete {
+		count++
+	}
+	if has.Tenant.Create {
+		count++
+	}
+	if has.Tenant.Read {
+		count++
+	}
+	if has.Tenant.Update {
+		count++
+	}
+	if has.Tenant.Delete {
+		count++
+	}
+	if has.User.Create {
+		count++
+	}
+	if has.User.Read {
+		count++
+	}
+	if has.User.Update {
+		count++
+	}
+	if has.User.Delete {
+		count++
+	}
+	if has.User.AssignAndRevoke {
+		count++
+	}
+
+	if count == 1 {
+		return &api.HasPermissionRequest{
+			Alias:       api.AliasPermission(has.Alias),
+			Backups:     api.BackupsPermission(has.Backups),
+			Cluster:     api.ClusterPermission(has.Cluster),
+			Collections: api.CollectionPermission(has.Collection),
+			Data:        api.DataPermission(has.Data),
+			Groups:      api.GroupPermission(has.Group),
+			Nodes: api.NodesPermission{
+				Collection: has.Nodes.Collection,
+				Verbosity:  api.NodeVerbosity(has.Nodes.Verbosity),
+			},
+			Replication: api.ReplicationPermission(has.Replication),
+			Roles: api.RolePermission{
+				RoleID: has.Role.RoleID,
+				Scope:  api.RoleScope(has.Role.Scope),
+			},
+			Tenants: api.TenantPermission(has.Tenant),
+			Users:   api.UserPermission(has.User),
+		}, nil
+	}
+
+	return nil, fmt.Errorf("has-permission accepts 1 permission but %d were provided", count)
 }

--- a/rbac/roles.go
+++ b/rbac/roles.go
@@ -6,10 +6,16 @@ import (
 
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
 )
 
 type RolesClient struct {
 	transport internal.Transport
+}
+
+func NewRolesClient(t internal.Transport) *RolesClient {
+	dev.AssertNotNil(t, "transport")
+	return &RolesClient{transport: t}
 }
 
 type Role struct {
@@ -122,27 +128,33 @@ func (rc *RolesClient) Delete(ctx context.Context, roleID string) error {
 	return nil
 }
 
-type AddPermissions Role
+type AddPermissions struct {
+	RoleID      string
+	Permissions Permissions
+}
 
 func (rc *RolesClient) AddPermissions(ctx context.Context, options AddPermissions) error {
 	req := &api.AddPermissionsRequest{
-		RoleID:      options.ID,
+		RoleID:      options.RoleID,
 		Permissions: marshalPermissions(&options.Permissions),
 	}
-	if err := rc.transport.Do(ctx, &req, nil); err != nil {
+	if err := rc.transport.Do(ctx, req, nil); err != nil {
 		return fmt.Errorf("add role permissions: %w", err)
 	}
 	return nil
 }
 
-type RemovePermissions Role
+type RemovePermissions struct {
+	RoleID      string
+	Permissions Permissions
+}
 
 func (rc *RolesClient) RemovePermissions(ctx context.Context, options RemovePermissions) error {
 	req := &api.RemovePermissionsRequest{
-		RoleID:      options.ID,
+		RoleID:      options.RoleID,
 		Permissions: marshalPermissions(&options.Permissions),
 	}
-	if err := rc.transport.Do(ctx, &req, nil); err != nil {
+	if err := rc.transport.Do(ctx, req, nil); err != nil {
 		return fmt.Errorf("remove role permissions: %w", err)
 	}
 	return nil
@@ -166,7 +178,7 @@ type HasPermission struct {
 
 // HasPermission checks if a role contains a permission.
 // Only one permission can be checked in a single call.
-func (rc *RolesClient) HasPermission(ctx context.Context, roleID string, options HasPermission) (bool, error) {
+func (rc *RolesClient) HasPermission(ctx context.Context, options HasPermission) (bool, error) {
 	req := &api.HasPermissionRequest{
 		RoleID:      options.RoleID,
 		Alias:       api.AliasPermission(options.Alias),

--- a/rbac/roles.go
+++ b/rbac/roles.go
@@ -202,6 +202,9 @@ func (rc *RolesClient) AssignedUserIDs(ctx context.Context, roleID string) ([]st
 	return []string(resp), nil
 }
 
+// TODO(dyma): replace with map[username]usertype?
+// Or just User, containing Type and ID, but other fields zeroed.
+// Otherwise we're polluting the API.
 type UserAssignment api.UserAssignment
 
 func (rc *RolesClient) UserAssignments(ctx context.Context, roleID string) ([]UserAssignment, error) {

--- a/rbac/roles_test.go
+++ b/rbac/roles_test.go
@@ -1,0 +1,460 @@
+package rbac_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+	"github.com/weaviate/weaviate-go-client/v6/rbac"
+)
+
+func TestNewRolesClient(t *testing.T) {
+	require.Panics(t, func() {
+		rbac.NewRolesClient(nil)
+	}, "nil transport")
+}
+
+func TestRolesClient_Create(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		role  rbac.Role
+		stubs []testkit.Stub[api.CreateRoleRequest, any]
+		err   testkit.Error
+	}{
+		{
+			name: "ok",
+			role: rbac.Role{
+				ID: "rock-n-role",
+				Permissions: rbac.Permissions{
+					Cluster: []rbac.ClusterPermission{
+						{Read: true},
+					},
+				},
+			},
+			stubs: []testkit.Stub[api.CreateRoleRequest, any]{{
+				Request: &api.CreateRoleRequest{
+					Role: api.Role{
+						ID: "rock-n-role",
+						Permissions: api.Permissions{
+							Cluster: []api.ClusterPermission{
+								{Read: true},
+							},
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "with error",
+			role: rbac.Role{ID: "empty-role"},
+			stubs: []testkit.Stub[api.CreateRoleRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewRolesClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			err := c.Create(t.Context(), tt.role)
+			tt.err.Require(t, err, "request error")
+		})
+	}
+}
+
+func TestRolesClient_Exists(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		roleID string
+		stubs  []testkit.Stub[any, api.ResourceExistsResponse]
+		want   bool
+		err    testkit.Error
+	}{
+		{
+			name:   "role exists",
+			roleID: "rock-n-role",
+			stubs: []testkit.Stub[any, api.ResourceExistsResponse]{{
+				Request:  testkit.Ptr(api.GetRoleRequest("rock-n-role")),
+				Response: true,
+			}},
+			want: true,
+		},
+		{
+			name:   "role not exists",
+			roleID: "rock-n-role",
+			stubs: []testkit.Stub[any, api.ResourceExistsResponse]{{
+				Request:  testkit.Ptr(api.GetRoleRequest("rock-n-role")),
+				Response: false,
+			}},
+			want: false,
+		},
+		{
+			name:   "with error",
+			roleID: "rock-n-role",
+			stubs: []testkit.Stub[any, api.ResourceExistsResponse]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewRolesClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.Exists(t.Context(), tt.roleID)
+			tt.err.Require(t, err, "request error")
+			require.Equal(t, tt.want, got, "exists")
+		})
+	}
+}
+
+func TestRolesClient_Get(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		roleID string
+		stubs  []testkit.Stub[any, api.Role]
+		want   *rbac.Role
+		err    testkit.Error
+	}{
+		{
+			name:   "ok",
+			roleID: "rock-n-role",
+			stubs: []testkit.Stub[any, api.Role]{{
+				Request:  testkit.Ptr(api.GetRoleRequest("rock-n-role")),
+				Response: api.Role{ID: "rock-n-role"},
+			}},
+			want: &rbac.Role{ID: "rock-n-role"},
+		},
+		{
+			name:   "with error",
+			roleID: "rock-n-role",
+			stubs: []testkit.Stub[any, api.Role]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewRolesClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.Get(t.Context(), tt.roleID)
+			tt.err.Require(t, err, "request error")
+			require.Equal(t, tt.want, got, "bad result")
+		})
+	}
+}
+
+func TestRolesClient_List(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		roleID string
+		stubs  []testkit.Stub[any, []api.Role]
+		want   []rbac.Role
+		err    testkit.Error
+	}{
+		{
+			name:   "ok",
+			roleID: "rock-n-role",
+			stubs: []testkit.Stub[any, []api.Role]{{
+				Request:  testkit.Ptr[any](api.ListRolesRequest),
+				Response: []api.Role{{ID: "rock-n-role"}},
+			}},
+			want: []rbac.Role{{ID: "rock-n-role"}},
+		},
+		{
+			name:   "with error",
+			roleID: "rock-n-role",
+			stubs: []testkit.Stub[any, []api.Role]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewRolesClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.List(t.Context())
+			tt.err.Require(t, err, "request error")
+			require.Equal(t, tt.want, got, "bad result")
+		})
+	}
+}
+
+func TestRolesClient_AddPermissions(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		add   rbac.AddPermissions
+		stubs []testkit.Stub[api.AddPermissionsRequest, any]
+		err   testkit.Error
+	}{
+		{
+			name: "ok",
+			add: rbac.AddPermissions{
+				RoleID: "rock-n-role",
+				Permissions: rbac.Permissions{
+					Cluster: []rbac.ClusterPermission{
+						{Read: true},
+					},
+				},
+			},
+			stubs: []testkit.Stub[api.AddPermissionsRequest, any]{{
+				Request: &api.AddPermissionsRequest{
+					RoleID: "rock-n-role",
+					Permissions: api.Permissions{
+						Cluster: []api.ClusterPermission{
+							{Read: true},
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.AddPermissionsRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewRolesClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			err := c.AddPermissions(t.Context(), tt.add)
+			tt.err.Require(t, err, "request error")
+		})
+	}
+}
+
+func TestRolesClient_RemovePermissions(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		remove rbac.RemovePermissions
+		stubs  []testkit.Stub[api.RemovePermissionsRequest, any]
+		err    testkit.Error
+	}{
+		{
+			name: "ok",
+			remove: rbac.RemovePermissions{
+				RoleID: "rock-n-role",
+				Permissions: rbac.Permissions{
+					Cluster: []rbac.ClusterPermission{
+						{Read: true},
+					},
+				},
+			},
+			stubs: []testkit.Stub[api.RemovePermissionsRequest, any]{{
+				Request: &api.RemovePermissionsRequest{
+					RoleID: "rock-n-role",
+					Permissions: api.Permissions{
+						Cluster: []api.ClusterPermission{
+							{Read: true},
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.RemovePermissionsRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewRolesClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			err := c.RemovePermissions(t.Context(), tt.remove)
+			tt.err.Require(t, err, "request error")
+		})
+	}
+}
+
+func TestRolesClient_HasPermission(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		permission rbac.HasPermission
+		stubs      []testkit.Stub[api.HasPermissionRequest, api.HasPermissionResponse]
+		want       bool
+		err        testkit.Error
+	}{
+		{
+			name: "has permission",
+			permission: rbac.HasPermission{
+				RoleID:  "rock-n-role",
+				Cluster: rbac.ClusterPermission{Read: true},
+			},
+			stubs: []testkit.Stub[api.HasPermissionRequest, api.HasPermissionResponse]{{
+				Request: &api.HasPermissionRequest{
+					RoleID:  "rock-n-role",
+					Cluster: api.ClusterPermission{Read: true},
+				},
+				Response: true,
+			}},
+			want: true,
+		},
+		{
+			name: "not has permission",
+			permission: rbac.HasPermission{
+				RoleID:  "rock-n-role",
+				Cluster: rbac.ClusterPermission{Read: true},
+			},
+			stubs: []testkit.Stub[api.HasPermissionRequest, api.HasPermissionResponse]{{
+				Request: &api.HasPermissionRequest{
+					RoleID:  "rock-n-role",
+					Cluster: api.ClusterPermission{Read: true},
+				},
+				Response: false,
+			}},
+			want: false,
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.HasPermissionRequest, api.HasPermissionResponse]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewRolesClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.HasPermission(t.Context(), tt.permission)
+			tt.err.Require(t, err, "request error")
+			require.Equal(t, tt.want, got, "bad result")
+		})
+	}
+}
+
+func TestRolesClient_AssignedUserIDs(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		roleID string
+		stubs  []testkit.Stub[any, api.GetAssignedUsersResponse]
+		want   []string
+		err    testkit.Error
+	}{
+		{
+			name:   "has permission",
+			roleID: "rock-n-role",
+			stubs: []testkit.Stub[any, api.GetAssignedUsersResponse]{{
+				Request:  testkit.Ptr(api.GetAssignedUsersRequest("rock-n-role")),
+				Response: []string{"john_doe", "jane_doe"},
+			}},
+			want: []string{"john_doe", "jane_doe"},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[any, api.GetAssignedUsersResponse]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewRolesClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.AssignedUserIDs(t.Context(), tt.roleID)
+			tt.err.Require(t, err, "request error")
+			require.Equal(t, tt.want, got, "bad result")
+		})
+	}
+}
+
+func TestRolesClient_UserAssignments(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		roleID string
+		stubs  []testkit.Stub[any, []api.UserAssignment]
+		want   []rbac.UserAssignment
+		err    testkit.Error
+	}{
+		{
+			name:   "has permission",
+			roleID: "rock-n-role",
+			stubs: []testkit.Stub[any, []api.UserAssignment]{{
+				Request: testkit.Ptr(api.GetUserAssignmentsRequest("rock-n-role")),
+				Response: []api.UserAssignment{
+					{ID: "john_doe", Type: "db_env"},
+				},
+			}},
+			want: []rbac.UserAssignment{
+				{ID: "john_doe", Type: "db_env"},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[any, []api.UserAssignment]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewRolesClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.UserAssignments(t.Context(), tt.roleID)
+			tt.err.Require(t, err, "request error")
+			require.Equal(t, tt.want, got, "bad result")
+		})
+	}
+}
+
+func TestRolesClient_GroupAssignments(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		roleID string
+		stubs  []testkit.Stub[any, []api.GroupAssignment]
+		want   []rbac.GroupAssignment
+		err    testkit.Error
+	}{
+		{
+			name:   "has permission",
+			roleID: "rock-n-role",
+			stubs: []testkit.Stub[any, []api.GroupAssignment]{{
+				Request: testkit.Ptr(api.GetGroupAssignmentsRequest("rock-n-role")),
+				Response: []api.GroupAssignment{
+					{ID: "external", Type: "oidc"},
+				},
+			}},
+			want: []rbac.GroupAssignment{
+				{ID: "external", Type: "oidc"},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[any, []api.GroupAssignment]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewRolesClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.GroupAssignments(t.Context(), tt.roleID)
+			tt.err.Require(t, err, "request error")
+			require.Equal(t, tt.want, got, "bad result")
+		})
+	}
+}

--- a/rbac/roles_test.go
+++ b/rbac/roles_test.go
@@ -3,6 +3,7 @@ package rbac_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
@@ -283,7 +284,9 @@ func TestRolesClient_RemovePermissions(t *testing.T) {
 }
 
 func TestRolesClient_HasPermission(t *testing.T) {
-	for _, tt := range []struct {
+	for _, tt := range testkit.WithOnly(t, []struct {
+		testkit.Only
+
 		name       string
 		permission rbac.HasPermission
 		stubs      []testkit.Stub[api.HasPermissionRequest, api.HasPermissionResponse]
@@ -321,13 +324,40 @@ func TestRolesClient_HasPermission(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "too many actions",
+			permission: rbac.HasPermission{
+				RoleID: "rock-n-role",
+				Collection: rbac.CollectionPermission{
+					Create: true, Read: true, Update: true,
+				},
+			},
+			err: testkit.Error(func(tt assert.TestingT, got error, a ...any) bool {
+				return assert.ErrorContains(tt, got, "3 were provided")
+			}),
+		},
+		{
+			name: "multiple permissions",
+			permission: rbac.HasPermission{
+				RoleID:     "rock-n-role",
+				Cluster:    rbac.ClusterPermission{Read: true},
+				Collection: rbac.CollectionPermission{Read: true},
+			},
+			err: testkit.Error(func(tt assert.TestingT, got error, a ...any) bool {
+				return assert.ErrorContains(tt, got, "2 were provided")
+			}),
+		},
+		{
 			name: "with error",
+			permission: rbac.HasPermission{
+				RoleID:  "rock-n-role",
+				Cluster: rbac.ClusterPermission{Read: true},
+			},
 			stubs: []testkit.Stub[api.HasPermissionRequest, api.HasPermissionResponse]{
 				{Err: testkit.ErrWhaam},
 			},
-			err: testkit.ExpectError,
+			err: testkit.ErrorIs(testkit.ErrWhaam),
 		},
-	} {
+	}) {
 		t.Run(tt.name, func(t *testing.T) {
 			transport := testkit.NewTransport(t, tt.stubs)
 			c := rbac.NewRolesClient(transport)
@@ -349,7 +379,7 @@ func TestRolesClient_AssignedUserIDs(t *testing.T) {
 		err    testkit.Error
 	}{
 		{
-			name:   "has permission",
+			name:   "ok",
 			roleID: "rock-n-role",
 			stubs: []testkit.Stub[any, api.GetAssignedUsersResponse]{{
 				Request:  testkit.Ptr(api.GetAssignedUsersRequest("rock-n-role")),
@@ -386,7 +416,7 @@ func TestRolesClient_UserAssignments(t *testing.T) {
 		err    testkit.Error
 	}{
 		{
-			name:   "has permission",
+			name:   "ok",
 			roleID: "rock-n-role",
 			stubs: []testkit.Stub[any, []api.UserAssignment]{{
 				Request: testkit.Ptr(api.GetUserAssignmentsRequest("rock-n-role")),
@@ -427,7 +457,7 @@ func TestRolesClient_GroupAssignments(t *testing.T) {
 		err    testkit.Error
 	}{
 		{
-			name:   "has permission",
+			name:   "ok",
 			roleID: "rock-n-role",
 			stubs: []testkit.Stub[any, []api.GroupAssignment]{{
 				Request: testkit.Ptr(api.GetGroupAssignmentsRequest("rock-n-role")),


### PR DESCRIPTION
This PR adds support for a set of RBAC APIs related to role management and user/group assignment. It is available under `Client.Roles` namespace. Similarly to other client, permissions for the same resource are grouped under one object (unlike in the REST API), so that the AliasPermission looks like so:

```go
type AliasPermission struct{
    // Resource
    Collection, Alias string
    // Permitted actions
    Create, Read, Update, Delete bool
}
```

Consequently, the un-/marshaling in `internal/api/rbac.go` is quite verbose, but overall simple to follow (?), as the same pattern is repeated for every permission type / action. I did not want to resort to using reflection here and the only "heuristic" you'll find is the assumption that the last element of the "action" value in the REST body corresponds to the key for the resource. I.e `groups` in:

```json
{ "action": "assign_and_revoke_groups", "groups": { ... } }
```

