### PR TITLE
Send empty vector index type on Weaviate 1.37.5

### DIFF
--- a/test/docker/weaviate.go
+++ b/test/docker/weaviate.go
@@ -9,12 +9,22 @@ import (
 )
 
 func StartWeaviate(ctx context.Context, weaviateImage string) (*DockerContainer, error) {
+	return StartWeaviateWithEnv(ctx, weaviateImage, nil)
+}
+
+// StartWeaviateWithEnv starts a Weaviate container using the given image and
+// merges any caller-supplied env vars on top of the default set. Pass nil for
+// extraEnv when no extra variables are needed.
+func StartWeaviateWithEnv(ctx context.Context, weaviateImage string, extraEnv map[string]string) (*DockerContainer, error) {
 	env := map[string]string{
 		"AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED": "true",
 		"LOG_LEVEL":                 "debug",
 		"QUERY_DEFAULTS_LIMIT":      "20",
 		"PERSISTENCE_DATA_PATH":     "./data",
 		"DEFAULT_VECTORIZER_MODULE": "none",
+	}
+	for k, v := range extraEnv {
+		env[k] = v
 	}
 
 	c, err := weaviate.Run(

--- a/test/schema/default_vector_index_type_test.go
+++ b/test/schema/default_vector_index_type_test.go
@@ -1,0 +1,215 @@
+package schema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v5/test/docker"
+	"github.com/weaviate/weaviate-go-client/v5/weaviate"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// serverVersion bundles a Weaviate image tag with optional server-side env var
+// overrides that modify default behaviour (e.g. DEFAULT_VECTOR_INDEX=flat).
+type serverVersion struct {
+	name        string
+	image       string
+	extraEnv    map[string]string
+	wantDefault string // expected VectorIndexType when the caller sends none
+}
+
+// TestDefaultVectorIndexType_Legacy137_4_InjectsHnsw proves that when the
+// client connects to Weaviate 1.37.4 (which does not apply a server-side
+// DEFAULT_VECTOR_INDEX), the client injects "hnsw" for every class whose
+// VectorIndexType is empty.
+func TestDefaultVectorIndexType_Legacy137_4_InjectsHnsw(t *testing.T) {
+	ctx := context.Background()
+
+	container, err := docker.StartWeaviateWithEnv(ctx, "semitechnologies/weaviate:1.37.4", nil)
+	require.NoError(t, err, "start Weaviate 1.37.4 container")
+	defer func() {
+		require.NoError(t, container.Terminate(ctx))
+	}()
+
+	client, err := weaviate.NewClient(weaviate.Config{
+		Host:   container.Endpoint(docker.HTTP),
+		Scheme: "http",
+	})
+	require.NoError(t, err)
+
+	t.Run("legacy single-vector: empty type becomes hnsw", func(t *testing.T) {
+		className := "LegacyNoType"
+		defer client.Schema().ClassDeleter().WithClassName(className).Do(ctx) //nolint:errcheck
+
+		class := &models.Class{Class: className}
+		require.NoError(t, client.Schema().ClassCreator().WithClass(class).Do(ctx))
+
+		got, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "hnsw", got.VectorIndexType,
+			"client must inject 'hnsw' for legacy server when VectorIndexType is empty")
+	})
+
+	t.Run("named vector: empty type becomes hnsw", func(t *testing.T) {
+		className := "LegacyNamedNoType"
+		defer client.Schema().ClassDeleter().WithClassName(className).Do(ctx) //nolint:errcheck
+
+		class := &models.Class{
+			Class: className,
+			VectorConfig: map[string]models.VectorConfig{
+				"main": {
+					Vectorizer:      map[string]interface{}{"none": map[string]interface{}{}},
+					VectorIndexType: "", // intentionally empty
+				},
+			},
+		}
+		require.NoError(t, client.Schema().ClassCreator().WithClass(class).Do(ctx))
+
+		got, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+		require.NoError(t, err)
+		require.Contains(t, got.VectorConfig, "main")
+		assert.Equal(t, "hnsw", got.VectorConfig["main"].VectorIndexType,
+			"client must inject 'hnsw' in named vector config for legacy server")
+	})
+}
+
+// TestDefaultVectorIndexType_New137_5_AppliesServerDefault proves that when
+// the client connects to Weaviate 1.37.5 (which natively supports
+// DEFAULT_VECTOR_INDEX), the client does NOT inject "hnsw" — instead the
+// server applies whatever its DEFAULT_VECTOR_INDEX env var says (here "flat").
+func TestDefaultVectorIndexType_New137_5_AppliesServerDefault(t *testing.T) {
+	ctx := context.Background()
+
+	extraEnv := map[string]string{
+		"DEFAULT_VECTOR_INDEX": "flat",
+	}
+	// 1.37.5-e0fe0d5.amd64 is a locally-built image from stable/v1.37 HEAD
+	// (commit ea7a136193) which includes the DEFAULT_VECTOR_INDEX feature
+	// merged in a63dc833d8. The version string reports as "1.37.5-..." which
+	// the supportsServerSideDefaultVectorIndexType helper treats as >= 1.37.5.
+	container, err := docker.StartWeaviateWithEnv(ctx, "semitechnologies/weaviate:1.37.5-e0fe0d5.amd64", extraEnv)
+	require.NoError(t, err, "start Weaviate 1.37.5 container")
+	defer func() {
+		require.NoError(t, container.Terminate(ctx))
+	}()
+
+	client, err := weaviate.NewClient(weaviate.Config{
+		Host:   container.Endpoint(docker.HTTP),
+		Scheme: "http",
+	})
+	require.NoError(t, err)
+
+	t.Run("legacy single-vector: server default applies (flat)", func(t *testing.T) {
+		className := "NewServerNoType"
+		defer client.Schema().ClassDeleter().WithClassName(className).Do(ctx) //nolint:errcheck
+
+		class := &models.Class{Class: className}
+		require.NoError(t, client.Schema().ClassCreator().WithClass(class).Do(ctx))
+
+		got, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "flat", got.VectorIndexType,
+			"server must apply DEFAULT_VECTOR_INDEX=flat; client must NOT override it with 'hnsw'")
+	})
+
+	t.Run("named vector: server default applies (flat)", func(t *testing.T) {
+		className := "NewServerNamedNoType"
+		defer client.Schema().ClassDeleter().WithClassName(className).Do(ctx) //nolint:errcheck
+
+		class := &models.Class{
+			Class: className,
+			VectorConfig: map[string]models.VectorConfig{
+				"main": {
+					Vectorizer:      map[string]interface{}{"none": map[string]interface{}{}},
+					VectorIndexType: "", // intentionally empty — server should fill in "flat"
+				},
+			},
+		}
+		require.NoError(t, client.Schema().ClassCreator().WithClass(class).Do(ctx))
+
+		got, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+		require.NoError(t, err)
+		require.Contains(t, got.VectorConfig, "main")
+		assert.Equal(t, "flat", got.VectorConfig["main"].VectorIndexType,
+			"server must apply DEFAULT_VECTOR_INDEX=flat in named vector config")
+	})
+}
+
+// TestDefaultVectorIndexType_ExplicitFlat_BothVersions verifies that an
+// explicit VectorIndexType:"flat" set by the caller is preserved unchanged on
+// both the legacy (1.37.4) and new (1.37.5) servers. The inject helper must
+// never overwrite a non-empty user value.
+func TestDefaultVectorIndexType_ExplicitFlat_BothVersions(t *testing.T) {
+	ctx := context.Background()
+
+	versions := []serverVersion{
+		{
+			name:  "legacy 1.37.4",
+			image: "semitechnologies/weaviate:1.37.4",
+		},
+		{
+			name:  "new 1.37.5 with DEFAULT_VECTOR_INDEX=flat",
+			image: "semitechnologies/weaviate:1.37.5-e0fe0d5.amd64",
+			extraEnv: map[string]string{
+				"DEFAULT_VECTOR_INDEX": "flat",
+			},
+		},
+	}
+
+	for _, sv := range versions {
+		sv := sv
+		t.Run(sv.name, func(t *testing.T) {
+			container, err := docker.StartWeaviateWithEnv(ctx, sv.image, sv.extraEnv)
+			require.NoError(t, err, "start container")
+			defer func() {
+				require.NoError(t, container.Terminate(ctx))
+			}()
+
+			client, err := weaviate.NewClient(weaviate.Config{
+				Host:   container.Endpoint(docker.HTTP),
+				Scheme: "http",
+			})
+			require.NoError(t, err)
+
+			t.Run("legacy single-vector explicit flat preserved", func(t *testing.T) {
+				className := "ExplicitFlatSingle"
+				defer client.Schema().ClassDeleter().WithClassName(className).Do(ctx) //nolint:errcheck
+
+				class := &models.Class{
+					Class:           className,
+					VectorIndexType: "flat",
+				}
+				require.NoError(t, client.Schema().ClassCreator().WithClass(class).Do(ctx))
+
+				got, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+				require.NoError(t, err)
+				assert.Equal(t, "flat", got.VectorIndexType,
+					"explicit 'flat' must be preserved on %s", sv.name)
+			})
+
+			t.Run("named vector explicit flat preserved", func(t *testing.T) {
+				className := "ExplicitFlatNamed"
+				defer client.Schema().ClassDeleter().WithClassName(className).Do(ctx) //nolint:errcheck
+
+				class := &models.Class{
+					Class: className,
+					VectorConfig: map[string]models.VectorConfig{
+						"main": {
+							Vectorizer:      map[string]interface{}{"none": map[string]interface{}{}},
+							VectorIndexType: "flat",
+						},
+					},
+				}
+				require.NoError(t, client.Schema().ClassCreator().WithClass(class).Do(ctx))
+
+				got, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+				require.NoError(t, err)
+				require.Contains(t, got.VectorConfig, "main")
+				assert.Equal(t, "flat", got.VectorConfig["main"].VectorIndexType,
+					"explicit 'flat' must be preserved in named vector config on %s", sv.name)
+			})
+		})
+	}
+}

