### PR TITLE
feat(tokenize): adapt to Weaviate 1.37.4 response shape changes

### DIFF
--- a/.github/workflows/workflow-tests.yaml
+++ b/.github/workflows/workflow-tests.yaml
@@ -2,7 +2,7 @@ on:
   workflow_call:
 
 env:
-  WEAVIATE_VERSION: 1.37.1
+  WEAVIATE_VERSION: 1.37.4
 
 jobs:
   auth-tests:

--- a/test/testsuit/version.go
+++ b/test/testsuit/version.go
@@ -10,16 +10,23 @@ import (
 
 // AtLeastWeaviateVersion skips the test if the weaviate version is lower than the required version.
 func AtLeastWeaviateVersion(t *testing.T, client *weaviate.Client, requiredVersion, message string) {
+	if !ServerAtLeast(t, client, requiredVersion) {
+		t.Skip(message)
+	}
+}
+
+// ServerAtLeast reports whether the connected server is at least requiredVersion.
+// Use it when a test needs to branch on server version; use AtLeastWeaviateVersion
+// when it should skip.
+func ServerAtLeast(t *testing.T, client *weaviate.Client, requiredVersion string) bool {
 	meta, err := client.Misc().MetaGetter().Do(t.Context())
 	require.Nil(t, err, "could not get weaviate meta information")
 
 	runningVersion, err := semver.Parse(meta.Version)
-	require.Nil(t, err, "could not parse WEAVIATE_VERSION env var")
+	require.Nil(t, err, "could not parse weaviate server version %q", meta.Version)
 
 	minVersion, err := semver.Parse(requiredVersion)
-	require.Nil(t, err, "could not parse required version")
+	require.Nil(t, err, "could not parse required version %q", requiredVersion)
 
-	if runningVersion.ComparePrecedence(minVersion) < 0 {
-		t.Skip(message)
-	}
+	return runningVersion.ComparePrecedence(minVersion) >= 0
 }

--- a/test/tokenize/tokenize_test.go
+++ b/test/tokenize/tokenize_test.go
@@ -31,17 +31,21 @@ func TestTokenize_integration(t *testing.T) {
 	// -------- Serialization ------------------------------------------------
 
 	t.Run("Tokenization_Enum", func(t *testing.T) {
+		// Weaviate >=1.37.4 filters default stopwords on the query side for `word`;
+		// older versions return query == indexed.
+		queryStopwordsFiltered := testsuit.ServerAtLeast(t, client, "1.37.4")
 		cases := []struct {
-			name     string
-			method   tokenize.Tokenization
-			text     string
-			expected []string
+			name            string
+			method          tokenize.Tokenization
+			text            string
+			expectedIndexed []string
+			expectedQuery   []string // nil = same as expectedIndexed
 		}{
-			{"word", tokenize.Word, "The quick brown fox", []string{"the", "quick", "brown", "fox"}},
-			{"lowercase", tokenize.Lowercase, "Hello World Test", []string{"hello", "world", "test"}},
-			{"whitespace", tokenize.Whitespace, "Hello World Test", []string{"Hello", "World", "Test"}},
-			{"field", tokenize.Field, "  Hello World  ", []string{"Hello World"}},
-			{"trigram", tokenize.Trigram, "Hello", []string{"hel", "ell", "llo"}},
+			{"word", tokenize.Word, "The quick brown fox", []string{"the", "quick", "brown", "fox"}, []string{"quick", "brown", "fox"}},
+			{"lowercase", tokenize.Lowercase, "Hello World Test", []string{"hello", "world", "test"}, nil},
+			{"whitespace", tokenize.Whitespace, "Hello World Test", []string{"Hello", "World", "Test"}, nil},
+			{"field", tokenize.Field, "  Hello World  ", []string{"Hello World"}, nil},
+			{"trigram", tokenize.Trigram, "Hello", []string{"hel", "ell", "llo"}, nil},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
@@ -52,8 +56,12 @@ func TestTokenize_integration(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, result)
 				assert.Equal(t, tc.method, result.Tokenization)
-				assert.Equal(t, tc.expected, result.Indexed)
-				assert.Equal(t, tc.expected, result.Query)
+				assert.Equal(t, tc.expectedIndexed, result.Indexed)
+				wantQuery := tc.expectedIndexed
+				if queryStopwordsFiltered && tc.expectedQuery != nil {
+					wantQuery = tc.expectedQuery
+				}
+				assert.Equal(t, wantQuery, result.Query)
 			})
 		}
 	})
