### PR TITLE
v6: Close client

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package weaviate
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -23,6 +24,8 @@ type Client struct {
 	Backup      *backup.Client
 	Collections *collections.Client
 }
+
+var _ io.Closer = (*Client)(nil)
 
 // NewClient returns a new client. Nothing is configured by default and
 // the following must be provided:
@@ -296,4 +299,11 @@ func (c *Client) Metadata(ctx context.Context) (*InstanceMetadata, error) {
 		Modules:            resp.Modules,
 		GRPCMaxMessageSize: resp.GRPCMaxMessageSize,
 	}, nil
+}
+
+func (c *Client) Close() error {
+	if cl, ok := c.transport.(io.Closer); ok {
+		return cl.Close()
+	}
+	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package weaviate_test
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -385,4 +386,36 @@ func TestMetadata(t *testing.T) {
 		},
 		GRPCMaxMessageSize: 4096,
 	}, got, "bad result")
+}
+
+func TestClient_Close(t *testing.T) {
+	newFunc := transport.New
+	t.Cleanup(func() { transport.New = newFunc })
+
+	var closed spyCloser
+	transport.New = func(context.Context, transport.Config) (internal.Transport, error) {
+		return struct {
+			internal.Transport
+			io.Closer
+		}{
+			Transport: testkit.NopTransport,
+			Closer:    &closed,
+		}, nil
+	}
+
+	c, err := weaviate.NewClient(t.Context())
+	assert.NoError(t, err, "new client")
+	require.NotNil(t, c, "nil client")
+	assert.False(t, bool(closed), "new client closes transport")
+
+	err = c.Close()
+	assert.NoError(t, err, "close error")
+	assert.True(t, bool(closed), "closing client closes transport")
+}
+
+type spyCloser bool
+
+func (spy *spyCloser) Close() error {
+	*spy = true
+	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -413,6 +413,7 @@ func TestClient_Close(t *testing.T) {
 	assert.True(t, bool(closed), "closing client closes transport")
 }
 
+// spyCloser is true after [spyCloser.Close] has been called.
 type spyCloser bool
 
 func (spy *spyCloser) Close() error {


### PR DESCRIPTION
This PR adds a `Close()` method to the client so that resources (goroutines) can be freed when the client is no longer in use. 