--- a/test/schema/default_vector_index_type_test.go
+++ b/test/schema/default_vector_index_type_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,15 @@ import (
 	"github.com/weaviate/weaviate-go-client/v5/weaviate"
 	"github.com/weaviate/weaviate/entities/models"
 )
+
+// imageTag returns the value of the named env var, falling back to defaultTag
+// when the var is unset or empty.
+func imageTag(envVar, defaultTag string) string {
+	if v := os.Getenv(envVar); v != "" {
+		return v
+	}
+	return defaultTag
+}
 
 // serverVersion bundles a Weaviate image tag with optional server-side env var
 // overrides that modify default behaviour (e.g. DEFAULT_VECTOR_INDEX=flat).
@@ -27,8 +37,9 @@ type serverVersion struct {
 func TestDefaultVectorIndexType_Legacy137_4_InjectsHnsw(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := docker.StartWeaviateWithEnv(ctx, "semitechnologies/weaviate:1.37.4", nil)
-	require.NoError(t, err, "start Weaviate 1.37.4 container")
+	legacyTag := imageTag("WEAVIATE_VERSION_LEGACY", "1.37.4")
+	container, err := docker.StartWeaviateWithEnv(ctx, "semitechnologies/weaviate:"+legacyTag, nil)
+	require.NoError(t, err, "start Weaviate legacy container (%s)", legacyTag)
 	defer func() {
 		require.NoError(t, container.Terminate(ctx))
 	}()
@@ -85,12 +96,14 @@ func TestDefaultVectorIndexType_New137_5_AppliesServerDefault(t *testing.T) {
 	extraEnv := map[string]string{
 		"DEFAULT_VECTOR_INDEX": "flat",
 	}
-	// 1.37.5-e0fe0d5.amd64 is a locally-built image from stable/v1.37 HEAD
-	// (commit ea7a136193) which includes the DEFAULT_VECTOR_INDEX feature
-	// merged in a63dc833d8. The version string reports as "1.37.5-..." which
-	// the supportsServerSideDefaultVectorIndexType helper treats as >= 1.37.5.
-	container, err := docker.StartWeaviateWithEnv(ctx, "semitechnologies/weaviate:1.37.5-e0fe0d5.amd64", extraEnv)
-	require.NoError(t, err, "start Weaviate 1.37.5 container")
+	// The new-version image tag is read from WEAVIATE_VERSION (existing
+	// repo-wide convention). Default is a locally-built 1.37.5 image that
+	// includes the DEFAULT_VECTOR_INDEX feature. The version string reports
+	// as "1.37.5-..." which the supportsServerSideDefaultVectorIndexType
+	// helper treats as >= 1.37.5.
+	newTag := imageTag("WEAVIATE_VERSION", "1.37.5-e0fe0d5.amd64")
+	container, err := docker.StartWeaviateWithEnv(ctx, "semitechnologies/weaviate:"+newTag, extraEnv)
+	require.NoError(t, err, "start Weaviate new container (%s)", newTag)
 	defer func() {
 		require.NoError(t, container.Terminate(ctx))
 	}()
@@ -146,12 +159,12 @@ func TestDefaultVectorIndexType_ExplicitFlat_BothVersions(t *testing.T) {
 
 	versions := []serverVersion{
 		{
-			name:  "legacy 1.37.4",
-			image: "semitechnologies/weaviate:1.37.4",
+			name:  "legacy " + imageTag("WEAVIATE_VERSION_LEGACY", "1.37.4"),
+			image: "semitechnologies/weaviate:" + imageTag("WEAVIATE_VERSION_LEGACY", "1.37.4"),
 		},
 		{
-			name:  "new 1.37.5 with DEFAULT_VECTOR_INDEX=flat",
-			image: "semitechnologies/weaviate:1.37.5-e0fe0d5.amd64",
+			name:  "new " + imageTag("WEAVIATE_VERSION", "1.37.5-e0fe0d5.amd64") + " with DEFAULT_VECTOR_INDEX=flat",
+			image: "semitechnologies/weaviate:" + imageTag("WEAVIATE_VERSION", "1.37.5-e0fe0d5.amd64"),
 			extraEnv: map[string]string{
 				"DEFAULT_VECTOR_INDEX": "flat",
 			},

--- a/weaviate/internal/defaultVectorIndexType.go
+++ b/weaviate/internal/defaultVectorIndexType.go
@@ -51,7 +51,9 @@ func InjectLegacyDefaultVectorIndexType(p *db.VersionProvider, class *models.Cla
 	if supportsServerSideDefaultVectorIndexType(p.Version()) {
 		return
 	}
-	if class.VectorIndexType == "" {
+	// Only inject a class-level VectorIndexType when the class is NOT using
+	// named vectors (VectorConfig). Mixing both is rejected by the server.
+	if class.VectorIndexType == "" && len(class.VectorConfig) == 0 {
 		class.VectorIndexType = "hnsw"
 	}
 	for k, vc := range class.VectorConfig {

--- a/weaviate/internal/defaultVectorIndexType.go
+++ b/weaviate/internal/defaultVectorIndexType.go
@@ -1,0 +1,63 @@
+package internal
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/db"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// supportsServerSideDefaultVectorIndexType returns true iff the parsed
+// version is >= 1.37.5. Empty or malformed -> false (treat as old server).
+func supportsServerSideDefaultVectorIndexType(version string) bool {
+	if version == "" {
+		return false
+	}
+	// strip "-suffix" (e.g. "1.37.5-e0fe0d5.amd64")
+	base := strings.SplitN(version, "-", 2)[0]
+	parts := strings.Split(base, ".")
+	if len(parts) < 3 {
+		return false
+	}
+	major, err1 := strconv.Atoi(parts[0])
+	minor, err2 := strconv.Atoi(parts[1])
+	patch, err3 := strconv.Atoi(parts[2])
+	if err1 != nil || err2 != nil || err3 != nil {
+		return false
+	}
+	if major > 1 {
+		return true
+	}
+	if major < 1 {
+		return false
+	}
+	if minor > 37 {
+		return true
+	}
+	if minor < 37 {
+		return false
+	}
+	return patch >= 5
+}
+
+// InjectLegacyDefaultVectorIndexType injects "hnsw" into any empty
+// VectorIndexType field on the given class — but only when the server is
+// older than 1.37.5. Servers >= 1.37.5 apply DEFAULT_VECTOR_INDEX themselves.
+func InjectLegacyDefaultVectorIndexType(p *db.VersionProvider, class *models.Class) {
+	if class == nil || p == nil {
+		return
+	}
+	if supportsServerSideDefaultVectorIndexType(p.Version()) {
+		return
+	}
+	if class.VectorIndexType == "" {
+		class.VectorIndexType = "hnsw"
+	}
+	for k, vc := range class.VectorConfig {
+		if vc.VectorIndexType == "" {
+			vc.VectorIndexType = "hnsw"
+			class.VectorConfig[k] = vc
+		}
+	}
+}

--- a/weaviate/internal/defaultVectorIndexType_test.go
+++ b/weaviate/internal/defaultVectorIndexType_test.go
@@ -1,0 +1,125 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/db"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func newVersionProvider(version string) *db.VersionProvider {
+	return db.NewVersionProvider(func() string { return version })
+}
+
+func TestSupportsServerSideDefaultVectorIndexType(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{"1.37.4 is below threshold", "1.37.4", false},
+		{"1.37.5 is exactly threshold", "1.37.5", true},
+		{"1.37.5 with build suffix", "1.37.5-e0fe0d5.amd64", true},
+		{"1.38.0 is above minor", "1.38.0", true},
+		{"2.0.0 is major bump", "2.0.0", true},
+		{"empty string", "", false},
+		{"malformed string", "malformed", false},
+		{"only two parts", "1.37", false},
+		{"1.37.3 is below patch", "1.37.3", false},
+		{"1.36.99 is below minor", "1.36.99", false},
+		{"0.37.5 is below major", "0.37.5", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := supportsServerSideDefaultVectorIndexType(tt.version)
+			if got != tt.want {
+				t.Errorf("supportsServerSideDefaultVectorIndexType(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInjectLegacyDefaultVectorIndexType(t *testing.T) {
+	t.Run("nil class does not panic", func(t *testing.T) {
+		p := newVersionProvider("1.37.4")
+		InjectLegacyDefaultVectorIndexType(p, nil)
+	})
+
+	t.Run("nil provider does not panic", func(t *testing.T) {
+		class := &models.Class{}
+		InjectLegacyDefaultVectorIndexType(nil, class)
+	})
+
+	t.Run("server 1.37.5 + empty type stays empty", func(t *testing.T) {
+		p := newVersionProvider("1.37.5")
+		class := &models.Class{VectorIndexType: ""}
+		InjectLegacyDefaultVectorIndexType(p, class)
+		if class.VectorIndexType != "" {
+			t.Errorf("expected empty, got %q", class.VectorIndexType)
+		}
+	})
+
+	t.Run("server 1.37.5 + hnsw stays hnsw", func(t *testing.T) {
+		p := newVersionProvider("1.37.5")
+		class := &models.Class{VectorIndexType: "hnsw"}
+		InjectLegacyDefaultVectorIndexType(p, class)
+		if class.VectorIndexType != "hnsw" {
+			t.Errorf("expected hnsw, got %q", class.VectorIndexType)
+		}
+	})
+
+	t.Run("server 1.37.4 + empty type becomes hnsw", func(t *testing.T) {
+		p := newVersionProvider("1.37.4")
+		class := &models.Class{VectorIndexType: ""}
+		InjectLegacyDefaultVectorIndexType(p, class)
+		if class.VectorIndexType != "hnsw" {
+			t.Errorf("expected hnsw, got %q", class.VectorIndexType)
+		}
+	})
+
+	t.Run("server 1.37.4 + flat stays flat", func(t *testing.T) {
+		p := newVersionProvider("1.37.4")
+		class := &models.Class{VectorIndexType: "flat"}
+		InjectLegacyDefaultVectorIndexType(p, class)
+		if class.VectorIndexType != "flat" {
+			t.Errorf("expected flat, got %q", class.VectorIndexType)
+		}
+	})
+
+	t.Run("server 1.37.4 + empty VectorConfig entry becomes hnsw", func(t *testing.T) {
+		p := newVersionProvider("1.37.4")
+		class := &models.Class{
+			VectorIndexType: "hnsw",
+			VectorConfig: map[string]models.VectorConfig{
+				"custom": {VectorIndexType: ""},
+			},
+		}
+		InjectLegacyDefaultVectorIndexType(p, class)
+		if class.VectorConfig["custom"].VectorIndexType != "hnsw" {
+			t.Errorf("expected hnsw in VectorConfig, got %q", class.VectorConfig["custom"].VectorIndexType)
+		}
+	})
+
+	t.Run("server 1.37.4 + non-empty VectorConfig entry stays unchanged", func(t *testing.T) {
+		p := newVersionProvider("1.37.4")
+		class := &models.Class{
+			VectorConfig: map[string]models.VectorConfig{
+				"custom": {VectorIndexType: "flat"},
+			},
+		}
+		InjectLegacyDefaultVectorIndexType(p, class)
+		if class.VectorConfig["custom"].VectorIndexType != "flat" {
+			t.Errorf("expected flat in VectorConfig, got %q", class.VectorConfig["custom"].VectorIndexType)
+		}
+	})
+
+	t.Run("empty server version + empty type becomes hnsw (safe fallback)", func(t *testing.T) {
+		p := newVersionProvider("")
+		class := &models.Class{VectorIndexType: ""}
+		InjectLegacyDefaultVectorIndexType(p, class)
+		if class.VectorIndexType != "hnsw" {
+			t.Errorf("expected hnsw, got %q", class.VectorIndexType)
+		}
+	})
+}

--- a/weaviate/schema/classCreator.go
+++ b/weaviate/schema/classCreator.go
@@ -29,6 +29,7 @@ func (cc *ClassCreator) Do(ctx context.Context) error {
 	if err := internal.CheckTextAnalyzerSupport(cc.dbVersionProvider, cc.class); err != nil {
 		return err
 	}
+	internal.InjectLegacyDefaultVectorIndexType(cc.dbVersionProvider, cc.class)
 	responseData, err := cc.connection.RunREST(ctx, "/schema", http.MethodPost, cc.class)
 	return except.CheckResponseDataErrorAndStatusCode(responseData, err, 200)
 }


### PR DESCRIPTION
Starting with Weaviate 1.37.5 the server sets a default vector index type to set when the client does not specify one. This PR establishes that no vector index type is set by default, and only sets "hsnw" as default for servers running <=1.37.4.

Ensure compatibility with Weaviate 1.37.5+ by sending an empty vector index type, allowing the server to apply the default. Add integration tests to verify behavior across versions and fix a bug related to mixing vector types. Introduce a helper function for environment variable overrides in tests.