@@ -124,6 +132,11 @@ func TestTokenize_integration(t *testing.T) {
 	})
 
 	t.Run("CustomPreset_Additions", func(t *testing.T) {
+		// 1.37.4 changed `stopwordPresets` to `[]string`; SDK still emits the
+		// legacy map. TODO: rework SDK API and re-enable (weaviate/weaviate#11079).
+		if testsuit.ServerAtLeast(t, client, "1.37.4") {
+			t.Skip("custom stopword presets need an SDK API rework for 1.37.4+ wire shape")
+		}
 		cfg := &tokenize.AnalyzerConfig{StopwordPreset: "custom"}
 		presets := map[string]*tokenize.StopwordConfig{
 			"custom": {Additions: []string{"test"}},
@@ -140,6 +153,9 @@ func TestTokenize_integration(t *testing.T) {
 	})
 
 	t.Run("CustomPreset_BaseAndRemovals", func(t *testing.T) {
+		if testsuit.ServerAtLeast(t, client, "1.37.4") {
+			t.Skip("custom stopword presets need an SDK API rework for 1.37.4+ wire shape")
+		}
 		cfg := &tokenize.AnalyzerConfig{StopwordPreset: "en-no-the"}
 		presets := map[string]*tokenize.StopwordConfig{
 			"en-no-the": {Preset: "en", Removals: []string{"the"}},
@@ -169,6 +185,10 @@ func TestTokenize_integration(t *testing.T) {
 	})
 
 	t.Run("AnalyzerConfig_Echoed", func(t *testing.T) {
+		// Behaviour still covered by AsciiFold/StopwordPreset_String etc.
+		if testsuit.ServerAtLeast(t, client, "1.37.4") {
+			t.Skip("server no longer echoes AnalyzerConfig on response (weaviate/weaviate#11079)")
+		}
 		cfg := &tokenize.AnalyzerConfig{
 			AsciiFold:       ptrBool(true),
 			AsciiFoldIgnore: []string{"é"},

--- a/weaviate/tokenize/property_tokenizer.go
+++ b/weaviate/tokenize/property_tokenizer.go
@@ -2,6 +2,7 @@ package tokenize
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -58,5 +59,36 @@ func (p *PropertyTokenizer) Do(ctx context.Context) (*TokenizeResult, error) {
 	if decodeErr := responseData.DecodeBodyIntoTarget(&result); decodeErr != nil {
 		return nil, decodeErr
 	}
+	// Weaviate >=1.37.4 no longer echoes `tokenization`; backfill from the schema.
+	// Only paid when the server omitted the field — older servers skip the lookup.
+	if result.Tokenization == "" {
+		if t, _ := p.fetchPropertyTokenization(ctx); t != "" {
+			result.Tokenization = Tokenization(t)
+		}
+	}
 	return &result, nil
+}
+
+// fetchPropertyTokenization returns "" on any failure: backfill is best-effort
+// and must not mask the tokenize result with a schema error.
+func (p *PropertyTokenizer) fetchPropertyTokenization(ctx context.Context) (string, error) {
+	resp, err := p.connection.RunREST(ctx, "/schema/"+p.className, http.MethodGet, nil)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return "", err
+	}
+	var class struct {
+		Properties []struct {
+			Name         string `json:"name"`
+			Tokenization string `json:"tokenization"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(resp.Body, &class); err != nil {
+		return "", err
+	}
+	for _, prop := range class.Properties {
+		if prop.Name == p.propertyName {
+			return prop.Tokenization, nil
+		}
+	}
+	return "", nil
 }

--- a/weaviate/tokenize/text_tokenizer.go
+++ b/weaviate/tokenize/text_tokenizer.go
@@ -65,5 +65,9 @@ func (b *TextTokenizer) Do(ctx context.Context) (*TokenizeResult, error) {
 	if decodeErr := responseData.DecodeBodyIntoTarget(&result); decodeErr != nil {
 		return nil, decodeErr
 	}
+	// Weaviate >=1.37.4 no longer echoes `tokenization`; backfill from the request.
+	if result.Tokenization == "" {
+		result.Tokenization = b.tokenization
+	}
 	return &result, nil
 }


### PR DESCRIPTION
## Summary

Weaviate 1.37.4 ([weaviate/weaviate#11079](https://github.com/weaviate/weaviate/pull/11079)) changed the `/v1/tokenize` wire shape: response no longer echoes `tokenization` or `analyzerConfig`, and the request's `stopwordPresets` is now `[]string` instead of `map<string,StopwordConfig>` (inline custom presets → HTTP 400).

This PR keeps the existing SDK surface working across **1.37.0 – 1.37.4**. The SDK API rework needed to actually *use* custom presets on 1.37.4+ is a follow-up.

## Changes

- `weaviate/tokenize/text_tokenizer.go` — backfill `Tokenization` from the request when the server omits it.
- `weaviate/tokenize/property_tokenizer.go` — backfill via class-schema lookup; only paid when the server omitted the field.
- `test/testsuit/version.go` — add `ServerAtLeast` for tests that branch on server version; `AtLeastWeaviateVersion` wraps it.
- `test/tokenize/tokenize_test.go` — `Tokenization_Enum` asserts asymmetric query/indexed on 1.37.4+; `CustomPreset_*` and `AnalyzerConfig_Echoed` skip on 1.37.4+ with TODOs.
- `.github/workflows/workflow-tests.yaml` — `WEAVIATE_VERSION` 1.37.1 → 1.37.4.

## Test plan

- [x] `go test ./test/tokenize/...` against stock 1.37.0 and 1.37.4
- [ ] CI green at bumped version
- [ ] Follow-up: SDK rework for `stopwordPresets: []string`
