### PR TITLE
feat(query): add OverAll query to do plain search

### DIFF
--- a/query/client.go
+++ b/query/client.go
@@ -20,6 +20,7 @@ func NewClient(t internal.Transport, rd api.RequestDefaults) *Client {
 	return &Client{
 		transport:  t,
 		defaults:   rd,
+		OverAll:    overAllFunc(t, rd),
 		NearVector: nearVectorFunc(t, rd),
 		NearText:   nearTextFunc(t, rd),
 		Hybrid:     hybridFunc(t, rd),
@@ -30,6 +31,7 @@ type Client struct {
 	transport internal.Transport
 	defaults  api.RequestDefaults
 
+	OverAll    OverAllFunc
 	NearVector NearVectorFunc
 	NearText   NearTextFunc
 	Hybrid     HybridFunc

--- a/query/hybrid.go
+++ b/query/hybrid.go
@@ -65,7 +65,7 @@ const (
 // HybridFunc runs plain near text search.
 type HybridFunc func(context.Context, Hybrid) (*Result, error)
 
-// hybridFunc makes internal.Transport available to nearText via a closure.
+// hybridFunc makes internal.Transport available to [query] via a closure.
 func hybridFunc(t internal.Transport, rd api.RequestDefaults) HybridFunc {
 	return func(ctx context.Context, h Hybrid) (*Result, error) {
 		return query(ctx, t, request{

--- a/query/near_vector.go
+++ b/query/near_vector.go
@@ -45,7 +45,7 @@ func Certainty(c float64) VectorSimilarity { return VectorSimilarity{certainty: 
 // NearVectorFunc runs plain near vector search.
 type NearVectorFunc func(context.Context, NearVector) (*Result, error)
 
-// nearVectorFunc makes internal.Transport available to nearVector via a closure.
+// nearVectorFunc makes internal.Transport available to [query] via a closure.
 func nearVectorFunc(t internal.Transport, rd api.RequestDefaults) NearVectorFunc {
 	return func(ctx context.Context, nv NearVector) (*Result, error) {
 		return query(ctx, t, request{

--- a/query/over_all.go
+++ b/query/over_all.go
@@ -1,0 +1,58 @@
+package query
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/query/filter"
+)
+
+type OverAll struct {
+	Limit                  int32            // Limit the number of results returned for the query.
+	Offset                 int32            // Skip the first N objects in the collection.
+	AutoLimit              int32            // Return objects in the first N similarity clusters.
+	After                  uuid.UUID        // Skip all objects before the one with this ID.
+	Filter                 filter.Expr      // Filter results based on their properties.
+	ReturnMetadata         ReturnMetadata   // Select query and object metadata to return for each object.
+	ReturnVectors          []string         // List vectors to return for each object in the result set.
+	ReturnReferences       []Reference      // Select reference properties to return.
+	ReturnNestedProperties []NestedProperty // Return object properties and a subset of their nested properties.
+
+	// Select a subset of properties to return. By default, all properties are returned.
+	// To not return any properties, initialize this value to an empty slice explicitly.
+	ReturnProperties []string
+
+	// groupBy can only be set by [NearVectorFunc.GroupBy], as it changes the shape of the response.
+	groupBy *GroupBy
+}
+
+// OverAllFunc runs plain near text search.
+type OverAllFunc func(context.Context, OverAll) (*Result, error)
+
+// overAllFunc makes internal.Transport available to [query] via a closure.
+func overAllFunc(t internal.Transport, rd api.RequestDefaults) OverAllFunc {
+	return func(ctx context.Context, oaf OverAll) (*Result, error) {
+		return query(ctx, t, request{
+			RequestDefaults:        rd,
+			Limit:                  oaf.Limit,
+			AutoLimit:              oaf.AutoLimit,
+			Offset:                 oaf.Offset,
+			After:                  oaf.After,
+			Filter:                 oaf.Filter,
+			ReturnVectors:          oaf.ReturnVectors,
+			ReturnMetadata:         oaf.ReturnMetadata,
+			ReturnProperties:       oaf.ReturnProperties,
+			ReturnNestedProperties: oaf.ReturnNestedProperties,
+			ReturnReferences:       oaf.ReturnReferences,
+			GroupBy:                oaf.groupBy,
+		}, func(req *api.SearchRequest) {})
+	}
+}
+
+// GroupBy runs OverAll search with a GroupBy clause.
+func (oaf OverAllFunc) GroupBy(ctx context.Context, oa OverAll, groupBy GroupBy) (*GroupByResult, error) {
+	oa.groupBy = &groupBy
+	return queryGroupBy(ctx, oaf, oa)
+}

--- a/query/over_all_test.go
+++ b/query/over_all_test.go
@@ -1,0 +1,135 @@
+package query_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+	"github.com/weaviate/weaviate-go-client/v6/query"
+	"github.com/weaviate/weaviate-go-client/v6/query/filter"
+	"github.com/weaviate/weaviate-go-client/v6/types"
+)
+
+func TestOverAll(t *testing.T) {
+	rd := api.RequestDefaults{
+		CollectionName:   "Songs",
+		Tenant:           "john_doe",
+		ConsistencyLevel: api.ConsistencyLevelQuorum,
+	}
+
+	for _, tt := range testkit.WithOnly(t, []struct {
+		testkit.Only
+
+		name  string
+		nv    query.OverAll
+		stubs []testkit.Stub[api.SearchRequest, api.SearchResponse]
+		want  *query.Result // Expected return value.
+		err   testkit.Error
+	}{
+		{
+			name: "request ok",
+			nv: query.OverAll{
+				Limit:     1,
+				Offset:    2,
+				AutoLimit: 3,
+				After:     testkit.UUID,
+				Filter: filter.Not{
+					P: &filter.Cond{
+						Target:   []string{"album"},
+						Operator: filter.Like,
+						Value:    ".*Blood",
+					},
+				},
+				ReturnMetadata: query.ReturnMetadata{
+					CreatedAt:    true,
+					LastUpdateAt: true,
+				},
+				ReturnProperties: []string{"title", "duration_sec", "release_date"},
+			},
+			stubs: []testkit.Stub[api.SearchRequest, api.SearchResponse]{
+				{
+					Request: &api.SearchRequest{
+						RequestDefaults: rd,
+						Limit:           1,
+						Offset:          2,
+						AutoLimit:       3,
+						After:           testkit.UUID,
+						Filter: api.FilterExpr{
+							Operator: api.FilterOperatorNot,
+							Exprs: []api.FilterExpr{{
+								Operator: api.FilterOperatorLike,
+								Target:   []string{"album"},
+								Value:    ".*Blood",
+							}},
+						},
+						ReturnMetadata: api.ReturnMetadata{
+							CreatedAt:    true,
+							LastUpdateAt: true,
+						},
+						ReturnProperties: []api.ReturnProperty{
+							{Name: "title"},
+							{Name: "duration_sec"},
+							{Name: "release_date"},
+						},
+					},
+					Response: api.SearchResponse{
+						Took: 92 * time.Second,
+						Results: []api.Object{
+							{
+								Collection: "Songs",
+								Metadata: api.ObjectMetadata{
+									UUID:          testkit.UUID,
+									CreatedAt:     &testkit.Now,
+									LastUpdatedAt: &testkit.Now,
+								},
+								Properties: map[string]any{
+									"title":        "High Speed Dirt",
+									"duration_sec": 252,
+									"release_date": testkit.Now,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &query.Result{
+				Took: 92 * time.Second,
+				Objects: []query.Object[map[string]any]{
+					{
+						Object: types.Object[map[string]any]{
+							Collection: "Songs",
+							UUID:       testkit.UUID,
+							Properties: map[string]any{
+								"title":        "High Speed Dirt",
+								"duration_sec": 252,
+								"release_date": testkit.Now,
+							},
+							CreatedAt:     &testkit.Now,
+							LastUpdatedAt: &testkit.Now,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "request error",
+			stubs: []testkit.Stub[api.SearchRequest, api.SearchResponse]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	}) {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+
+			c := query.NewClient(transport, rd)
+			require.NotNil(t, c, "client")
+
+			got, err := c.OverAll(t.Context(), tt.nv)
+			tt.err.Require(t, err, "near vector query")
+			require.EqualExportedValues(t, tt.want, got, "query result")
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the OverAll query type, which allows the user to run a simple query without a semantic / keyword search component.