### PR TITLE
v6(RBAC) Users / Groups

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,6 +25,8 @@ type Client struct {
 	Backup      *backup.Client
 	Collections *collections.Client
 	Roles       *rbac.RolesClient
+	Users       *rbac.UsersClient
+	Groups      *rbac.GroupsClient
 }
 
 var _ io.Closer = (*Client)(nil)

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -925,7 +925,7 @@ func TestRESTRequests(t *testing.T) {
 			req: &api.GetAssignedRolesRequest{
 				Entity:             api.EntityUser,
 				ID:                 "john-malkovich",
-				Type:               api.UserTypeDB,
+				Kind:               api.RBACKindDB,
 				IncludePermissions: true,
 			},
 			wantMethod: http.MethodGet,
@@ -937,7 +937,7 @@ func TestRESTRequests(t *testing.T) {
 			req: &api.GetAssignedRolesRequest{
 				Entity:             api.EntityGroup,
 				ID:                 "external",
-				Type:               api.GroupTypeOIDC,
+				Kind:               api.RBACKindOIDC,
 				IncludePermissions: true,
 			},
 			wantMethod: http.MethodGet,
@@ -949,7 +949,7 @@ func TestRESTRequests(t *testing.T) {
 			req: &api.AssignRolesRequest{
 				Entity: api.EntityUser,
 				ID:     "john-malkovich",
-				Type:   api.UserTypeDB,
+				Kind:   api.RBACKindDB,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,
@@ -964,7 +964,7 @@ func TestRESTRequests(t *testing.T) {
 			req: &api.AssignRolesRequest{
 				Entity: api.EntityGroup,
 				ID:     "external",
-				Type:   api.GroupTypeOIDC,
+				Kind:   api.RBACKindOIDC,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,
@@ -979,7 +979,7 @@ func TestRESTRequests(t *testing.T) {
 			req: &api.RevokeRolesRequest{
 				Entity: api.EntityUser,
 				ID:     "john-malkovich",
-				Type:   api.UserTypeDB,
+				Kind:   api.RBACKindDB,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,
@@ -994,7 +994,7 @@ func TestRESTRequests(t *testing.T) {
 			req: &api.RevokeRolesRequest{
 				Entity: api.EntityGroup,
 				ID:     "external",
-				Type:   api.GroupTypeOIDC,
+				Kind:   api.RBACKindOIDC,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,
@@ -1743,6 +1743,84 @@ func TestRESTResponses(t *testing.T) {
 				ID:   "external",
 				Type: "oidc",
 			},
+		},
+		{
+			name: "own user info",
+			body: &rest.UserOwnInfo{
+				Username: "john-malkovich",
+				Roles: []rest.Role{
+					{Name: "rock-n-role"},
+					{Name: "sushi-role"},
+				},
+				Groups: []string{"external"},
+			},
+			dest: new(api.GetOwnUserInfoResponse),
+			want: &api.GetOwnUserInfoResponse{
+				ID: "john-malkovich",
+				Roles: []api.Role{
+					{ID: "rock-n-role"},
+					{ID: "sushi-role"},
+				},
+				Groups: []string{"external"},
+			},
+		},
+		{
+			name: "create db user",
+			body: &rest.UserApiKey{
+				Apikey: "abracadabra",
+			},
+			dest: new(api.CreateUserResponse),
+			want: &api.CreateUserResponse{
+				APIKey: "abracadabra",
+			},
+		},
+		{
+			name: "rotate db user api key",
+			body: &rest.UserApiKey{
+				Apikey: "abracadabra",
+			},
+			dest: new(api.RotateUserKeyResponse),
+			want: &api.RotateUserKeyResponse{
+				APIKey: "abracadabra",
+			},
+		},
+		{
+			name: "get user info",
+			body: &rest.DBUserInfo{
+				UserId:     "john-malkovich",
+				DbUserType: rest.DBUserInfoDbUserTypeDbUser,
+				Active:     true,
+				Roles:      []string{"external"},
+			},
+			dest: new(api.UserInfo),
+			want: &api.UserInfo{
+				ID:     "john-malkovich",
+				Type:   "db_user",
+				Active: true,
+				Roles:  []string{"external"},
+			},
+		},
+		{
+			name: "list db users",
+			body: []rest.DBUserInfo{{
+				UserId:     "john-malkovich",
+				DbUserType: rest.DBUserInfoDbUserTypeDbUser,
+				Active:     true,
+				Roles:      []string{"external"},
+			}},
+			dest: new([]api.UserInfo),
+			want: &[]api.UserInfo{{
+				ID:     "john-malkovich",
+				Type:   "db_user",
+				Active: true,
+				Roles:  []string{"external"},
+			}},
+		},
+		{
+			name: "list groups",
+			body: []string{"internal", "external"},
+			dest: new(api.ListGroupsResponse),
+			want: &api.ListGroupsResponse{"internal", "external"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -868,8 +868,9 @@ func TestRESTRequests(t *testing.T) {
 		},
 		{
 			name: "add permissions to role",
-			req: &api.AddPermissionsRequest{
+			req: &api.ManagePermissionsRequest{
 				RoleID: "rock-n-role",
+				Action: api.PermissionActionAdd,
 				Permissions: api.Permissions{
 					Cluster: []api.ClusterPermission{
 						{Read: true},
@@ -886,8 +887,9 @@ func TestRESTRequests(t *testing.T) {
 		},
 		{
 			name: "remove permissions from role",
-			req: &api.RemovePermissionsRequest{
+			req: &api.ManagePermissionsRequest{
 				RoleID: "rock-n-role",
+				Action: api.PermissionActionRemove,
 				Permissions: api.Permissions{
 					Cluster: []api.ClusterPermission{
 						{Read: true},
@@ -947,7 +949,7 @@ func TestRESTRequests(t *testing.T) {
 			req: &api.ManageRolesRequest{
 				Entity: api.UserID("john-malkovich"),
 				Kind:   api.RBACKindDB,
-				Action: api.RBACActionAssign,
+				Action: api.RoleActionAssign,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,
@@ -962,7 +964,7 @@ func TestRESTRequests(t *testing.T) {
 			req: &api.ManageRolesRequest{
 				Entity: api.GroupID("external"),
 				Kind:   api.RBACKindOIDC,
-				Action: api.RBACActionAssign,
+				Action: api.RoleActionAssign,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,
@@ -977,7 +979,7 @@ func TestRESTRequests(t *testing.T) {
 			req: &api.ManageRolesRequest{
 				Entity: api.UserID("john-malkovich"),
 				Kind:   api.RBACKindDB,
-				Action: api.RBACActionRevoke,
+				Action: api.RoleActionRevoke,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,
@@ -992,7 +994,7 @@ func TestRESTRequests(t *testing.T) {
 			req: &api.ManageRolesRequest{
 				Entity: api.GroupID("external"),
 				Kind:   api.RBACKindOIDC,
-				Action: api.RBACActionRevoke,
+				Action: api.RoleActionRevoke,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -923,8 +923,7 @@ func TestRESTRequests(t *testing.T) {
 		{
 			name: "get roles assigned to the user (include permissions)",
 			req: &api.GetAssignedRolesRequest{
-				Entity:             api.EntityUser,
-				ID:                 "john-malkovich",
+				Entity:             api.UserID("john-malkovich"),
 				Kind:               api.RBACKindDB,
 				IncludePermissions: true,
 			},
@@ -935,8 +934,7 @@ func TestRESTRequests(t *testing.T) {
 		{
 			name: "get roles assigned to the group (include permissions)",
 			req: &api.GetAssignedRolesRequest{
-				Entity:             api.EntityGroup,
-				ID:                 "external",
+				Entity:             api.GroupID("external"),
 				Kind:               api.RBACKindOIDC,
 				IncludePermissions: true,
 			},
@@ -946,10 +944,10 @@ func TestRESTRequests(t *testing.T) {
 		},
 		{
 			name: "assign roles to user",
-			req: &api.AssignRolesRequest{
-				Entity: api.EntityUser,
-				ID:     "john-malkovich",
+			req: &api.ManageRolesRequest{
+				Entity: api.UserID("john-malkovich"),
 				Kind:   api.RBACKindDB,
+				Action: api.RBACActionAssign,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,
@@ -961,10 +959,10 @@ func TestRESTRequests(t *testing.T) {
 		},
 		{
 			name: "assign roles to group",
-			req: &api.AssignRolesRequest{
-				Entity: api.EntityGroup,
-				ID:     "external",
+			req: &api.ManageRolesRequest{
+				Entity: api.GroupID("external"),
 				Kind:   api.RBACKindOIDC,
+				Action: api.RBACActionAssign,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,
@@ -976,10 +974,10 @@ func TestRESTRequests(t *testing.T) {
 		},
 		{
 			name: "revoke roles from user",
-			req: &api.RevokeRolesRequest{
-				Entity: api.EntityUser,
-				ID:     "john-malkovich",
+			req: &api.ManageRolesRequest{
+				Entity: api.UserID("john-malkovich"),
 				Kind:   api.RBACKindDB,
+				Action: api.RBACActionRevoke,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,
@@ -991,10 +989,10 @@ func TestRESTRequests(t *testing.T) {
 		},
 		{
 			name: "revoke roles from group",
-			req: &api.RevokeRolesRequest{
-				Entity: api.EntityGroup,
-				ID:     "external",
+			req: &api.ManageRolesRequest{
+				Entity: api.GroupID("external"),
 				Kind:   api.RBACKindOIDC,
+				Action: api.RBACActionRevoke,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -1042,7 +1042,7 @@ func TestRESTRequests(t *testing.T) {
 		},
 		{
 			name:       "rotate db user api key",
-			req:        api.RotateUserKeyRequest("john-malkovich"),
+			req:        api.RotateAPIKeyRequest("john-malkovich"),
 			wantMethod: http.MethodPost,
 			wantPath:   "/users/db/john-malkovich/rotate-key",
 		},
@@ -1779,8 +1779,8 @@ func TestRESTResponses(t *testing.T) {
 			body: &rest.UserApiKey{
 				Apikey: "abracadabra",
 			},
-			dest: new(api.RotateUserKeyResponse),
-			want: &api.RotateUserKeyResponse{
+			dest: new(api.RotateAPIKeyResponse),
+			want: &api.RotateAPIKeyResponse{
 				APIKey: "abracadabra",
 			},
 		},

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -870,7 +870,7 @@ func TestRESTRequests(t *testing.T) {
 			name: "add permissions to role",
 			req: &api.ManagePermissionsRequest{
 				RoleID: "rock-n-role",
-				Action: api.PermissionActionAdd,
+				Verb:   api.PermissionVerbAdd,
 				Permissions: api.Permissions{
 					Cluster: []api.ClusterPermission{
 						{Read: true},
@@ -889,7 +889,7 @@ func TestRESTRequests(t *testing.T) {
 			name: "remove permissions from role",
 			req: &api.ManagePermissionsRequest{
 				RoleID: "rock-n-role",
-				Action: api.PermissionActionRemove,
+				Verb:   api.PermissionVerbRemove,
 				Permissions: api.Permissions{
 					Cluster: []api.ClusterPermission{
 						{Read: true},
@@ -949,7 +949,7 @@ func TestRESTRequests(t *testing.T) {
 			req: &api.ManageRolesRequest{
 				Entity: api.UserID("john-malkovich"),
 				Kind:   api.RBACKindDB,
-				Action: api.RoleActionAssign,
+				Verb:   api.RoleVerbAssign,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,
@@ -964,7 +964,7 @@ func TestRESTRequests(t *testing.T) {
 			req: &api.ManageRolesRequest{
 				Entity: api.GroupID("external"),
 				Kind:   api.RBACKindOIDC,
-				Action: api.RoleActionAssign,
+				Verb:   api.RoleVerbAssign,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,
@@ -979,7 +979,7 @@ func TestRESTRequests(t *testing.T) {
 			req: &api.ManageRolesRequest{
 				Entity: api.UserID("john-malkovich"),
 				Kind:   api.RBACKindDB,
-				Action: api.RoleActionRevoke,
+				Verb:   api.RoleVerbRevoke,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,
@@ -994,7 +994,7 @@ func TestRESTRequests(t *testing.T) {
 			req: &api.ManageRolesRequest{
 				Entity: api.GroupID("external"),
 				Kind:   api.RBACKindOIDC,
-				Action: api.RoleActionRevoke,
+				Verb:   api.RoleVerbRevoke,
 				Roles:  []string{"rock-n-role", "sushi-role"},
 			},
 			wantMethod: http.MethodPost,

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -914,6 +914,157 @@ func TestRESTRequests(t *testing.T) {
 				"action": "read_cluster",
 			},
 		},
+		{
+			name:       "get own user info",
+			req:        api.GetOwnUserInfoRequest,
+			wantMethod: http.MethodGet,
+			wantPath:   "/users/own-info",
+		},
+		{
+			name: "get roles assigned to the user (include permissions)",
+			req: &api.GetAssignedRolesRequest{
+				Entity:             api.EntityUser,
+				ID:                 "john-malkovich",
+				Type:               api.UserTypeDB,
+				IncludePermissions: true,
+			},
+			wantMethod: http.MethodGet,
+			wantPath:   "/authz/users/john-malkovich/roles/db",
+			wantQuery:  url.Values{"includePermissions": {"true"}},
+		},
+		{
+			name: "get roles assigned to the group (include permissions)",
+			req: &api.GetAssignedRolesRequest{
+				Entity:             api.EntityGroup,
+				ID:                 "external",
+				Type:               api.GroupTypeOIDC,
+				IncludePermissions: true,
+			},
+			wantMethod: http.MethodGet,
+			wantPath:   "/authz/groups/external/roles/oidc",
+			wantQuery:  url.Values{"includePermissions": {"true"}},
+		},
+		{
+			name: "assign roles to user",
+			req: &api.AssignRolesRequest{
+				Entity: api.EntityUser,
+				ID:     "john-malkovich",
+				Type:   api.UserTypeDB,
+				Roles:  []string{"rock-n-role", "sushi-role"},
+			},
+			wantMethod: http.MethodPost,
+			wantPath:   "/authz/users/john-malkovich/assign",
+			wantBody: rest.AssignRoleToUserJSONBody{
+				UserType: rest.UserTypeInputDb,
+				Roles:    []string{"rock-n-role", "sushi-role"},
+			},
+		},
+		{
+			name: "assign roles to group",
+			req: &api.AssignRolesRequest{
+				Entity: api.EntityGroup,
+				ID:     "external",
+				Type:   api.GroupTypeOIDC,
+				Roles:  []string{"rock-n-role", "sushi-role"},
+			},
+			wantMethod: http.MethodPost,
+			wantPath:   "/authz/groups/external/assign",
+			wantBody: rest.AssignRoleToGroupJSONBody{
+				GroupType: rest.GroupTypeOidc,
+				Roles:     []string{"rock-n-role", "sushi-role"},
+			},
+		},
+		{
+			name: "revoke roles from user",
+			req: &api.RevokeRolesRequest{
+				Entity: api.EntityUser,
+				ID:     "john-malkovich",
+				Type:   api.UserTypeDB,
+				Roles:  []string{"rock-n-role", "sushi-role"},
+			},
+			wantMethod: http.MethodPost,
+			wantPath:   "/authz/users/john-malkovich/revoke",
+			wantBody: rest.RevokeRoleFromUserJSONBody{
+				UserType: rest.UserTypeInputDb,
+				Roles:    []string{"rock-n-role", "sushi-role"},
+			},
+		},
+		{
+			name: "revoke roles from group",
+			req: &api.RevokeRolesRequest{
+				Entity: api.EntityGroup,
+				ID:     "external",
+				Type:   api.GroupTypeOIDC,
+				Roles:  []string{"rock-n-role", "sushi-role"},
+			},
+			wantMethod: http.MethodPost,
+			wantPath:   "/authz/groups/external/revoke",
+			wantBody: rest.RevokeRoleFromGroupJSONBody{
+				GroupType: rest.GroupTypeOidc,
+				Roles:     []string{"rock-n-role", "sushi-role"},
+			},
+		},
+		{
+			name:       "list groups",
+			req:        api.ListGroupsRequest,
+			wantMethod: http.MethodGet,
+			wantPath:   "/authz/groups/oidc",
+		},
+		{
+			name:       "create db user",
+			req:        api.CreateUserRequest("john-malkovich"),
+			wantMethod: http.MethodPost,
+			wantPath:   "/users/db/john-malkovich",
+		},
+		{
+			name:       "delete db user",
+			req:        api.DeleteUserRequest("john-malkovich"),
+			wantMethod: http.MethodDelete,
+			wantPath:   "/users/db/john-malkovich",
+		},
+		{
+			name:       "activate db user",
+			req:        api.ActivateUserRequest("john-malkovich"),
+			wantMethod: http.MethodPost,
+			wantPath:   "/users/db/john-malkovich/activate",
+		},
+		{
+			name: "deactivate db user (revoke api key)",
+			req: &api.DeactivateUserRequest{
+				ID:        "john-malkovich",
+				RevokeKey: true,
+			},
+			wantMethod: http.MethodPost,
+			wantPath:   "/users/db/john-malkovich/deactivate",
+			wantBody: rest.DeactivateUserJSONRequestBody{
+				RevokeKey: true,
+			},
+		},
+		{
+			name:       "rotate db user api key",
+			req:        api.RotateUserKeyRequest("john-malkovich"),
+			wantMethod: http.MethodPost,
+			wantPath:   "/users/db/john-malkovich/rotate-key",
+		},
+		{
+			name: "get db user info",
+			req: &api.GetUserInfoRequest{
+				ID:                "john-malkovich",
+				IncludeLastUsedAt: true,
+			},
+			wantMethod: http.MethodGet,
+			wantPath:   "/users/db/john-malkovich",
+			wantQuery:  url.Values{"includeLastUsedTime": {"true"}},
+		},
+		{
+			name: "list db users",
+			req: &api.ListUsersRequest{
+				IncludeLastUsedAt: true,
+			},
+			wantMethod: http.MethodGet,
+			wantPath:   "/users/db",
+			wantQuery:  url.Values{"includeLastUsedTime": {"true"}},
+		},
 	}) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Implements(t, (*transports.Endpoint)(nil), tt.req)

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -1719,16 +1719,16 @@ func TestRESTResponses(t *testing.T) {
 			want: testkit.Ptr[api.HasPermissionResponse](true),
 		},
 		{
-			name: "user assignment",
-			body: map[string]any{
+			name: "user assignments",
+			body: []map[string]any{{
 				"userId":   "john_doe",
-				"userType": "db_env",
-			},
-			dest: new(api.UserAssignment),
-			want: &api.UserAssignment{
+				"userType": rest.DBUserInfoDbUserTypeDbEnvUser,
+			}},
+			dest: new([]api.UserInfo),
+			want: &[]api.UserInfo{{
 				ID:   "john_doe",
-				Type: "db_env",
-			},
+				Type: api.UserTypeDBEnv,
+			}},
 		},
 		{
 			name: "group assignment",
@@ -1736,8 +1736,8 @@ func TestRESTResponses(t *testing.T) {
 				"groupId":   "external",
 				"groupType": "oidc",
 			},
-			dest: new(api.GroupAssignment),
-			want: &api.GroupAssignment{
+			dest: new(api.GroupInfo),
+			want: &api.GroupInfo{
 				ID:   "external",
 				Type: "oidc",
 			},

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/rest"
+	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
 	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
 )
 
@@ -204,7 +205,7 @@ var _ transports.Endpoint = (*AddPermissionsRequest)(nil)
 
 func (*AddPermissionsRequest) Method() string { return http.MethodPost }
 func (r *AddPermissionsRequest) Path() string {
-	return "/authz/roles/" + url.PathEscape(r.RoleID) + "/add-permissions"
+	return transports.Path("/authz/roles/%s/add-permissions", r.RoleID)
 }
 func (r *AddPermissionsRequest) Body() any { return &r }
 
@@ -691,4 +692,211 @@ func find[T any](lookup map[string]any, action rest.PermissionAction, data json.
 		lookup[key] = addr
 	}
 	return addr.(*T)
+}
+
+// GetOwnUserInfoRequest fetches user info for the current user.
+var GetOwnUserInfoRequest = transports.StaticEndpoint(http.MethodGet, "/users/own-info")
+
+const (
+	EntityUser  = "users"
+	EntityGroup = "groups"
+
+	UserTypeDB    = "db"
+	UserTypeDBEnv = "db_env"
+	UserTypeOIDC  = "oidc"
+
+	GroupTypeOIDC = "oidc"
+)
+
+// GetAssignedRolesRequest fetches roles assigned to a user or a group.
+// Use with [Role].
+type GetAssignedRolesRequest struct {
+	transports.BaseEndpoint
+
+	Entity string // [EntityUser] or [EntityGroup]
+	ID     string // User or Group ID
+	Type   string // User or Group type
+
+	IncludePermissions bool // Include permissions associated with each role.
+}
+
+var _ transports.Endpoint = (*GetAssignedRolesRequest)(nil)
+
+func (*GetAssignedRolesRequest) Method() string { return http.MethodGet }
+func (r *GetAssignedRolesRequest) Path() string {
+	return transports.Path("/authz/"+r.Entity+"/%s/roles/"+r.Type, r.ID)
+}
+
+func (r *GetAssignedRolesRequest) Query() url.Values {
+	if !r.IncludePermissions {
+		return nil
+	}
+	return url.Values{"includePermissions": {"true"}}
+}
+
+type AssignRolesRequest struct {
+	transports.BaseEndpoint
+
+	Entity string   // [EntityUser] or [EntityGroup]
+	ID     string   // User or Group ID
+	Type   string   // User or Group type
+	Roles  []string // IDs of roles to assign
+}
+
+var (
+	_ transports.Endpoint = (*AssignRolesRequest)(nil)
+	_ json.Marshaler      = (*AssignRolesRequest)(nil)
+)
+
+func (*AssignRolesRequest) Method() string { return http.MethodPost }
+func (r *AssignRolesRequest) Path() string {
+	return transports.Path("/authz/"+r.Entity+"/%s/assign", r.ID)
+}
+
+func (r *AssignRolesRequest) Body() any { return r }
+
+func (r *AssignRolesRequest) MarshalJSON() ([]byte, error) {
+	switch r.Entity {
+	case EntityUser:
+		return json.Marshal(rest.AssignRoleToUserJSONBody{
+			UserType: rest.UserTypeInput(r.Type),
+			Roles:    r.Roles,
+		})
+	case EntityGroup:
+		return json.Marshal(rest.AssignRoleToGroupJSONBody{
+			GroupType: rest.GroupType(r.Type),
+			Roles:     r.Roles,
+		})
+	default:
+		dev.Unreachable()
+	}
+	return nil, nil
+}
+
+type RevokeRolesRequest struct {
+	transports.BaseEndpoint
+
+	Entity string   // [EntityUser] or [EntityGroup]
+	ID     string   // User or Group ID
+	Type   string   // User or Group type
+	Roles  []string // IDs of roles to assign
+}
+
+var (
+	_ transports.Endpoint = (*RevokeRolesRequest)(nil)
+	_ json.Marshaler      = (*RevokeRolesRequest)(nil)
+)
+
+func (*RevokeRolesRequest) Method() string { return http.MethodPost }
+func (r *RevokeRolesRequest) Path() string {
+	return transports.Path("/authz/"+r.Entity+"/%s/revoke", r.ID)
+}
+
+func (r *RevokeRolesRequest) Body() any { return r }
+
+func (r *RevokeRolesRequest) MarshalJSON() ([]byte, error) {
+	switch r.Entity {
+	case EntityUser:
+		return json.Marshal(rest.AssignRoleToUserJSONBody{
+			UserType: rest.UserTypeInput(r.Type),
+			Roles:    r.Roles,
+		})
+	case EntityGroup:
+		return json.Marshal(rest.AssignRoleToGroupJSONBody{
+			GroupType: rest.GroupType(r.Type),
+			Roles:     r.Roles,
+		})
+	default:
+		dev.Unreachable()
+	}
+	return nil, nil
+}
+
+// ListGroupsRequest fetches IDs of the all known OIDC groups.
+var ListGroupsRequest = transports.StaticEndpoint(http.MethodGet, "/authz/groups/oidc")
+
+// ============================================================================
+// TODO(dyma): I wonder how many of the following requests will eventually
+// include Namespace in the body. Probably deleting a namespaced user will
+// need that. So they will likely not stay IdentityEndpoints for long.
+// We can leave them like as is for alpha.3, or until namespaces stabilize,
+// that's just something to keep in mind.
+// ============================================================================
+
+// CreateUserRequest creates a new user with type [UserTypeDB].
+// Use with [CreateUserResponse].
+var CreateUserRequest = transports.IdentityEndpoint[string](http.MethodPost, "/users/db/%s")
+
+type CreateUserResponse struct {
+	APIKey string `json:"apiKey"`
+}
+
+// DeleteUserRequest deletes a [UserTypeDB] user.
+var DeleteUserRequest = transports.IdentityEndpoint[string](http.MethodDelete, "/users/db/%s")
+
+// ActivateUserRequest activates a [UserTypeDB] user.
+var ActivateUserRequest = transports.IdentityEndpoint[string](http.MethodPost, "/users/db/%s/activate")
+
+// DeactivateUserRequest deactivates a [UserTypeDB] user.
+type DeactivateUserRequest struct {
+	transports.BaseEndpoint
+
+	ID        string
+	RevokeKey bool
+}
+
+var _ transports.Endpoint = (*DeactivateUserRequest)(nil)
+
+func (*DeactivateUserRequest) Method() string { return http.MethodPost }
+func (r *DeactivateUserRequest) Path() string {
+	return transports.Path("/users/db/%s/deactivate", r.ID)
+}
+func (r *DeactivateUserRequest) Body() any { return r }
+
+func (r *DeactivateUserRequest) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rest.DeactivateUserJSONRequestBody{
+		RevokeKey: r.RevokeKey,
+	})
+}
+
+// RotateUserKeyRequest generates a new API key for a [UserTypeDB] user.
+// Use with [RotateUserKeyResponse].
+var RotateUserKeyRequest = transports.IdentityEndpoint[string](http.MethodPost, "/users/db/%s/rotate-key")
+
+type RotateUserKeyResponse CreateUserResponse
+
+// GetUserInfoRequest fetches user info for a [UserTypeDB] user.
+type GetUserInfoRequest struct {
+	transports.BaseEndpoint
+
+	ID                string
+	IncludeLastUsedAt bool
+}
+
+var _ transports.Endpoint = (*DeactivateUserRequest)(nil)
+
+func (*GetUserInfoRequest) Method() string { return http.MethodGet }
+func (r *GetUserInfoRequest) Path() string { return transports.Path("/users/db/%s", r.ID) }
+func (r *GetUserInfoRequest) Query() url.Values {
+	if !r.IncludeLastUsedAt {
+		return nil
+	}
+	return url.Values{"includeLastUsedTime": {"true"}}
+}
+
+// ListUsersRequest fetches user info for all [UserTypeDB] users.
+type ListUsersRequest struct {
+	transports.BaseEndpoint
+	IncludeLastUsedAt bool
+}
+
+var _ transports.Endpoint = (*DeactivateUserRequest)(nil)
+
+func (*ListUsersRequest) Method() string { return http.MethodGet }
+func (r *ListUsersRequest) Path() string { return "/users/db" }
+func (r *ListUsersRequest) Query() url.Values {
+	if !r.IncludeLastUsedAt {
+		return nil
+	}
+	return url.Values{"includeLastUsedTime": {"true"}}
 }

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -187,15 +187,15 @@ type GroupInfo struct {
 }
 
 const (
-	PermissionActionAdd    = "add"
-	PermissionActionRemove = "remove"
+	PermissionVerbAdd    = "add"
+	PermissionVerbRemove = "remove"
 )
 
 // ManagePermissionsRequest adds permissions to a role.
 type ManagePermissionsRequest struct {
 	transports.BaseEndpoint
 	RoleID      string      `json:"-"`
-	Action      string      `json:"-"`
+	Verb        string      `json:"-"` // [PermissionVerbAdd] or [PermissionVerbRemove]
 	Permissions Permissions `json:"permissions"`
 }
 
@@ -203,7 +203,7 @@ var _ transports.Endpoint = (*ManagePermissionsRequest)(nil)
 
 func (*ManagePermissionsRequest) Method() string { return http.MethodPost }
 func (r *ManagePermissionsRequest) Path() string {
-	return transports.Path("/authz/roles/%s/%s-permissions", r.RoleID, r.Action)
+	return transports.Path("/authz/roles/%s/%s-permissions", r.RoleID, r.Verb)
 }
 func (r *ManagePermissionsRequest) Body() any { return r }
 
@@ -747,8 +747,8 @@ func (r *GetAssignedRolesRequest) Query() url.Values {
 }
 
 const (
-	RoleActionAssign = "assign"
-	RoleActionRevoke = "revoke"
+	RoleVerbAssign = "assign"
+	RoleVerbRevoke = "revoke"
 )
 
 // ManageRolesRequest assigns or revokes roles from an RBAC entity.
@@ -757,7 +757,7 @@ type ManageRolesRequest struct {
 
 	Entity RBACEntity // [UserID] or [GroupID]
 	Kind   string     // [RBACKindDB] or [RBACKindOIDC]
-	Action string     // [RBACActionAssign] or [RBACActionRevoke]
+	Verb   string     // [RoleVerbAssign] or [RoleVerbRevoke]
 	Roles  []string   // IDs of roles to assign
 }
 
@@ -767,7 +767,7 @@ var (
 )
 
 func (*ManageRolesRequest) Method() string { return http.MethodPost }
-func (r *ManageRolesRequest) Path() string { return r.Entity.Path() + "/" + r.Action }
+func (r *ManageRolesRequest) Path() string { return r.Entity.Path() + "/" + r.Verb }
 func (r *ManageRolesRequest) Body() any    { return r }
 func (r *ManageRolesRequest) MarshalJSON() ([]byte, error) {
 	// [rest.AssignRoleToUserJSONBody], [rest.AssignRoleToGroupJSONBody],

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -725,7 +725,7 @@ const (
 )
 
 // GetAssignedRolesRequest fetches roles assigned to a user or a group.
-// Use with [Role].
+// Use with [Role] slice.
 type GetAssignedRolesRequest struct {
 	transports.BaseEndpoint
 

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/rest"
-	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
 	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
 )
 
@@ -722,10 +721,21 @@ func (r *GetOwnUserInfoResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-const (
-	EntityUser  = "users"
-	EntityGroup = "groups"
+type (
+	RBACEntity interface{ Path() string }
+	UserID     string
+	GroupID    string
+)
 
+var (
+	_ RBACEntity = (*UserID)(nil)
+	_ RBACEntity = (*GroupID)(nil)
+)
+
+func (id UserID) Path() string  { return transports.Path("/authz/users/%s", id) }
+func (id GroupID) Path() string { return transports.Path("/authz/groups/%s", id) }
+
+const (
 	RBACKindDB   = "db"
 	RBACKindOIDC = "oidc"
 )
@@ -735,9 +745,8 @@ const (
 type GetAssignedRolesRequest struct {
 	transports.BaseEndpoint
 
-	Entity string // [EntityUser] or [EntityGroup]
-	ID     string // User or Group ID
-	Kind   string // User or Group kind
+	Entity RBACEntity // [UserID] or [GroupID]
+	Kind   string     // [RBACKindDB] or [RBACKindOIDC]
 
 	IncludePermissions bool // Include permissions associated with each role.
 }
@@ -745,10 +754,7 @@ type GetAssignedRolesRequest struct {
 var _ transports.Endpoint = (*GetAssignedRolesRequest)(nil)
 
 func (*GetAssignedRolesRequest) Method() string { return http.MethodGet }
-func (r *GetAssignedRolesRequest) Path() string {
-	return transports.Path("/authz/"+r.Entity+"/%s/roles/"+r.Kind, r.ID)
-}
-
+func (r *GetAssignedRolesRequest) Path() string { return r.Entity.Path() + "/roles/" + r.Kind }
 func (r *GetAssignedRolesRequest) Query() url.Values {
 	if !r.IncludePermissions {
 		return nil
@@ -756,82 +762,54 @@ func (r *GetAssignedRolesRequest) Query() url.Values {
 	return url.Values{"includePermissions": {"true"}}
 }
 
-type AssignRolesRequest struct {
+const (
+	RBACActionAssign = "assign"
+	RBACActionRevoke = "revoke"
+)
+
+// ManageRolesRequest assigns or revokes roles from an RBAC entity.
+type ManageRolesRequest struct {
 	transports.BaseEndpoint
 
-	Entity string   // [EntityUser] or [EntityGroup]
-	ID     string   // User or Group ID
-	Kind   string   // User or Group kind
-	Roles  []string // IDs of roles to assign
+	Entity RBACEntity // [UserID] or [GroupID]
+	Kind   string     // [RBACKindDB] or [RBACKindOIDC]
+	Action string     // [RBACActionAssign] or [RBACActionRevoke]
+	Roles  []string   // IDs of roles to assign
 }
 
 var (
-	_ transports.Endpoint = (*AssignRolesRequest)(nil)
-	_ json.Marshaler      = (*AssignRolesRequest)(nil)
+	_ transports.Endpoint = (*ManageRolesRequest)(nil)
+	_ json.Marshaler      = (*ManageRolesRequest)(nil)
 )
 
-func (*AssignRolesRequest) Method() string { return http.MethodPost }
-func (r *AssignRolesRequest) Path() string {
-	return transports.Path("/authz/"+r.Entity+"/%s/assign", r.ID)
-}
-
-func (r *AssignRolesRequest) Body() any { return r }
-
-func (r *AssignRolesRequest) MarshalJSON() ([]byte, error) {
-	switch r.Entity {
-	case EntityUser:
-		return json.Marshal(rest.AssignRoleToUserJSONBody{
-			UserType: rest.UserTypeInput(r.Kind),
-			Roles:    r.Roles,
-		})
-	case EntityGroup:
-		return json.Marshal(rest.AssignRoleToGroupJSONBody{
-			GroupType: rest.GroupType(r.Kind),
-			Roles:     r.Roles,
-		})
-	default:
-		dev.Unreachable()
+func (*ManageRolesRequest) Method() string { return http.MethodPost }
+func (r *ManageRolesRequest) Path() string { return r.Entity.Path() + "/" + r.Action }
+func (r *ManageRolesRequest) Body() any    { return r }
+func (r *ManageRolesRequest) MarshalJSON() ([]byte, error) {
+	// [rest.AssignRoleToUserJSONBody], [rest.AssignRoleToGroupJSONBody],
+	// [rest.RevokeRoleFromUserJSONBody], and [rest.RevokeRoleFromGroupJSONBody]
+	// are practically identical. The only difference is the userType vs groupType
+	// key to identify the RBAC entity. This simple struct allows us to unify
+	// request body marshaling with minimal branching.
+	//
+	// To avoid drift, endpoint_test.go uses models from rest package
+	// to validate the generated JSON payloads.
+	// in endpoint_test.go
+	var req struct {
+		UserKind  string   `json:"userType,omitempty"`
+		GroupKind string   `json:"groupType,omitempty"`
+		Roles     []string `json:"roles"`
 	}
-	return nil, nil
-}
 
-type RevokeRolesRequest struct {
-	transports.BaseEndpoint
-
-	Entity string   // [EntityUser] or [EntityGroup]
-	ID     string   // User or Group ID
-	Kind   string   // User or Group kind
-	Roles  []string // IDs of roles to assign
-}
-
-var (
-	_ transports.Endpoint = (*RevokeRolesRequest)(nil)
-	_ json.Marshaler      = (*RevokeRolesRequest)(nil)
-)
-
-func (*RevokeRolesRequest) Method() string { return http.MethodPost }
-func (r *RevokeRolesRequest) Path() string {
-	return transports.Path("/authz/"+r.Entity+"/%s/revoke", r.ID)
-}
-
-func (r *RevokeRolesRequest) Body() any { return r }
-
-func (r *RevokeRolesRequest) MarshalJSON() ([]byte, error) {
-	switch r.Entity {
-	case EntityUser:
-		return json.Marshal(rest.AssignRoleToUserJSONBody{
-			UserType: rest.UserTypeInput(r.Kind),
-			Roles:    r.Roles,
-		})
-	case EntityGroup:
-		return json.Marshal(rest.AssignRoleToGroupJSONBody{
-			GroupType: rest.GroupType(r.Kind),
-			Roles:     r.Roles,
-		})
-	default:
-		dev.Unreachable()
+	req.Roles = r.Roles
+	switch r.Entity.(type) {
+	case UserID:
+		req.UserKind = r.Kind
+	case GroupID:
+		req.GroupKind = r.Kind
 	}
-	return nil, nil
+
+	return json.Marshal(&req)
 }
 
 // ListGroupsRequest fetches IDs of the all known OIDC groups.

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -695,17 +695,39 @@ func find[T any](lookup map[string]any, action rest.PermissionAction, data json.
 }
 
 // GetOwnUserInfoRequest fetches user info for the current user.
+// Use with [GetOwnUserInfoResponse].
 var GetOwnUserInfoRequest = transports.StaticEndpoint(http.MethodGet, "/users/own-info")
+
+type GetOwnUserInfoResponse struct {
+	ID     string
+	Roles  []Role
+	Groups []string
+}
+
+var _ json.Unmarshaler = (*GetOwnUserInfoResponse)(nil)
+
+func (r *GetOwnUserInfoResponse) UnmarshalJSON(data []byte) error {
+	var resp struct {
+		rest.UserOwnInfo
+		Roles []Role `json:"roles"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return err
+	}
+	*r = GetOwnUserInfoResponse{
+		ID:     resp.Username,
+		Roles:  resp.Roles,
+		Groups: resp.Groups,
+	}
+	return nil
+}
 
 const (
 	EntityUser  = "users"
 	EntityGroup = "groups"
 
-	UserTypeDB    = "db"
-	UserTypeDBEnv = "db_env"
-	UserTypeOIDC  = "oidc"
-
-	GroupTypeOIDC = "oidc"
+	RBACKindDB   = "db"
+	RBACKindOIDC = "oidc"
 )
 
 // GetAssignedRolesRequest fetches roles assigned to a user or a group.
@@ -715,7 +737,7 @@ type GetAssignedRolesRequest struct {
 
 	Entity string // [EntityUser] or [EntityGroup]
 	ID     string // User or Group ID
-	Type   string // User or Group type
+	Kind   string // User or Group kind
 
 	IncludePermissions bool // Include permissions associated with each role.
 }
@@ -724,7 +746,7 @@ var _ transports.Endpoint = (*GetAssignedRolesRequest)(nil)
 
 func (*GetAssignedRolesRequest) Method() string { return http.MethodGet }
 func (r *GetAssignedRolesRequest) Path() string {
-	return transports.Path("/authz/"+r.Entity+"/%s/roles/"+r.Type, r.ID)
+	return transports.Path("/authz/"+r.Entity+"/%s/roles/"+r.Kind, r.ID)
 }
 
 func (r *GetAssignedRolesRequest) Query() url.Values {
@@ -739,7 +761,7 @@ type AssignRolesRequest struct {
 
 	Entity string   // [EntityUser] or [EntityGroup]
 	ID     string   // User or Group ID
-	Type   string   // User or Group type
+	Kind   string   // User or Group kind
 	Roles  []string // IDs of roles to assign
 }
 
@@ -759,12 +781,12 @@ func (r *AssignRolesRequest) MarshalJSON() ([]byte, error) {
 	switch r.Entity {
 	case EntityUser:
 		return json.Marshal(rest.AssignRoleToUserJSONBody{
-			UserType: rest.UserTypeInput(r.Type),
+			UserType: rest.UserTypeInput(r.Kind),
 			Roles:    r.Roles,
 		})
 	case EntityGroup:
 		return json.Marshal(rest.AssignRoleToGroupJSONBody{
-			GroupType: rest.GroupType(r.Type),
+			GroupType: rest.GroupType(r.Kind),
 			Roles:     r.Roles,
 		})
 	default:
@@ -778,7 +800,7 @@ type RevokeRolesRequest struct {
 
 	Entity string   // [EntityUser] or [EntityGroup]
 	ID     string   // User or Group ID
-	Type   string   // User or Group type
+	Kind   string   // User or Group kind
 	Roles  []string // IDs of roles to assign
 }
 
@@ -798,12 +820,12 @@ func (r *RevokeRolesRequest) MarshalJSON() ([]byte, error) {
 	switch r.Entity {
 	case EntityUser:
 		return json.Marshal(rest.AssignRoleToUserJSONBody{
-			UserType: rest.UserTypeInput(r.Type),
+			UserType: rest.UserTypeInput(r.Kind),
 			Roles:    r.Roles,
 		})
 	case EntityGroup:
 		return json.Marshal(rest.AssignRoleToGroupJSONBody{
-			GroupType: rest.GroupType(r.Type),
+			GroupType: rest.GroupType(r.Kind),
 			Roles:     r.Roles,
 		})
 	default:
@@ -813,7 +835,10 @@ func (r *RevokeRolesRequest) MarshalJSON() ([]byte, error) {
 }
 
 // ListGroupsRequest fetches IDs of the all known OIDC groups.
+// Use with [ListGroupsResponse].
 var ListGroupsRequest = transports.StaticEndpoint(http.MethodGet, "/authz/groups/oidc")
+
+type ListGroupsResponse []string
 
 // ============================================================================
 // TODO(dyma): I wonder how many of the following requests will eventually
@@ -823,21 +848,32 @@ var ListGroupsRequest = transports.StaticEndpoint(http.MethodGet, "/authz/groups
 // that's just something to keep in mind.
 // ============================================================================
 
-// CreateUserRequest creates a new user with type [UserTypeDB].
+// CreateUserRequest creates a new user with type [RBACKindDB].
 // Use with [CreateUserResponse].
 var CreateUserRequest = transports.IdentityEndpoint[string](http.MethodPost, "/users/db/%s")
 
 type CreateUserResponse struct {
-	APIKey string `json:"apiKey"`
+	APIKey string
 }
 
-// DeleteUserRequest deletes a [UserTypeDB] user.
+var _ json.Unmarshaler = (*CreateUserResponse)(nil)
+
+func (r *CreateUserResponse) UnmarshalJSON(data []byte) error {
+	var resp rest.UserApiKey
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return err
+	}
+	*r = CreateUserResponse{APIKey: resp.Apikey}
+	return nil
+}
+
+// DeleteUserRequest deletes a [RBACKindDB] user.
 var DeleteUserRequest = transports.IdentityEndpoint[string](http.MethodDelete, "/users/db/%s")
 
-// ActivateUserRequest activates a [UserTypeDB] user.
+// ActivateUserRequest activates a [RBACKindDB] user.
 var ActivateUserRequest = transports.IdentityEndpoint[string](http.MethodPost, "/users/db/%s/activate")
 
-// DeactivateUserRequest deactivates a [UserTypeDB] user.
+// DeactivateUserRequest deactivates a [RBACKindDB] user.
 type DeactivateUserRequest struct {
 	transports.BaseEndpoint
 
@@ -859,13 +895,42 @@ func (r *DeactivateUserRequest) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// RotateUserKeyRequest generates a new API key for a [UserTypeDB] user.
+// RotateUserKeyRequest generates a new API key for a [RBACKindDB] user.
 // Use with [RotateUserKeyResponse].
 var RotateUserKeyRequest = transports.IdentityEndpoint[string](http.MethodPost, "/users/db/%s/rotate-key")
 
 type RotateUserKeyResponse CreateUserResponse
 
-// GetUserInfoRequest fetches user info for a [UserTypeDB] user.
+const (
+	UserTypeDB    = "db_user"
+	UserTypeDBEnv = "db_env"
+)
+
+type UserInfo struct {
+	ID     string
+	Type   string
+	Active bool
+	Roles  []string
+}
+
+var _ json.Unmarshaler = (*UserInfo)(nil)
+
+func (ui *UserInfo) UnmarshalJSON(data []byte) error {
+	var resp rest.DBUserInfo
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return err
+	}
+	*ui = UserInfo{
+		ID:     resp.UserId,
+		Type:   string(resp.DbUserType),
+		Active: resp.Active,
+		Roles:  resp.Roles,
+	}
+	return nil
+}
+
+// GetUserInfoRequest fetches user info for a [RBACKindDB] user.
+// Use with [UserInfo].
 type GetUserInfoRequest struct {
 	transports.BaseEndpoint
 
@@ -884,7 +949,8 @@ func (r *GetUserInfoRequest) Query() url.Values {
 	return url.Values{"includeLastUsedTime": {"true"}}
 }
 
-// ListUsersRequest fetches user info for all [UserTypeDB] users.
+// ListUsersRequest fetches user info for all [RBACKindDB] users.
+// Use with [UserInfo] slice.
 type ListUsersRequest struct {
 	transports.BaseEndpoint
 	IncludeLastUsedAt bool

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -173,25 +173,18 @@ var GetAssignedUsersRequest = transports.IdentityEndpoint[string](http.MethodGet
 type GetAssignedUsersResponse []string
 
 // GetUserAssignmentsRequest retrieves IDs and type of users this role is assigned to.
-// Use with [UserAssignment].
+// Use with [UserInfo] slice. Note that only [UserInfo.ID] and [UserInfo.Type] fields
+// will be populated.
 var GetUserAssignmentsRequest = transports.IdentityEndpoint[string](http.MethodGet, "/authz/roles/%s/user-assignments")
 
 // GetUserAssignmentsRequest retrieves IDs and type of groups this role is assigned to.
-// Use with [GroupAssignment].
+// Use with [GroupInfo] slice.
 var GetGroupAssignmentsRequest = transports.IdentityEndpoint[string](http.MethodGet, "/authz/roles/%s/group-assignments")
 
-// oapi-codegen does not generate inline response types.
-// https://github.com/oapi-codegen/oapi-codegen/issues/513
-type (
-	UserAssignment struct {
-		ID   string `json:"userId"`
-		Type string `json:"userType"`
-	}
-	GroupAssignment struct {
-		ID   string `json:"groupId"`
-		Type string `json:"groupType"`
-	}
-)
+type GroupInfo struct {
+	ID   string `json:"groupId"`
+	Type string `json:"groupType"`
+}
 
 // AddPermissionsRequest adds permissions to a role.
 type AddPermissionsRequest struct {
@@ -880,27 +873,39 @@ var RotateUserKeyRequest = transports.IdentityEndpoint[string](http.MethodPost, 
 type RotateUserKeyResponse CreateUserResponse
 
 const (
-	UserTypeDB    = "db_user"
-	UserTypeDBEnv = "db_env"
+	UserTypeDB    = "db_user"     // User created via REST API.
+	UserTypeDBEnv = "db_env_user" // User defined in the server environment.
+	UserTypeOIDC  = "oidc"        // User managed by an OIDC provider.
+
+	GroupTypeOIDC = "oidc" // Group managed by an OIDC provider.
 )
 
 type UserInfo struct {
-	ID     string
-	Type   string
-	Active bool
-	Roles  []string
+	ID     string   // User ID.
+	Type   string   // [UserTypeDB] or [UserTypeDBEnv]
+	Active bool     // Is the user activated?
+	Roles  []string // Roles assigned to this user.
 }
 
 var _ json.Unmarshaler = (*UserInfo)(nil)
 
 func (ui *UserInfo) UnmarshalJSON(data []byte) error {
-	var resp rest.DBUserInfo
+	var resp struct {
+		rest.DBUserInfo
+		UserType string `json:"userType"`
+	}
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return err
 	}
+
+	userType := resp.UserType
+	if userType == "" {
+		userType = string(resp.DbUserType)
+	}
+
 	*ui = UserInfo{
 		ID:     resp.UserId,
-		Type:   string(resp.DbUserType),
+		Type:   userType,
 		Active: resp.Active,
 		Roles:  resp.Roles,
 	}
@@ -931,6 +936,7 @@ func (r *GetUserInfoRequest) Query() url.Values {
 // Use with [UserInfo] slice.
 type ListUsersRequest struct {
 	transports.BaseEndpoint
+
 	IncludeLastUsedAt bool
 }
 

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -836,6 +836,8 @@ var DeleteUserRequest = transports.IdentityEndpoint[string](http.MethodDelete, "
 var ActivateUserRequest = transports.IdentityEndpoint[string](http.MethodPost, "/users/db/%s/activate")
 
 // DeactivateUserRequest deactivates a [RBACKindDB] user.
+// TODO(dyma): the response needs to implement [transport.StatucAccepter] to handle
+// "already deactivated" case.
 type DeactivateUserRequest struct {
 	transports.BaseEndpoint
 
@@ -857,11 +859,11 @@ func (r *DeactivateUserRequest) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// RotateUserKeyRequest generates a new API key for a [RBACKindDB] user.
-// Use with [RotateUserKeyResponse].
-var RotateUserKeyRequest = transports.IdentityEndpoint[string](http.MethodPost, "/users/db/%s/rotate-key")
+// RotateAPIKeyRequest generates a new API key for a [RBACKindDB] user.
+// Use with [RotateAPIKeyResponse].
+var RotateAPIKeyRequest = transports.IdentityEndpoint[string](http.MethodPost, "/users/db/%s/rotate-key")
 
-type RotateUserKeyResponse CreateUserResponse
+type RotateAPIKeyResponse CreateUserResponse
 
 const (
 	UserTypeDB    = "db_user"     // User created via REST API.

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -186,35 +186,26 @@ type GroupInfo struct {
 	Type string `json:"groupType"`
 }
 
-// AddPermissionsRequest adds permissions to a role.
-type AddPermissionsRequest struct {
+const (
+	PermissionActionAdd    = "add"
+	PermissionActionRemove = "remove"
+)
+
+// ManagePermissionsRequest adds permissions to a role.
+type ManagePermissionsRequest struct {
 	transports.BaseEndpoint
 	RoleID      string      `json:"-"`
+	Action      string      `json:"-"`
 	Permissions Permissions `json:"permissions"`
 }
 
-var _ transports.Endpoint = (*AddPermissionsRequest)(nil)
+var _ transports.Endpoint = (*ManagePermissionsRequest)(nil)
 
-func (*AddPermissionsRequest) Method() string { return http.MethodPost }
-func (r *AddPermissionsRequest) Path() string {
-	return transports.Path("/authz/roles/%s/add-permissions", r.RoleID)
+func (*ManagePermissionsRequest) Method() string { return http.MethodPost }
+func (r *ManagePermissionsRequest) Path() string {
+	return transports.Path("/authz/roles/%s/%s-permissions", r.RoleID, r.Action)
 }
-func (r *AddPermissionsRequest) Body() any { return &r }
-
-// RemovePermissionsRequest removes permissions from a role.
-type RemovePermissionsRequest struct {
-	transports.BaseEndpoint
-	RoleID      string      `json:"-"`
-	Permissions Permissions `json:"permissions"`
-}
-
-var _ transports.Endpoint = (*RemovePermissionsRequest)(nil)
-
-func (*RemovePermissionsRequest) Method() string { return http.MethodPost }
-func (r *RemovePermissionsRequest) Path() string {
-	return "/authz/roles/" + url.PathEscape(r.RoleID) + "/remove-permissions"
-}
-func (r *RemovePermissionsRequest) Body() any { return &r }
+func (r *ManagePermissionsRequest) Body() any { return r }
 
 // HasPermissionRequest checks if a role contains a permission.
 type HasPermissionRequest struct {
@@ -756,8 +747,8 @@ func (r *GetAssignedRolesRequest) Query() url.Values {
 }
 
 const (
-	RBACActionAssign = "assign"
-	RBACActionRevoke = "revoke"
+	RoleActionAssign = "assign"
+	RoleActionRevoke = "revoke"
 )
 
 // ManageRolesRequest assigns or revokes roles from an RBAC entity.

--- a/internal/api/transport/token_refresh_test.go
+++ b/internal/api/transport/token_refresh_test.go
@@ -43,6 +43,8 @@ func TestTokenKeepalive(t *testing.T) {
 
 		src.used = 0
 		time.Sleep(5 * time.Millisecond)
+
+		// FIXME(dyma): this can flake
 		require.Zero(t, src.used, "no src.Token() after context is canceled")
 	})
 }

--- a/internal/transports/rest.go
+++ b/internal/transports/rest.go
@@ -240,12 +240,16 @@ type identityEndpoint[I any] struct {
 var _ Endpoint = (*identityEndpoint[any])(nil)
 
 func (r *identityEndpoint[I]) Method() string { return r.method }
-func (r *identityEndpoint[I]) Path() string {
-	id := any(r.id)
-	if s, ok := id.(string); ok {
-		id = url.PathEscape(s)
+func (r *identityEndpoint[I]) Path() string   { return Path(r.pathFmt, r.id) }
+
+// Path URL-encodes all string elements of a and formats the output to pathFmt.
+func Path(pathFmt string, a ...any) string {
+	for i := range a {
+		if s, ok := a[i].(string); ok {
+			a[i] = url.PathEscape(s)
+		}
 	}
-	return fmt.Sprintf(r.pathFmt, id)
+	return fmt.Sprintf(pathFmt, a...)
 }
 
 // StaticEndpoint creates a new static endpoint with a method and a path.

--- a/internal/transports/rest_test.go
+++ b/internal/transports/rest_test.go
@@ -343,3 +343,9 @@ func TestStaticEndpoint(t *testing.T) {
 	assert.Nil(t, static.Query(), "query")
 	assert.Nil(t, static.Body(), "body")
 }
+
+func TestPath(t *testing.T) {
+	want := "/path/url%20encode%20me"
+	got := transports.Path("/path/%s", "url encode me")
+	assert.Equal(t, got, want)
+}

--- a/query/over_all_test.go
+++ b/query/over_all_test.go
@@ -37,7 +37,7 @@ func TestOverAll(t *testing.T) {
 				After:     testkit.UUID,
 				Filter: filter.Not{
 					P: &filter.Cond{
-						Target:   []string{"album"},
+						Target:   "album",
 						Operator: filter.Like,
 						Value:    ".*Blood",
 					},

--- a/rbac/groups.go
+++ b/rbac/groups.go
@@ -1,0 +1,18 @@
+package rbac
+
+import (
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
+)
+
+type GroupsClient struct {
+	*kindClient[api.GroupID]
+}
+
+func NewGroupsClient(t internal.Transport) *GroupsClient {
+	dev.AssertNotNil(t, "transport")
+	return &GroupsClient{
+		kindClient: newKindClient[api.GroupID](t, api.RBACKindOIDC),
+	}
+}

--- a/rbac/groups_test.go
+++ b/rbac/groups_test.go
@@ -82,7 +82,7 @@ func TestGroupsClient_AssignRoles(t *testing.T) {
 				Request: &api.ManageRolesRequest{
 					Kind:   api.RBACKindOIDC,
 					Entity: api.GroupID("external"),
-					Action: api.RoleActionAssign,
+					Verb:   api.RoleVerbAssign,
 					Roles:  []string{"rock-n-role", "sushi-role"},
 				},
 			}},
@@ -123,7 +123,7 @@ func TestGroupsClient_RevokeRoles(t *testing.T) {
 				Request: &api.ManageRolesRequest{
 					Kind:   api.RBACKindOIDC,
 					Entity: api.GroupID("external"),
-					Action: api.RoleActionRevoke,
+					Verb:   api.RoleVerbRevoke,
 					Roles:  []string{"rock-n-role", "sushi-role"},
 				},
 			}},

--- a/rbac/groups_test.go
+++ b/rbac/groups_test.go
@@ -1,0 +1,148 @@
+package rbac_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+	"github.com/weaviate/weaviate-go-client/v6/rbac"
+)
+
+func TestNewGroupsClient(t *testing.T) {
+	require.Panics(t, func() {
+		rbac.NewGroupsClient(nil)
+	}, "nil transport")
+}
+
+func TestGroupsClient_AssignedRoles(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options rbac.AssignedRolesOptions
+		stubs   []testkit.Stub[api.GetAssignedRolesRequest, []api.Role]
+		want    []rbac.Role
+		err     testkit.Error
+	}{
+		{
+			name: "ok",
+			options: rbac.AssignedRolesOptions{
+				ID:                 "external",
+				IncludePermissions: false,
+			},
+			stubs: []testkit.Stub[api.GetAssignedRolesRequest, []api.Role]{{
+				Request: &api.GetAssignedRolesRequest{
+					Kind:               api.RBACKindOIDC,
+					Entity:             api.GroupID("external"),
+					IncludePermissions: false,
+				},
+				Response: []api.Role{
+					{ID: "rock-n-role"},
+					{ID: "sushi-role"},
+				},
+			}},
+			want: []rbac.Role{
+				{ID: "rock-n-role"},
+				{ID: "sushi-role"},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.GetAssignedRolesRequest, []api.Role]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewGroupsClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.AssignedRoles(t.Context(), tt.options)
+			tt.err.Require(t, err, "request error")
+			require.Equal(t, tt.want, got, "bad result")
+		})
+	}
+}
+
+func TestGroupsClient_AssignRoles(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options rbac.AssignRolesOptions
+		stubs   []testkit.Stub[api.ManageRolesRequest, any]
+		err     testkit.Error
+	}{
+		{
+			name: "ok",
+			options: rbac.AssignRolesOptions{
+				ID:    "external",
+				Roles: []string{"rock-n-role", "sushi-role"},
+			},
+			stubs: []testkit.Stub[api.ManageRolesRequest, any]{{
+				Request: &api.ManageRolesRequest{
+					Kind:   api.RBACKindOIDC,
+					Entity: api.GroupID("external"),
+					Action: api.RoleActionAssign,
+					Roles:  []string{"rock-n-role", "sushi-role"},
+				},
+			}},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.ManageRolesRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewGroupsClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			err := c.AssignRoles(t.Context(), tt.options)
+			tt.err.Require(t, err, "request error")
+		})
+	}
+}
+
+func TestGroupsClient_RevokeRoles(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options rbac.RevokeRolesOptions
+		stubs   []testkit.Stub[api.ManageRolesRequest, any]
+		err     testkit.Error
+	}{
+		{
+			name: "ok",
+			options: rbac.RevokeRolesOptions{
+				ID:    "external",
+				Roles: []string{"rock-n-role", "sushi-role"},
+			},
+			stubs: []testkit.Stub[api.ManageRolesRequest, any]{{
+				Request: &api.ManageRolesRequest{
+					Kind:   api.RBACKindOIDC,
+					Entity: api.GroupID("external"),
+					Action: api.RoleActionRevoke,
+					Roles:  []string{"rock-n-role", "sushi-role"},
+				},
+			}},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.ManageRolesRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewGroupsClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			err := c.RevokeRoles(t.Context(), tt.options)
+			tt.err.Require(t, err, "request error")
+		})
+	}
+}

--- a/rbac/roles.go
+++ b/rbac/roles.go
@@ -3,6 +3,7 @@ package rbac
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
@@ -106,7 +107,8 @@ func (c *RolesClient) Get(ctx context.Context, roleID string) (*Role, error) {
 	if err := c.transport.Do(ctx, api.GetRoleRequest(roleID), &resp); err != nil {
 		return nil, fmt.Errorf("get role: %w", err)
 	}
-	return unmarshalRole(&resp), nil
+	role := unmarshalRole(&resp)
+	return &role, nil
 }
 
 // List fetches all roles defined in the cluster.
@@ -115,9 +117,9 @@ func (c *RolesClient) List(ctx context.Context) ([]Role, error) {
 	if err := c.transport.Do(ctx, api.ListRolesRequest, &resp); err != nil {
 		return nil, fmt.Errorf("list role: %w", err)
 	}
-	var roles []Role
+	roles := slices.Grow([]Role(nil), len(resp))
 	for i := range resp {
-		roles = append(roles, *unmarshalRole(&resp[i]))
+		roles = append(roles, unmarshalRole(&resp[i]))
 	}
 	return roles, nil
 }
@@ -286,7 +288,7 @@ func marshalPermissions(ps *Permissions) api.Permissions {
 	return out
 }
 
-func unmarshalRole(r *api.Role) *Role {
+func unmarshalRole(r *api.Role) Role {
 	role := Role{ID: r.ID}
 	for _, p := range r.Aliases {
 		role.Aliases = append(role.Aliases, AliasPermission(p))
@@ -333,7 +335,7 @@ func unmarshalRole(r *api.Role) *Role {
 	for _, p := range r.Users {
 		role.Users = append(role.Users, UserPermission(p))
 	}
-	return &role
+	return role
 }
 
 // marshalHasPermission returns [api.HasPermissionRequest] with exacly 1 permission

--- a/rbac/roles.go
+++ b/rbac/roles.go
@@ -136,8 +136,9 @@ type AddPermissions struct {
 }
 
 func (rc *RolesClient) AddPermissions(ctx context.Context, options AddPermissions) error {
-	req := &api.AddPermissionsRequest{
+	req := &api.ManagePermissionsRequest{
 		RoleID:      options.RoleID,
+		Action:      api.PermissionActionAdd,
 		Permissions: marshalPermissions(&options.Permissions),
 	}
 	if err := rc.transport.Do(ctx, req, nil); err != nil {
@@ -152,8 +153,9 @@ type RemovePermissions struct {
 }
 
 func (rc *RolesClient) RemovePermissions(ctx context.Context, options RemovePermissions) error {
-	req := &api.RemovePermissionsRequest{
+	req := &api.ManagePermissionsRequest{
 		RoleID:      options.RoleID,
+		Action:      api.PermissionActionRemove,
 		Permissions: marshalPermissions(&options.Permissions),
 	}
 	if err := rc.transport.Do(ctx, req, nil); err != nil {

--- a/rbac/roles.go
+++ b/rbac/roles.go
@@ -78,41 +78,41 @@ const (
 	RoleScopeMatch = RoleScope(api.RoleScopeMatch)
 )
 
-func (rc *RolesClient) Create(ctx context.Context, r Role) error {
+func (c *RolesClient) Create(ctx context.Context, r Role) error {
 	req := &api.CreateRoleRequest{
 		Role: api.Role{
 			ID:          r.ID,
 			Permissions: marshalPermissions(&r.Permissions),
 		},
 	}
-	if err := rc.transport.Do(ctx, req, nil); err != nil {
+	if err := c.transport.Do(ctx, req, nil); err != nil {
 		return fmt.Errorf("create role: %w", err)
 	}
 	return nil
 }
 
 // Exists returns true and nil error if role with the given roleID exists.
-func (rc *RolesClient) Exists(ctx context.Context, roleID string) (bool, error) {
+func (c *RolesClient) Exists(ctx context.Context, roleID string) (bool, error) {
 	var resp api.ResourceExistsResponse
-	if err := rc.transport.Do(ctx, api.GetRoleRequest(roleID), &resp); err != nil {
+	if err := c.transport.Do(ctx, api.GetRoleRequest(roleID), &resp); err != nil {
 		return false, fmt.Errorf("check role exists: %w", err)
 	}
 	return resp.Bool(), nil
 }
 
 // Get fetches a role with the given roleID.
-func (rc *RolesClient) Get(ctx context.Context, roleID string) (*Role, error) {
+func (c *RolesClient) Get(ctx context.Context, roleID string) (*Role, error) {
 	var resp api.Role
-	if err := rc.transport.Do(ctx, api.GetRoleRequest(roleID), &resp); err != nil {
+	if err := c.transport.Do(ctx, api.GetRoleRequest(roleID), &resp); err != nil {
 		return nil, fmt.Errorf("get role: %w", err)
 	}
 	return unmarshalRole(&resp), nil
 }
 
 // List fetches all roles defined in the cluster.
-func (rc *RolesClient) List(ctx context.Context) ([]Role, error) {
+func (c *RolesClient) List(ctx context.Context) ([]Role, error) {
 	var resp []api.Role
-	if err := rc.transport.Do(ctx, api.ListRolesRequest, &resp); err != nil {
+	if err := c.transport.Do(ctx, api.ListRolesRequest, &resp); err != nil {
 		return nil, fmt.Errorf("list role: %w", err)
 	}
 	var roles []Role
@@ -123,8 +123,8 @@ func (rc *RolesClient) List(ctx context.Context) ([]Role, error) {
 }
 
 // Delete deletes a role with the given roleID.
-func (rc *RolesClient) Delete(ctx context.Context, roleID string) error {
-	if err := rc.transport.Do(ctx, api.DeleteRoleRequest(roleID), nil); err != nil {
+func (c *RolesClient) Delete(ctx context.Context, roleID string) error {
+	if err := c.transport.Do(ctx, api.DeleteRoleRequest(roleID), nil); err != nil {
 		return fmt.Errorf("delete role: %w", err)
 	}
 	return nil
@@ -135,13 +135,13 @@ type AddPermissions struct {
 	Permissions Permissions
 }
 
-func (rc *RolesClient) AddPermissions(ctx context.Context, options AddPermissions) error {
+func (c *RolesClient) AddPermissions(ctx context.Context, options AddPermissions) error {
 	req := &api.ManagePermissionsRequest{
 		RoleID:      options.RoleID,
 		Action:      api.PermissionActionAdd,
 		Permissions: marshalPermissions(&options.Permissions),
 	}
-	if err := rc.transport.Do(ctx, req, nil); err != nil {
+	if err := c.transport.Do(ctx, req, nil); err != nil {
 		return fmt.Errorf("add role permissions: %w", err)
 	}
 	return nil
@@ -152,13 +152,13 @@ type RemovePermissions struct {
 	Permissions Permissions
 }
 
-func (rc *RolesClient) RemovePermissions(ctx context.Context, options RemovePermissions) error {
+func (c *RolesClient) RemovePermissions(ctx context.Context, options RemovePermissions) error {
 	req := &api.ManagePermissionsRequest{
 		RoleID:      options.RoleID,
 		Action:      api.PermissionActionRemove,
 		Permissions: marshalPermissions(&options.Permissions),
 	}
-	if err := rc.transport.Do(ctx, req, nil); err != nil {
+	if err := c.transport.Do(ctx, req, nil); err != nil {
 		return fmt.Errorf("remove role permissions: %w", err)
 	}
 	return nil
@@ -184,7 +184,7 @@ type HasPermission struct {
 
 // HasPermission checks if a role contains a permission.
 // Only one permission can be checked in a single call.
-func (rc *RolesClient) HasPermission(ctx context.Context, options HasPermission) (bool, error) {
+func (c *RolesClient) HasPermission(ctx context.Context, options HasPermission) (bool, error) {
 	req, err := marshalHasPermission(options)
 	if err != nil {
 		return false, err
@@ -192,15 +192,15 @@ func (rc *RolesClient) HasPermission(ctx context.Context, options HasPermission)
 	req.RoleID = options.RoleID
 
 	var resp api.HasPermissionResponse
-	if err := rc.transport.Do(ctx, req, &resp); err != nil {
+	if err := c.transport.Do(ctx, req, &resp); err != nil {
 		return false, fmt.Errorf("check role has permission: %w", err)
 	}
 	return bool(resp), nil
 }
 
-func (rc *RolesClient) AssignedUserIDs(ctx context.Context, roleID string) ([]string, error) {
+func (c *RolesClient) AssignedUserIDs(ctx context.Context, roleID string) ([]string, error) {
 	var resp api.GetAssignedUsersResponse
-	if err := rc.transport.Do(ctx, api.GetAssignedUsersRequest(roleID), &resp); err != nil {
+	if err := c.transport.Do(ctx, api.GetAssignedUsersRequest(roleID), &resp); err != nil {
 		return nil, fmt.Errorf("get assigned users: %w", err)
 	}
 	return []string(resp), nil
@@ -208,9 +208,9 @@ func (rc *RolesClient) AssignedUserIDs(ctx context.Context, roleID string) ([]st
 
 type UserInfo api.UserInfo
 
-func (rc *RolesClient) UserAssignments(ctx context.Context, roleID string) ([]UserInfo, error) {
+func (c *RolesClient) UserAssignments(ctx context.Context, roleID string) ([]UserInfo, error) {
 	var resp []api.UserInfo
-	if err := rc.transport.Do(ctx, api.GetUserAssignmentsRequest(roleID), &resp); err != nil {
+	if err := c.transport.Do(ctx, api.GetUserAssignmentsRequest(roleID), &resp); err != nil {
 		return nil, fmt.Errorf("get user assignments: %w", err)
 	}
 
@@ -223,9 +223,9 @@ func (rc *RolesClient) UserAssignments(ctx context.Context, roleID string) ([]Us
 
 type GroupInfo api.GroupInfo
 
-func (rc *RolesClient) GroupAssignments(ctx context.Context, roleID string) ([]GroupInfo, error) {
+func (c *RolesClient) GroupAssignments(ctx context.Context, roleID string) ([]GroupInfo, error) {
 	var resp []api.GroupInfo
-	if err := rc.transport.Do(ctx, api.GetGroupAssignmentsRequest(roleID), &resp); err != nil {
+	if err := c.transport.Do(ctx, api.GetGroupAssignmentsRequest(roleID), &resp); err != nil {
 		return nil, fmt.Errorf("get group assignments: %w", err)
 	}
 

--- a/rbac/roles.go
+++ b/rbac/roles.go
@@ -140,7 +140,7 @@ type AddPermissions struct {
 func (c *RolesClient) AddPermissions(ctx context.Context, options AddPermissions) error {
 	req := &api.ManagePermissionsRequest{
 		RoleID:      options.RoleID,
-		Action:      api.PermissionActionAdd,
+		Verb:        api.PermissionVerbAdd,
 		Permissions: marshalPermissions(&options.Permissions),
 	}
 	if err := c.transport.Do(ctx, req, nil); err != nil {
@@ -157,7 +157,7 @@ type RemovePermissions struct {
 func (c *RolesClient) RemovePermissions(ctx context.Context, options RemovePermissions) error {
 	req := &api.ManagePermissionsRequest{
 		RoleID:      options.RoleID,
-		Action:      api.PermissionActionRemove,
+		Verb:        api.PermissionVerbRemove,
 		Permissions: marshalPermissions(&options.Permissions),
 	}
 	if err := c.transport.Do(ctx, req, nil); err != nil {

--- a/rbac/roles.go
+++ b/rbac/roles.go
@@ -204,35 +204,32 @@ func (rc *RolesClient) AssignedUserIDs(ctx context.Context, roleID string) ([]st
 	return []string(resp), nil
 }
 
-// TODO(dyma): replace with map[username]usertype?
-// Or just User, containing Type and ID, but other fields zeroed.
-// Otherwise we're polluting the API.
-type UserAssignment api.UserAssignment
+type UserInfo api.UserInfo
 
-func (rc *RolesClient) UserAssignments(ctx context.Context, roleID string) ([]UserAssignment, error) {
-	var resp []api.UserAssignment
+func (rc *RolesClient) UserAssignments(ctx context.Context, roleID string) ([]UserInfo, error) {
+	var resp []api.UserInfo
 	if err := rc.transport.Do(ctx, api.GetUserAssignmentsRequest(roleID), &resp); err != nil {
 		return nil, fmt.Errorf("get user assignments: %w", err)
 	}
 
-	out := make([]UserAssignment, len(resp))
+	out := make([]UserInfo, len(resp))
 	for i := range resp {
-		out[i] = UserAssignment(resp[i])
+		out[i] = UserInfo(resp[i])
 	}
 	return out, nil
 }
 
-type GroupAssignment api.GroupAssignment
+type GroupInfo api.GroupInfo
 
-func (rc *RolesClient) GroupAssignments(ctx context.Context, roleID string) ([]GroupAssignment, error) {
-	var resp []api.GroupAssignment
+func (rc *RolesClient) GroupAssignments(ctx context.Context, roleID string) ([]GroupInfo, error) {
+	var resp []api.GroupInfo
 	if err := rc.transport.Do(ctx, api.GetGroupAssignmentsRequest(roleID), &resp); err != nil {
 		return nil, fmt.Errorf("get group assignments: %w", err)
 	}
 
-	out := make([]GroupAssignment, len(resp))
+	out := make([]GroupInfo, len(resp))
 	for i := range resp {
-		out[i] = GroupAssignment(resp[i])
+		out[i] = GroupInfo(resp[i])
 	}
 	return out, nil
 }

--- a/rbac/roles_test.go
+++ b/rbac/roles_test.go
@@ -411,26 +411,26 @@ func TestRolesClient_UserAssignments(t *testing.T) {
 	for _, tt := range []struct {
 		name   string
 		roleID string
-		stubs  []testkit.Stub[any, []api.UserAssignment]
-		want   []rbac.UserAssignment
+		stubs  []testkit.Stub[any, []api.UserInfo]
+		want   []rbac.UserInfo
 		err    testkit.Error
 	}{
 		{
 			name:   "ok",
 			roleID: "rock-n-role",
-			stubs: []testkit.Stub[any, []api.UserAssignment]{{
+			stubs: []testkit.Stub[any, []api.UserInfo]{{
 				Request: testkit.Ptr(api.GetUserAssignmentsRequest("rock-n-role")),
-				Response: []api.UserAssignment{
+				Response: []api.UserInfo{
 					{ID: "john_doe", Type: "db_env"},
 				},
 			}},
-			want: []rbac.UserAssignment{
+			want: []rbac.UserInfo{
 				{ID: "john_doe", Type: "db_env"},
 			},
 		},
 		{
 			name: "with error",
-			stubs: []testkit.Stub[any, []api.UserAssignment]{
+			stubs: []testkit.Stub[any, []api.UserInfo]{
 				{Err: testkit.ErrWhaam},
 			},
 			err: testkit.ExpectError,
@@ -452,26 +452,26 @@ func TestRolesClient_GroupAssignments(t *testing.T) {
 	for _, tt := range []struct {
 		name   string
 		roleID string
-		stubs  []testkit.Stub[any, []api.GroupAssignment]
-		want   []rbac.GroupAssignment
+		stubs  []testkit.Stub[any, []api.GroupInfo]
+		want   []rbac.GroupInfo
 		err    testkit.Error
 	}{
 		{
 			name:   "ok",
 			roleID: "rock-n-role",
-			stubs: []testkit.Stub[any, []api.GroupAssignment]{{
+			stubs: []testkit.Stub[any, []api.GroupInfo]{{
 				Request: testkit.Ptr(api.GetGroupAssignmentsRequest("rock-n-role")),
-				Response: []api.GroupAssignment{
+				Response: []api.GroupInfo{
 					{ID: "external", Type: "oidc"},
 				},
 			}},
-			want: []rbac.GroupAssignment{
+			want: []rbac.GroupInfo{
 				{ID: "external", Type: "oidc"},
 			},
 		},
 		{
 			name: "with error",
-			stubs: []testkit.Stub[any, []api.GroupAssignment]{
+			stubs: []testkit.Stub[any, []api.GroupInfo]{
 				{Err: testkit.ErrWhaam},
 			},
 			err: testkit.ExpectError,

--- a/rbac/roles_test.go
+++ b/rbac/roles_test.go
@@ -193,7 +193,7 @@ func TestRolesClient_AddPermissions(t *testing.T) {
 	for _, tt := range []struct {
 		name  string
 		add   rbac.AddPermissions
-		stubs []testkit.Stub[api.AddPermissionsRequest, any]
+		stubs []testkit.Stub[api.ManagePermissionsRequest, any]
 		err   testkit.Error
 	}{
 		{
@@ -206,9 +206,10 @@ func TestRolesClient_AddPermissions(t *testing.T) {
 					},
 				},
 			},
-			stubs: []testkit.Stub[api.AddPermissionsRequest, any]{{
-				Request: &api.AddPermissionsRequest{
+			stubs: []testkit.Stub[api.ManagePermissionsRequest, any]{{
+				Request: &api.ManagePermissionsRequest{
 					RoleID: "rock-n-role",
+					Action: api.PermissionActionAdd,
 					Permissions: api.Permissions{
 						Cluster: []api.ClusterPermission{
 							{Read: true},
@@ -219,7 +220,7 @@ func TestRolesClient_AddPermissions(t *testing.T) {
 		},
 		{
 			name: "with error",
-			stubs: []testkit.Stub[api.AddPermissionsRequest, any]{
+			stubs: []testkit.Stub[api.ManagePermissionsRequest, any]{
 				{Err: testkit.ErrWhaam},
 			},
 			err: testkit.ExpectError,
@@ -240,7 +241,7 @@ func TestRolesClient_RemovePermissions(t *testing.T) {
 	for _, tt := range []struct {
 		name   string
 		remove rbac.RemovePermissions
-		stubs  []testkit.Stub[api.RemovePermissionsRequest, any]
+		stubs  []testkit.Stub[api.ManagePermissionsRequest, any]
 		err    testkit.Error
 	}{
 		{
@@ -253,9 +254,10 @@ func TestRolesClient_RemovePermissions(t *testing.T) {
 					},
 				},
 			},
-			stubs: []testkit.Stub[api.RemovePermissionsRequest, any]{{
-				Request: &api.RemovePermissionsRequest{
+			stubs: []testkit.Stub[api.ManagePermissionsRequest, any]{{
+				Request: &api.ManagePermissionsRequest{
 					RoleID: "rock-n-role",
+					Action: api.PermissionActionRemove,
 					Permissions: api.Permissions{
 						Cluster: []api.ClusterPermission{
 							{Read: true},
@@ -266,7 +268,7 @@ func TestRolesClient_RemovePermissions(t *testing.T) {
 		},
 		{
 			name: "with error",
-			stubs: []testkit.Stub[api.RemovePermissionsRequest, any]{
+			stubs: []testkit.Stub[api.ManagePermissionsRequest, any]{
 				{Err: testkit.ErrWhaam},
 			},
 			err: testkit.ExpectError,

--- a/rbac/roles_test.go
+++ b/rbac/roles_test.go
@@ -209,7 +209,7 @@ func TestRolesClient_AddPermissions(t *testing.T) {
 			stubs: []testkit.Stub[api.ManagePermissionsRequest, any]{{
 				Request: &api.ManagePermissionsRequest{
 					RoleID: "rock-n-role",
-					Action: api.PermissionActionAdd,
+					Verb:   api.PermissionVerbAdd,
 					Permissions: api.Permissions{
 						Cluster: []api.ClusterPermission{
 							{Read: true},
@@ -257,7 +257,7 @@ func TestRolesClient_RemovePermissions(t *testing.T) {
 			stubs: []testkit.Stub[api.ManagePermissionsRequest, any]{{
 				Request: &api.ManagePermissionsRequest{
 					RoleID: "rock-n-role",
-					Action: api.PermissionActionRemove,
+					Verb:   api.PermissionVerbRemove,
 					Permissions: api.Permissions{
 						Cluster: []api.ClusterPermission{
 							{Read: true},

--- a/rbac/users.go
+++ b/rbac/users.go
@@ -22,16 +22,10 @@ func NewUsersClient(t internal.Transport) *UsersClient {
 	return &UsersClient{
 		transport: t,
 		DB: &DBUsersClient{
-			kindClient: &kindClient{
-				transport: t,
-				kind:      api.RBACKindDB,
-			},
+			kindClient: newKindClient[api.UserID](t, api.RBACKindDB),
 		},
 		OIDC: &OIDCUsersClient{
-			kindClient: &kindClient{
-				transport: t,
-				kind:      api.RBACKindOIDC,
-			},
+			kindClient: newKindClient[api.UserID](t, api.RBACKindOIDC),
 		},
 	}
 }
@@ -60,20 +54,27 @@ func (c *UsersClient) MyUserInfo(ctx context.Context) (*MyUserInfo, error) {
 	}, nil
 }
 
-type kindClient struct {
+func newKindClient[ID api.UserID | api.GroupID](t internal.Transport, kind string) *kindClient[ID] {
+	return &kindClient[ID]{
+		transport: t,
+		kind:      kind,
+	}
+}
+
+type kindClient[ID api.UserID | api.GroupID] struct {
 	transport internal.Transport
 	kind      string
 }
 
 type AssignedRolesOptions struct {
-	UserID             string
+	ID                 string
 	IncludePermissions bool
 }
 
-func (c *kindClient) AssignedRoles(ctx context.Context, options AssignedRolesOptions) ([]Role, error) {
+func (c *kindClient[ID]) AssignedRoles(ctx context.Context, options AssignedRolesOptions) ([]Role, error) {
 	req := &api.GetAssignedRolesRequest{
 		Kind:               c.kind,
-		Entity:             api.UserID(options.UserID),
+		Entity:             api.RBACEntity(ID(options.ID)),
 		IncludePermissions: options.IncludePermissions,
 	}
 
@@ -89,14 +90,14 @@ func (c *kindClient) AssignedRoles(ctx context.Context, options AssignedRolesOpt
 }
 
 type AssignRolesOptions struct {
-	UserID string
-	Roles  []string
+	ID    string
+	Roles []string
 }
 
-func (c *kindClient) AssignRoles(ctx context.Context, options AssignRolesOptions) error {
+func (c *kindClient[ID]) AssignRoles(ctx context.Context, options AssignRolesOptions) error {
 	req := &api.ManageRolesRequest{
 		Kind:   c.kind,
-		Entity: api.UserID(options.UserID),
+		Entity: api.RBACEntity(ID(options.ID)),
 		Action: api.RoleActionAssign,
 		Roles:  options.Roles,
 	}
@@ -107,14 +108,14 @@ func (c *kindClient) AssignRoles(ctx context.Context, options AssignRolesOptions
 }
 
 type RevokeRolesOptions struct {
-	UserID string
-	Roles  []string
+	ID    string
+	Roles []string
 }
 
-func (c *kindClient) RevokeRoles(ctx context.Context, options RevokeRolesOptions) error {
+func (c *kindClient[ID]) RevokeRoles(ctx context.Context, options RevokeRolesOptions) error {
 	req := &api.ManageRolesRequest{
 		Kind:   c.kind,
-		Entity: api.UserID(options.UserID),
+		Entity: api.RBACEntity(ID(options.ID)),
 		Action: api.RoleActionRevoke,
 		Roles:  options.Roles,
 	}
@@ -125,8 +126,8 @@ func (c *kindClient) RevokeRoles(ctx context.Context, options RevokeRolesOptions
 }
 
 type (
-	DBUsersClient   struct{ *kindClient }
-	OIDCUsersClient struct{ *kindClient }
+	DBUsersClient   struct{ *kindClient[api.UserID] }
+	OIDCUsersClient struct{ *kindClient[api.UserID] }
 )
 
 func (c *DBUsersClient) Create(ctx context.Context, userID string) (string, error) {

--- a/rbac/users.go
+++ b/rbac/users.go
@@ -3,9 +3,11 @@ package rbac
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
 )
 
 type UsersClient struct {
@@ -15,6 +17,8 @@ type UsersClient struct {
 }
 
 func NewUsersClient(t internal.Transport) *UsersClient {
+	dev.AssertNotNil(t, "transport")
+
 	return &UsersClient{
 		transport: t,
 		DB: &DBUsersClient{
@@ -32,14 +36,28 @@ func NewUsersClient(t internal.Transport) *UsersClient {
 	}
 }
 
-type MyUser struct {
+type MyUserInfo struct {
 	ID     string
 	Roles  []Role
 	Groups []string
 }
 
-func (c *UsersClient) MyUser(ctx context.Context) (*MyUser, error) {
-	return nil, nil
+func (c *UsersClient) MyUserInfo(ctx context.Context) (*MyUserInfo, error) {
+	var resp api.GetOwnUserInfoResponse
+	if err := c.transport.Do(ctx, api.GetOwnUserInfoRequest, &resp); err != nil {
+		return nil, fmt.Errorf("get my user info: %w", err)
+	}
+
+	roles := slices.Grow([]Role(nil), len(resp.Roles))
+	for i := range resp.Roles {
+		roles = append(roles, unmarshalRole(&resp.Roles[i]))
+	}
+
+	return &MyUserInfo{
+		ID:     resp.ID,
+		Groups: resp.Groups,
+		Roles:  roles,
+	}, nil
 }
 
 type kindClient struct {
@@ -47,20 +65,62 @@ type kindClient struct {
 	kind      string
 }
 
-type AssignedRoles struct {
+type AssignedRolesOptions struct {
 	UserID             string
 	IncludePermissions bool
 }
 
-func (c *kindClient) AssignedRoles(ctx context.Context, options AssignedRoles) ([]Role, error) {
-	return nil, nil
+func (c *kindClient) AssignedRoles(ctx context.Context, options AssignedRolesOptions) ([]Role, error) {
+	req := &api.GetAssignedRolesRequest{
+		Kind:               c.kind,
+		Entity:             api.UserID(options.UserID),
+		IncludePermissions: options.IncludePermissions,
+	}
+
+	var resp []api.Role
+	if err := c.transport.Do(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("get assigned roles: %w", err)
+	}
+	roles := slices.Grow([]Role(nil), len(resp))
+	for i := range resp {
+		roles = append(roles, unmarshalRole(&resp[i]))
+	}
+	return roles, nil
 }
 
-func (c *kindClient) AssignRoles(ctx context.Context, userID string, roles ...string) error {
+type AssignRolesOptions struct {
+	UserID string
+	Roles  []string
+}
+
+func (c *kindClient) AssignRoles(ctx context.Context, options AssignRolesOptions) error {
+	req := &api.ManageRolesRequest{
+		Kind:   c.kind,
+		Entity: api.UserID(options.UserID),
+		Action: api.RoleActionAssign,
+		Roles:  options.Roles,
+	}
+	if err := c.transport.Do(ctx, req, nil); err != nil {
+		return fmt.Errorf("assign roles: %w", err)
+	}
 	return nil
 }
 
-func (c *kindClient) RevokeRoles(ctx context.Context, userID string, roles ...string) error {
+type RevokeRolesOptions struct {
+	UserID string
+	Roles  []string
+}
+
+func (c *kindClient) RevokeRoles(ctx context.Context, options RevokeRolesOptions) error {
+	req := &api.ManageRolesRequest{
+		Kind:   c.kind,
+		Entity: api.UserID(options.UserID),
+		Action: api.RoleActionRevoke,
+		Roles:  options.Roles,
+	}
+	if err := c.transport.Do(ctx, req, nil); err != nil {
+		return fmt.Errorf("revoke roles: %w", err)
+	}
 	return nil
 }
 
@@ -91,12 +151,12 @@ func (c *DBUsersClient) Activate(ctx context.Context, userID string) error {
 	return nil
 }
 
-type DeactivateOptions struct {
+type DeactivateUserOptions struct {
 	ID        string
 	RevokeKey bool
 }
 
-func (c *DBUsersClient) Deactivate(ctx context.Context, options DeactivateOptions) error {
+func (c *DBUsersClient) Deactivate(ctx context.Context, options DeactivateUserOptions) error {
 	req := &api.DeactivateUserRequest{
 		ID:        options.ID,
 		RevokeKey: options.RevokeKey,
@@ -115,12 +175,20 @@ func (c *DBUsersClient) RotateKey(ctx context.Context, userID string) (string, e
 	return resp.APIKey, nil
 }
 
-type ByNameOptions struct {
+const (
+	UserTypeDB    = api.UserTypeDB    // User created via REST API.
+	UserTypeDBEnv = api.UserTypeDBEnv // User defined in the server environment.
+	UserTypeOIDC  = api.UserTypeOIDC  // User managed by an OIDC provider.
+
+	GroupTypeOIDC = api.GroupTypeOIDC // Group managed by an OIDC provider.
+)
+
+type UserInfoOptions struct {
 	ID                string
 	IncludeLastUsedAt bool
 }
 
-func (c *DBUsersClient) ByName(ctx context.Context, options ByNameOptions) (*UserInfo, error) {
+func (c *DBUsersClient) UserInfo(ctx context.Context, options UserInfoOptions) (*UserInfo, error) {
 	req := &api.GetUserInfoRequest{
 		ID:                options.ID,
 		IncludeLastUsedAt: options.IncludeLastUsedAt,

--- a/rbac/users.go
+++ b/rbac/users.go
@@ -98,7 +98,7 @@ func (c *kindClient[ID]) AssignRoles(ctx context.Context, options AssignRolesOpt
 	req := &api.ManageRolesRequest{
 		Kind:   c.kind,
 		Entity: api.RBACEntity(ID(options.ID)),
-		Action: api.RoleActionAssign,
+		Verb:   api.RoleVerbAssign,
 		Roles:  options.Roles,
 	}
 	if err := c.transport.Do(ctx, req, nil); err != nil {
@@ -116,7 +116,7 @@ func (c *kindClient[ID]) RevokeRoles(ctx context.Context, options RevokeRolesOpt
 	req := &api.ManageRolesRequest{
 		Kind:   c.kind,
 		Entity: api.RBACEntity(ID(options.ID)),
-		Action: api.RoleActionRevoke,
+		Verb:   api.RoleVerbRevoke,
 		Roles:  options.Roles,
 	}
 	if err := c.transport.Do(ctx, req, nil); err != nil {

--- a/rbac/users.go
+++ b/rbac/users.go
@@ -1,0 +1,165 @@
+package rbac
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+)
+
+type UsersClient struct {
+	transport internal.Transport
+	DB        *DBUsersClient
+	OIDC      *OIDCUsersClient
+}
+
+func NewUsersClient(t internal.Transport) *UsersClient {
+	return &UsersClient{
+		transport: t,
+		DB: &DBUsersClient{
+			kindClient: &kindClient{
+				transport: t,
+				kind:      api.RBACKindDB,
+			},
+		},
+		OIDC: &OIDCUsersClient{
+			kindClient: &kindClient{
+				transport: t,
+				kind:      api.RBACKindOIDC,
+			},
+		},
+	}
+}
+
+type MyUser struct {
+	ID     string
+	Roles  []Role
+	Groups []string
+}
+
+func (c *UsersClient) MyUser(ctx context.Context) (*MyUser, error) {
+	return nil, nil
+}
+
+type kindClient struct {
+	transport internal.Transport
+	kind      string
+}
+
+type AssignedRoles struct {
+	UserID             string
+	IncludePermissions bool
+}
+
+func (c *kindClient) AssignedRoles(ctx context.Context, options AssignedRoles) ([]Role, error) {
+	return nil, nil
+}
+
+func (c *kindClient) AssignRoles(ctx context.Context, userID string, roles ...string) error {
+	return nil
+}
+
+func (c *kindClient) RevokeRoles(ctx context.Context, userID string, roles ...string) error {
+	return nil
+}
+
+type (
+	DBUsersClient   struct{ *kindClient }
+	OIDCUsersClient struct{ *kindClient }
+)
+
+func (c *DBUsersClient) Create(ctx context.Context, userID string) (string, error) {
+	var resp api.CreateUserResponse
+	if err := c.transport.Do(ctx, api.CreateUserRequest(userID), &resp); err != nil {
+		return "", fmt.Errorf("create db user: %w", err)
+	}
+	return resp.APIKey, nil
+}
+
+func (c *DBUsersClient) Delete(ctx context.Context, userID string) error {
+	if err := c.transport.Do(ctx, api.DeleteUserRequest(userID), nil); err != nil {
+		return fmt.Errorf("delete db user: %w", err)
+	}
+	return nil
+}
+
+func (c *DBUsersClient) Activate(ctx context.Context, userID string) error {
+	if err := c.transport.Do(ctx, api.ActivateUserRequest(userID), nil); err != nil {
+		return fmt.Errorf("activate db user: %w", err)
+	}
+	return nil
+}
+
+type DeactivateOptions struct {
+	ID        string
+	RevokeKey bool
+}
+
+func (c *DBUsersClient) Deactivate(ctx context.Context, options DeactivateOptions) error {
+	req := &api.DeactivateUserRequest{
+		ID:        options.ID,
+		RevokeKey: options.RevokeKey,
+	}
+	if err := c.transport.Do(ctx, req, nil); err != nil {
+		return fmt.Errorf("deactivate db user: %w", err)
+	}
+	return nil
+}
+
+func (c *DBUsersClient) RotateKey(ctx context.Context, userID string) (string, error) {
+	var resp api.RotateAPIKeyResponse
+	if err := c.transport.Do(ctx, api.RotateAPIKeyRequest(userID), &resp); err != nil {
+		return "", fmt.Errorf("rotate db user api key: %w", err)
+	}
+	return resp.APIKey, nil
+}
+
+type ByNameOptions struct {
+	ID                string
+	IncludeLastUsedAt bool
+}
+
+func (c *DBUsersClient) ByName(ctx context.Context, options ByNameOptions) (*UserInfo, error) {
+	req := &api.GetUserInfoRequest{
+		ID:                options.ID,
+		IncludeLastUsedAt: options.IncludeLastUsedAt,
+	}
+
+	var resp api.UserInfo
+	if err := c.transport.Do(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("get db user info: %w", err)
+	}
+	return &UserInfo{
+		ID:     resp.ID,
+		Type:   resp.Type,
+		Active: resp.Active,
+		Roles:  resp.Roles,
+	}, nil
+}
+
+type ListUsersOptions struct {
+	IncludeLastUsedAt bool
+}
+
+func (c *DBUsersClient) List(ctx context.Context, options ListUsersOptions) ([]UserInfo, error) {
+	req := &api.ListUsersRequest{
+		IncludeLastUsedAt: options.IncludeLastUsedAt,
+	}
+
+	var resp []api.UserInfo
+	if err := c.transport.Do(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("list db users: %w", err)
+	}
+
+	out := make([]UserInfo, len(resp))
+	for i, ui := range resp {
+		out[i] = UserInfo{
+			ID:     ui.ID,
+			Type:   ui.Type,
+			Active: ui.Active,
+			Roles:  ui.Roles,
+		}
+	}
+	return out, nil
+}

--- a/rbac/users_test.go
+++ b/rbac/users_test.go
@@ -1,0 +1,497 @@
+package rbac_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+	"github.com/weaviate/weaviate-go-client/v6/rbac"
+)
+
+func TestNewUsersClient(t *testing.T) {
+	require.Panics(t, func() {
+		rbac.NewUsersClient(nil)
+	}, "nil transport")
+
+	t.Run("namespaces", func(t *testing.T) {
+		c := rbac.NewUsersClient(testkit.NopTransport)
+
+		assert.NotNil(t, c, "nil client")
+		assert.NotNil(t, c.DB, "nil DB namespace")
+		assert.NotNil(t, c.OIDC, "nil OIDC namespace")
+	})
+}
+
+func TestUsersClient_MyUserInfo(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		stubs []testkit.Stub[any, api.GetOwnUserInfoResponse]
+		want  *rbac.MyUserInfo
+		err   testkit.Error
+	}{
+		{
+			name: "ok",
+			stubs: []testkit.Stub[any, api.GetOwnUserInfoResponse]{{
+				Request: testkit.Ptr[any](api.GetOwnUserInfoRequest),
+				Response: api.GetOwnUserInfoResponse{
+					ID: "john-malkovich",
+					Roles: []api.Role{
+						{ID: "rock-n-role"},
+						{ID: "sushi-role"},
+					},
+					Groups: []string{"external", "internal"},
+				},
+			}},
+			want: &rbac.MyUserInfo{
+				ID: "john-malkovich",
+				Roles: []rbac.Role{
+					{ID: "rock-n-role"},
+					{ID: "sushi-role"},
+				},
+				Groups: []string{"external", "internal"},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[any, api.GetOwnUserInfoResponse]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewUsersClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.MyUserInfo(t.Context())
+			tt.err.Require(t, err, "request error")
+			require.Equal(t, tt.want, got, "bad result")
+		})
+	}
+}
+
+func TestUsersClient_DB_AssignedRoles(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options rbac.AssignedRolesOptions
+		stubs   []testkit.Stub[api.GetAssignedRolesRequest, []api.Role]
+		want    []rbac.Role
+		err     testkit.Error
+	}{
+		{
+			name: "ok",
+			options: rbac.AssignedRolesOptions{
+				UserID:             "john-malkovich",
+				IncludePermissions: false,
+			},
+			stubs: []testkit.Stub[api.GetAssignedRolesRequest, []api.Role]{{
+				Request: &api.GetAssignedRolesRequest{
+					Kind:               api.RBACKindDB,
+					Entity:             api.UserID("john-malkovich"),
+					IncludePermissions: false,
+				},
+				Response: []api.Role{
+					{ID: "rock-n-role"},
+					{ID: "sushi-role"},
+				},
+			}},
+			want: []rbac.Role{
+				{ID: "rock-n-role"},
+				{ID: "sushi-role"},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.GetAssignedRolesRequest, []api.Role]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewUsersClient(transport)
+			require.NotNil(t, c, "nil client")
+			require.NotNil(t, c.DB, "nil DB namespace")
+
+			got, err := c.DB.AssignedRoles(t.Context(), tt.options)
+			tt.err.Require(t, err, "request error")
+			require.Equal(t, tt.want, got, "bad result")
+		})
+	}
+}
+
+func TestUsersClient_DB_AssignRoles(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options rbac.AssignRolesOptions
+		stubs   []testkit.Stub[api.ManageRolesRequest, any]
+		err     testkit.Error
+	}{
+		{
+			name: "ok",
+			options: rbac.AssignRolesOptions{
+				UserID: "john-malkovich",
+				Roles:  []string{"rock-n-role", "sushi-role"},
+			},
+			stubs: []testkit.Stub[api.ManageRolesRequest, any]{{
+				Request: &api.ManageRolesRequest{
+					Kind:   api.RBACKindDB,
+					Entity: api.UserID("john-malkovich"),
+					Action: api.RoleActionAssign,
+					Roles:  []string{"rock-n-role", "sushi-role"},
+				},
+			}},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.ManageRolesRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewUsersClient(transport)
+			require.NotNil(t, c, "nil client")
+			require.NotNil(t, c.DB, "nil DB namespace")
+
+			err := c.DB.AssignRoles(t.Context(), tt.options)
+			tt.err.Require(t, err, "request error")
+		})
+	}
+}
+
+func TestUsersClient_DB_RevokeRoles(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options rbac.RevokeRolesOptions
+		stubs   []testkit.Stub[api.ManageRolesRequest, any]
+		err     testkit.Error
+	}{
+		{
+			name: "ok",
+			options: rbac.RevokeRolesOptions{
+				UserID: "john-malkovich",
+				Roles:  []string{"rock-n-role", "sushi-role"},
+			},
+			stubs: []testkit.Stub[api.ManageRolesRequest, any]{{
+				Request: &api.ManageRolesRequest{
+					Kind:   api.RBACKindDB,
+					Entity: api.UserID("john-malkovich"),
+					Action: api.RoleActionRevoke,
+					Roles:  []string{"rock-n-role", "sushi-role"},
+				},
+			}},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.ManageRolesRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewUsersClient(transport)
+			require.NotNil(t, c, "nil client")
+			require.NotNil(t, c.DB, "nil DB namespace")
+
+			err := c.DB.RevokeRoles(t.Context(), tt.options)
+			tt.err.Require(t, err, "request error")
+		})
+	}
+}
+
+func TestUsersClient_DB_Create(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		userID string
+		stubs  []testkit.Stub[any, api.CreateUserResponse]
+		want   string
+		err    testkit.Error
+	}{
+		{
+			name:   "ok",
+			userID: "john-malkovich",
+			stubs: []testkit.Stub[any, api.CreateUserResponse]{{
+				Request:  testkit.Ptr(api.CreateUserRequest("john-malkovich")),
+				Response: api.CreateUserResponse{APIKey: "abracadabra"},
+			}},
+			want: "abracadabra",
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[any, api.CreateUserResponse]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewUsersClient(transport)
+			require.NotNil(t, c, "nil client")
+			require.NotNil(t, c.DB, "nil DB namespace")
+
+			got, err := c.DB.Create(t.Context(), tt.userID)
+			tt.err.Require(t, err, "request error")
+			assert.Equal(t, tt.want, got, "bad result")
+		})
+	}
+}
+
+func TestUsersClient_DB_Delete(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		userID string
+		stubs  []testkit.Stub[any, any]
+		err    testkit.Error
+	}{
+		{
+			name:   "ok",
+			userID: "john-malkovich",
+			stubs: []testkit.Stub[any, any]{{
+				Request: testkit.Ptr(api.DeleteUserRequest("john-malkovich")),
+			}},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[any, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewUsersClient(transport)
+			require.NotNil(t, c, "nil client")
+			require.NotNil(t, c.DB, "nil DB namespace")
+
+			err := c.DB.Delete(t.Context(), tt.userID)
+			tt.err.Require(t, err, "request error")
+		})
+	}
+}
+
+func TestUsersClient_DB_Activate(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		userID string
+		stubs  []testkit.Stub[any, any]
+		err    testkit.Error
+	}{
+		{
+			name:   "ok",
+			userID: "john-malkovich",
+			stubs: []testkit.Stub[any, any]{{
+				Request: testkit.Ptr(api.ActivateUserRequest("john-malkovich")),
+			}},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[any, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewUsersClient(transport)
+			require.NotNil(t, c, "nil client")
+			require.NotNil(t, c.DB, "nil DB namespace")
+
+			err := c.DB.Activate(t.Context(), tt.userID)
+			tt.err.Require(t, err, "request error")
+		})
+	}
+}
+
+func TestUsersClient_DB_Deactivate(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options rbac.DeactivateUserOptions
+		stubs   []testkit.Stub[api.DeactivateUserRequest, any]
+		err     testkit.Error
+	}{
+		{
+			name: "ok",
+			options: rbac.DeactivateUserOptions{
+				ID:        "john-malkovich",
+				RevokeKey: true,
+			},
+			stubs: []testkit.Stub[api.DeactivateUserRequest, any]{{
+				Request: &api.DeactivateUserRequest{
+					ID:        "john-malkovich",
+					RevokeKey: true,
+				},
+			}},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.DeactivateUserRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewUsersClient(transport)
+			require.NotNil(t, c, "nil client")
+			require.NotNil(t, c.DB, "nil DB namespace")
+
+			err := c.DB.Deactivate(t.Context(), tt.options)
+			tt.err.Require(t, err, "request error")
+		})
+	}
+}
+
+func TestUsersClient_DB_RotateKey(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		userID string
+		stubs  []testkit.Stub[any, api.RotateAPIKeyResponse]
+		want   string
+		err    testkit.Error
+	}{
+		{
+			name:   "ok",
+			userID: "john-malkovich",
+			stubs: []testkit.Stub[any, api.RotateAPIKeyResponse]{{
+				Request:  testkit.Ptr(api.RotateAPIKeyRequest("john-malkovich")),
+				Response: api.RotateAPIKeyResponse{APIKey: "abracadabra"},
+			}},
+			want: "abracadabra",
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[any, api.RotateAPIKeyResponse]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewUsersClient(transport)
+			require.NotNil(t, c, "nil client")
+			require.NotNil(t, c.DB, "nil DB namespace")
+
+			got, err := c.DB.RotateKey(t.Context(), tt.userID)
+			tt.err.Require(t, err, "request error")
+			assert.Equal(t, tt.want, got, "bad result")
+		})
+	}
+}
+
+func TestUsersClient_DB_UserInfo(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options rbac.UserInfoOptions
+		stubs   []testkit.Stub[api.GetUserInfoRequest, api.UserInfo]
+		want    *rbac.UserInfo
+		err     testkit.Error
+	}{
+		{
+			name: "ok",
+			options: rbac.UserInfoOptions{
+				ID:                "john-malkovich",
+				IncludeLastUsedAt: true,
+			},
+			stubs: []testkit.Stub[api.GetUserInfoRequest, api.UserInfo]{{
+				Request: &api.GetUserInfoRequest{
+					ID:                "john-malkovich",
+					IncludeLastUsedAt: true,
+				},
+				Response: api.UserInfo{
+					ID:     "john-malkovich",
+					Type:   api.UserTypeDBEnv,
+					Roles:  []string{"rock-n-role", "sushi-role"},
+					Active: true,
+				},
+			}},
+			want: &rbac.UserInfo{
+				ID:     "john-malkovich",
+				Type:   rbac.UserTypeDBEnv,
+				Roles:  []string{"rock-n-role", "sushi-role"},
+				Active: true,
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.GetUserInfoRequest, api.UserInfo]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewUsersClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.DB.UserInfo(t.Context(), tt.options)
+			tt.err.Require(t, err, "request error")
+			require.Equal(t, tt.want, got, "bad result")
+		})
+	}
+}
+
+func TestUsersClient_DB_List(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options rbac.ListUsersOptions
+		stubs   []testkit.Stub[api.ListUsersRequest, []api.UserInfo]
+		want    []rbac.UserInfo
+		err     testkit.Error
+	}{
+		{
+			name: "ok",
+			options: rbac.ListUsersOptions{
+				IncludeLastUsedAt: true,
+			},
+			stubs: []testkit.Stub[api.ListUsersRequest, []api.UserInfo]{{
+				Request: &api.ListUsersRequest{
+					IncludeLastUsedAt: true,
+				},
+				Response: []api.UserInfo{{
+					ID:     "john-malkovich",
+					Type:   api.UserTypeDBEnv,
+					Roles:  []string{"rock-n-role", "sushi-role"},
+					Active: true,
+				}},
+			}},
+			want: []rbac.UserInfo{{
+				ID:     "john-malkovich",
+				Type:   rbac.UserTypeDBEnv,
+				Roles:  []string{"rock-n-role", "sushi-role"},
+				Active: true,
+			}},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.ListUsersRequest, []api.UserInfo]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := rbac.NewUsersClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.DB.List(t.Context(), tt.options)
+			tt.err.Require(t, err, "request error")
+			require.Equal(t, tt.want, got, "bad result")
+		})
+	}
+}

--- a/rbac/users_test.go
+++ b/rbac/users_test.go
@@ -84,7 +84,7 @@ func TestUsersClient_DB_AssignedRoles(t *testing.T) {
 		{
 			name: "ok",
 			options: rbac.AssignedRolesOptions{
-				UserID:             "john-malkovich",
+				ID:                 "john-malkovich",
 				IncludePermissions: false,
 			},
 			stubs: []testkit.Stub[api.GetAssignedRolesRequest, []api.Role]{{
@@ -134,8 +134,8 @@ func TestUsersClient_DB_AssignRoles(t *testing.T) {
 		{
 			name: "ok",
 			options: rbac.AssignRolesOptions{
-				UserID: "john-malkovich",
-				Roles:  []string{"rock-n-role", "sushi-role"},
+				ID:    "john-malkovich",
+				Roles: []string{"rock-n-role", "sushi-role"},
 			},
 			stubs: []testkit.Stub[api.ManageRolesRequest, any]{{
 				Request: &api.ManageRolesRequest{
@@ -176,8 +176,8 @@ func TestUsersClient_DB_RevokeRoles(t *testing.T) {
 		{
 			name: "ok",
 			options: rbac.RevokeRolesOptions{
-				UserID: "john-malkovich",
-				Roles:  []string{"rock-n-role", "sushi-role"},
+				ID:    "john-malkovich",
+				Roles: []string{"rock-n-role", "sushi-role"},
 			},
 			stubs: []testkit.Stub[api.ManageRolesRequest, any]{{
 				Request: &api.ManageRolesRequest{

--- a/rbac/users_test.go
+++ b/rbac/users_test.go
@@ -141,7 +141,7 @@ func TestUsersClient_DB_AssignRoles(t *testing.T) {
 				Request: &api.ManageRolesRequest{
 					Kind:   api.RBACKindDB,
 					Entity: api.UserID("john-malkovich"),
-					Action: api.RoleActionAssign,
+					Verb:   api.RoleVerbAssign,
 					Roles:  []string{"rock-n-role", "sushi-role"},
 				},
 			}},
@@ -183,7 +183,7 @@ func TestUsersClient_DB_RevokeRoles(t *testing.T) {
 				Request: &api.ManageRolesRequest{
 					Kind:   api.RBACKindDB,
 					Entity: api.UserID("john-malkovich"),
-					Action: api.RoleActionRevoke,
+					Verb:   api.RoleVerbRevoke,
 					Roles:  []string{"rock-n-role", "sushi-role"},
 				},
 			}},


### PR DESCRIPTION
This PR builds upon #397 and adds APIs for managing users and groups as well as their roles.
The API design mirrors that of the other clients and does not support the upcoming namespace feature yet. As such, it will likely need to be revisited later, when that feature stabilizes.

