### PR TITLE
v6: Objects Iterator

### DIFF
--- a/collections/client.go
+++ b/collections/client.go
@@ -80,6 +80,10 @@ func (h *Handle) Tenant() string {
 	return h.defaults.Tenant
 }
 
+func (h *Handle) Objects(ctx context.Context) *query.ObjectIterator {
+	return query.NewObjectIterator(ctx, h.Query)
+}
+
 // HandleOption configures request defaults for collection handle.
 type HandleOption func(*api.RequestDefaults)
 

--- a/collections/client.go
+++ b/collections/client.go
@@ -80,6 +80,9 @@ func (h *Handle) Tenant() string {
 	return h.defaults.Tenant
 }
 
+// Objects creates a new iterator for objects in target collection.
+// The context ctx will be used for all requests throughtout the
+// iterator's lifecycle.
 func (h *Handle) Objects(ctx context.Context) *query.ObjectIterator {
 	return query.NewObjectIterator(ctx, h.Query)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/weaviate/weaviate-go-client/v6
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.5.0
@@ -10,6 +10,7 @@ require (
 	github.com/oasdiff/yaml v0.1.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.36.0
+	google.golang.org/api v0.282.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,7 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-openapi/jsonpointer v0.23.1 h1:1HBACs7XIwR2RcmItfdSFlALhGbe6S92p0ry4d1GWg4=
 github.com/go-openapi/jsonpointer v0.23.1/go.mod h1:iWRmZTrGn7XwYhtPt/fvdSFj1OfNBngqRT2UG3BxSqY=
+github.com/go-openapi/swag v0.26.0/go.mod h1:82g3193sZJRbocs7bNCqGfIgq8pkuwVwCfhKIRlEQF0=
 github.com/go-openapi/swag/jsonname v0.26.0 h1:gV1NFX9M8avo0YSpmWogqfQISigCmpaiNci8cGECU5w=
 github.com/go-openapi/swag/jsonname v0.26.0/go.mod h1:urBBR8bZNoDYGr653ynhIx+gTeIz0ARZxHkAPktJK2M=
 github.com/go-openapi/testify/v2 v2.4.2 h1:tiByHpvE9uHrrKjOszax7ZvKB7QOgizBWGBLuq0ePx4=
@@ -107,6 +108,7 @@ github.com/speakeasy-api/jsonpath v0.6.3 h1:c+QPwzAOdrWvzycuc9HFsIZcxKIaWcNpC+xh
 github.com/speakeasy-api/jsonpath v0.6.3/go.mod h1:2cXloNuQ+RSXi5HTRaeBh7JEmjRXTiaKpFTdZiL7URI=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
+github.com/speakeasy-api/openapi-overlay v0.10.3/go.mod h1:RJjV0jbUHqXLS0/Mxv5XE7LAnJHqHw+01RDdpoGqiyY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -133,6 +135,7 @@ go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+go.yaml.in/yaml/v4 v4.0.0-rc.4/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -190,6 +193,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
+google.golang.org/api v0.282.0 h1:WmJiSVqUnKqJCpJOx7YADbXaC+9DDsnGSfllFSj7R2I=
+google.golang.org/api v0.282.0/go.mod h1:6Wssta4c5n9qHq5CBhmlai5h/PUa1djdDAIhYEHyvcM=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=

--- a/query/hybrid.go
+++ b/query/hybrid.go
@@ -10,9 +10,9 @@ import (
 )
 
 type Hybrid struct {
-	Limit                  int32            // Limit the number of results returned for the query.
-	Offset                 int32            // Skip the first N objects in the collection.
-	AutoLimit              int32            // Return objects in the first N similarity clusters.
+	Limit                  int              // Limit the number of results returned for the query.
+	Offset                 int              // Skip the first N objects in the collection.
+	AutoLimit              int              // Return objects in the first N similarity clusters.
 	After                  uuid.UUID        // Skip all objects before the one with this ID.
 	Filter                 filter.Expr      // Filter results based on their properties.
 	ReturnMetadata         ReturnMetadata   // Select query and object metadata to return for each object.
@@ -70,9 +70,9 @@ func hybridFunc(t internal.Transport, rd api.RequestDefaults) HybridFunc {
 	return func(ctx context.Context, h Hybrid) (*Result, error) {
 		return query(ctx, t, request{
 			RequestDefaults:        rd,
-			Limit:                  h.Limit,
-			AutoLimit:              h.AutoLimit,
-			Offset:                 h.Offset,
+			Limit:                  int32(h.Limit),
+			AutoLimit:              int32(h.AutoLimit),
+			Offset:                 int32(h.Offset),
 			After:                  h.After,
 			Filter:                 h.Filter,
 			ReturnVectors:          h.ReturnVectors,

--- a/query/iterator.go
+++ b/query/iterator.go
@@ -1,0 +1,65 @@
+package query
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"google.golang.org/api/iterator"
+)
+
+func NewObjectIterator(ctx context.Context, c *Client) *ObjectIterator {
+	it := &ObjectIterator{
+		ctx: ctx,
+		c:   c,
+	}
+
+	it.pageInfo, it.nextFunc = iterator.NewPageInfo(
+		it.fetch,
+		func() int { return len(it.items) },
+		func() any { b := it.items; it.items = nil; return b })
+
+	return it
+}
+
+type ObjectIterator struct {
+	ctx      context.Context
+	c        *Client
+	pageInfo *iterator.PageInfo
+	nextFunc func() error
+	items    []*Object[map[string]any]
+}
+
+var _ iterator.Pageable = (*ObjectIterator)(nil)
+
+func (it *ObjectIterator) PageInfo() *iterator.PageInfo { return it.pageInfo }
+
+func (it *ObjectIterator) Next() (*Object[map[string]any], error) {
+	if err := it.nextFunc(); err != nil {
+		return nil, err
+	}
+	item := it.items[0]
+	it.items = it.items[1:]
+	return item, nil
+}
+
+func (it *ObjectIterator) fetch(pageSize int, pageToken string) (string, error) {
+	req := OverAll{Limit: pageSize}
+	if pageToken != "" {
+		after, err := uuid.Parse(pageToken)
+		if err != nil {
+			return "", err
+		}
+		req.After = after
+	}
+
+	r, err := it.c.OverAll(it.ctx, req)
+	if err != nil {
+		return "", err
+	}
+
+	var i int
+	for i = range r.Objects {
+		it.items = append(it.items, &r.Objects[i])
+	}
+	return r.Objects[i].UUID.String(), nil
+}

--- a/query/iterator.go
+++ b/query/iterator.go
@@ -57,6 +57,12 @@ func (it *ObjectIterator) fetch(pageSize int, pageToken string) (string, error) 
 		return "", err
 	}
 
+	// iterator.Pager will mark the iterator as exhausted and return
+	// [iterator.Done] on every subsequent call to Next or NextPage.
+	if len(r.Objects) == 0 {
+		return "", nil
+	}
+
 	var i int
 	for i = range r.Objects {
 		it.items = append(it.items, &r.Objects[i])

--- a/query/iterator.go
+++ b/query/iterator.go
@@ -4,10 +4,17 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
 	"google.golang.org/api/iterator"
 )
 
+// NewObjectIterator creates a new [ObjectIterator] for objects in the collection
+// which client c targets. The context ctx will be used for all requests throughtout the
+// iterators lifecycle, and canceling it will prevent the iterator from fetching any more objects.
 func NewObjectIterator(ctx context.Context, c *Client) *ObjectIterator {
+	dev.AssertNotNil(ctx, "ctx")
+	dev.AssertNotNil(c, "client")
+
 	it := &ObjectIterator{
 		ctx: ctx,
 		c:   c,
@@ -18,9 +25,16 @@ func NewObjectIterator(ctx context.Context, c *Client) *ObjectIterator {
 		func() int { return len(it.items) },
 		func() any { b := it.items; it.items = nil; return b })
 
+	dev.AssertNotNil(it.pageInfo, "page info")
+	dev.AssertNotNil(it.nextFunc, "next func")
+
 	return it
 }
 
+// ObjectIterator implements a [Google-style iterator] for objects in the target collection.
+// This iterator does not support concurrent modification or iteration.
+//
+// [Google-style iterator]: https://github.com/googleapis/google-cloud-go/wiki/Iterator-Guidelines
 type ObjectIterator struct {
 	ctx      context.Context
 	c        *Client
@@ -31,8 +45,14 @@ type ObjectIterator struct {
 
 var _ iterator.Pageable = (*ObjectIterator)(nil)
 
+// PageInfo returns iterator's [iterator.PageInfo], which supports pagination.
+//
+// You can control the page size by setting [iterator.PageInfo.MaxSize] on the
+// returned page info and update the cursor by setting [iterator.PageInfo.Token].
+// These MUST be update synchronously before using the iterator again.
 func (it *ObjectIterator) PageInfo() *iterator.PageInfo { return it.pageInfo }
 
+// Next fetches the next object in the collection.
 func (it *ObjectIterator) Next() (*Object[map[string]any], error) {
 	if err := it.nextFunc(); err != nil {
 		return nil, err
@@ -42,6 +62,7 @@ func (it *ObjectIterator) Next() (*Object[map[string]any], error) {
 	return item, nil
 }
 
+// fetch fetches the next batch of pageSize objects and populates the internal buffer it.items.
 func (it *ObjectIterator) fetch(pageSize int, pageToken string) (string, error) {
 	req := OverAll{Limit: pageSize}
 	if pageToken != "" {
@@ -59,6 +80,16 @@ func (it *ObjectIterator) fetch(pageSize int, pageToken string) (string, error) 
 
 	// iterator.Pager will mark the iterator as exhausted and return
 	// [iterator.Done] on every subsequent call to Next or NextPage.
+	//
+	// TODO(dyma): should we also return iterator.Done in this case?
+	// I find it odd that the user should check for iterator.Done when
+	// using the Iterator and check for nextToken == "" when using the
+	// same inside a Pager. I would prefer if we could return this error
+	// every time the iterator's exhausted its resource.
+	// Feels like we should also check if len(r.Objects) < pageSize,
+	// which suggests there weren't any more objects on the server;
+	// otherwise we're likely to need another call to get here if
+	// the last request "undef-fetches".
 	if len(r.Objects) == 0 {
 		return "", nil
 	}

--- a/query/iterator_test.go
+++ b/query/iterator_test.go
@@ -1,0 +1,126 @@
+package query_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+	"github.com/weaviate/weaviate-go-client/v6/query"
+	"google.golang.org/api/iterator"
+)
+
+func TestObjectIterator(t *testing.T) {
+	rd := api.RequestDefaults{
+		CollectionName:   "Songs",
+		ConsistencyLevel: api.ConsistencyLevelOne,
+		Tenant:           "john_doe",
+	}
+
+	t.Run("iterate", func(t *testing.T) {
+		t.Skip()
+		after1 := uuid.New() // UUID of the last object in 1st batch
+		after2 := uuid.New() // UUID of the last object in 2nd batch
+
+		transport := testkit.NewTransport(t, []testkit.Stub[api.SearchRequest, api.SearchResponse]{
+			{
+				Request: &api.SearchRequest{RequestDefaults: rd},
+				Response: api.SearchResponse{Results: []api.Object{
+					{Metadata: api.ObjectMetadata{UUID: testkit.UUID}},
+					{Metadata: api.ObjectMetadata{UUID: testkit.UUID}},
+					{Metadata: api.ObjectMetadata{UUID: after1}},
+				}},
+			},
+			{
+				Request: &api.SearchRequest{RequestDefaults: rd, After: after1},
+				Response: api.SearchResponse{Results: []api.Object{
+					{Metadata: api.ObjectMetadata{UUID: testkit.UUID}},
+					{Metadata: api.ObjectMetadata{UUID: after2}},
+				}},
+			},
+			{
+				Request: &api.SearchRequest{RequestDefaults: rd, After: after2},
+				// The collection only has 5 items, no objects in the response.
+			},
+		})
+		c := query.NewClient(transport, rd)
+		require.NotNil(t, c, "nil client")
+
+		it := query.NewObjectIterator(t.Context(), c)
+		require.NotNil(t, it, "nil iterator")
+
+		// The collection has 5 items, which should all be fetched.
+		for i := range 5 {
+			o, err := it.Next()
+			assert.NoErrorf(t, err, "next #%d", i)
+			assert.NotNil(t, o, "object #%d", i)
+		}
+
+		// Each subsequent call to Next should return iterator.Done.
+		for range 2 {
+			o, err := it.Next()
+			assert.ErrorIs(t, err, iterator.Done)
+			assert.Nil(t, o, "object after iteration is done")
+		}
+	})
+
+	t.Run("paginate", func(t *testing.T) {
+		after1 := uuid.New() // UUID of the last object in 1st batch
+		after2 := uuid.New() // UUID of the last object in 2nd batch
+
+		transport := testkit.NewTransport(t, []testkit.Stub[api.SearchRequest, api.SearchResponse]{
+			{
+				Request: &api.SearchRequest{RequestDefaults: rd, Limit: 3},
+				Response: api.SearchResponse{Results: []api.Object{
+					{Metadata: api.ObjectMetadata{UUID: testkit.UUID}},
+					{Metadata: api.ObjectMetadata{UUID: testkit.UUID}},
+					{Metadata: api.ObjectMetadata{UUID: after1}},
+				}},
+			},
+			{
+				Request: &api.SearchRequest{RequestDefaults: rd, After: after1, Limit: 3},
+				Response: api.SearchResponse{Results: []api.Object{
+					{Metadata: api.ObjectMetadata{UUID: testkit.UUID}},
+					{Metadata: api.ObjectMetadata{UUID: after2}},
+				}},
+			},
+			{
+				// Page will try to fill the page up to the desired size 3 by fetching 1 more item.
+				// The collection only has 5 items, no objects in the response.
+				Request: &api.SearchRequest{RequestDefaults: rd, After: after2, Limit: 1},
+			},
+		})
+		c := query.NewClient(transport, rd)
+		require.NotNil(t, c, "nil client")
+
+		it := query.NewObjectIterator(t.Context(), c)
+		require.NotNil(t, it, "nil iterator")
+
+		p := iterator.NewPager(it, 3, "")
+		require.NotNil(t, p, "nil pager")
+
+		var total int
+
+		// The first batch contains pageSize items (3), but the second one is undersized (2).
+		// Pager will try to fetch the remaining 1 item before NextPage returns. As there are
+		// only 5 objects in the collection, the iteration finishes there with an empty nextPageToken.
+		wantToken := map[int]string{1: after1.String(), 2: ""}
+		for i := 1; ; i++ {
+			var objects []*query.Object[map[string]any]
+
+			nextPageToken, err := p.NextPage(&objects)
+			assert.NoError(t, err, "next page")
+			assert.Equal(t, wantToken[i], nextPageToken, "bad next page token for batch #%d", i)
+
+			total += len(objects)
+
+			if nextPageToken == "" {
+				break
+			}
+		}
+
+		assert.Equal(t, 5, total, "number of fetched objects")
+	})
+}

--- a/query/near_text.go
+++ b/query/near_text.go
@@ -10,9 +10,9 @@ import (
 )
 
 type NearText struct {
-	Limit                  int32            // Limit the number of results returned for the query.
-	Offset                 int32            // Skip the first N objects in the collection.
-	AutoLimit              int32            // Return objects in the first N similarity clusters.
+	Limit                  int              // Limit the number of results returned for the query.
+	Offset                 int              // Skip the first N objects in the collection.
+	AutoLimit              int              // Return objects in the first N similarity clusters.
 	After                  uuid.UUID        // Skip all objects before the one with this ID.
 	Filter                 filter.Expr      // Filter results based on their properties.
 	ReturnMetadata         ReturnMetadata   // Select query and object metadata to return for each object.
@@ -65,14 +65,14 @@ func (s *Selection) MMR() *MMR { return s.mmr }
 // NearTextFunc runs plain near text search.
 type NearTextFunc func(context.Context, NearText) (*Result, error)
 
-// nearTextFunc makes internal.Transport available to nearText via a closure.
+// nearTextFunc makes internal.Transport available to [query] via a closure.
 func nearTextFunc(t internal.Transport, rd api.RequestDefaults) NearTextFunc {
 	return func(ctx context.Context, nt NearText) (*Result, error) {
 		return query(ctx, t, request{
 			RequestDefaults:        rd,
-			Limit:                  nt.Limit,
-			AutoLimit:              nt.AutoLimit,
-			Offset:                 nt.Offset,
+			Limit:                  int32(nt.Limit),
+			AutoLimit:              int32(nt.AutoLimit),
+			Offset:                 int32(nt.Offset),
 			After:                  nt.After,
 			Filter:                 nt.Filter,
 			ReturnVectors:          nt.ReturnVectors,

--- a/query/near_vector.go
+++ b/query/near_vector.go
@@ -10,9 +10,9 @@ import (
 )
 
 type NearVector struct {
-	Limit                  int32            // Limit the number of results returned for the query.
-	Offset                 int32            // Skip the first N objects in the collection.
-	AutoLimit              int32            // Return objects in the first N similarity clusters.
+	Limit                  int              // Limit the number of results returned for the query.
+	Offset                 int              // Skip the first N objects in the collection.
+	AutoLimit              int              // Return objects in the first N similarity clusters.
 	After                  uuid.UUID        // Skip all objects before the one with this ID.
 	Filter                 filter.Expr      // Filter results based on their properties.
 	ReturnMetadata         ReturnMetadata   // Select query and object metadata to return for each object.
@@ -50,9 +50,9 @@ func nearVectorFunc(t internal.Transport, rd api.RequestDefaults) NearVectorFunc
 	return func(ctx context.Context, nv NearVector) (*Result, error) {
 		return query(ctx, t, request{
 			RequestDefaults:        rd,
-			Limit:                  nv.Limit,
-			AutoLimit:              nv.AutoLimit,
-			Offset:                 nv.Offset,
+			Limit:                  int32(nv.Limit),
+			AutoLimit:              int32(nv.AutoLimit),
+			Offset:                 int32(nv.Offset),
 			After:                  nv.After,
 			Filter:                 nv.Filter,
 			ReturnVectors:          nv.ReturnVectors,

--- a/query/over_all.go
+++ b/query/over_all.go
@@ -10,9 +10,9 @@ import (
 )
 
 type OverAll struct {
-	Limit                  int32            // Limit the number of results returned for the query.
-	Offset                 int32            // Skip the first N objects in the collection.
-	AutoLimit              int32            // Return objects in the first N similarity clusters.
+	Limit                  int              // Limit the number of results returned for the query.
+	Offset                 int              // Skip the first N objects in the collection.
+	AutoLimit              int              // Return objects in the first N similarity clusters.
 	After                  uuid.UUID        // Skip all objects before the one with this ID.
 	Filter                 filter.Expr      // Filter results based on their properties.
 	ReturnMetadata         ReturnMetadata   // Select query and object metadata to return for each object.
@@ -36,9 +36,9 @@ func overAllFunc(t internal.Transport, rd api.RequestDefaults) OverAllFunc {
 	return func(ctx context.Context, oaf OverAll) (*Result, error) {
 		return query(ctx, t, request{
 			RequestDefaults:        rd,
-			Limit:                  oaf.Limit,
-			AutoLimit:              oaf.AutoLimit,
-			Offset:                 oaf.Offset,
+			Limit:                  int32(oaf.Limit),
+			AutoLimit:              int32(oaf.AutoLimit),
+			Offset:                 int32(oaf.Offset),
 			After:                  oaf.After,
 			Filter:                 oaf.Filter,
 			ReturnVectors:          oaf.ReturnVectors,


### PR DESCRIPTION
This PR implements an object iterator compatible with Google's `iterator.Pager` following the guidelines published here: https://github.com/googleapis/google-cloud-go/wiki/Iterator-Guidelines.

The idea with using an existing pager implementation is to follow some wider-known pattern in the absence of an established iterator patter in Go std lib. Anyone familiar with Google Cloud Clients will find themselves at home; anyone new to the pattern can benefit from existing [documentation](https://github.com/googleapis/google-cloud-go/wiki/Iterator-Guidelines) and examples.

Following the naming convention, object iterator is exposed from a `collections.Handle` under the name `Objects`.

```go
songs := c.Collections.Use("Songs")
it := songs.Objects(ctx)

Play:
for {
    song, err := it.Next()
    switch err {
    case nil:
        play(song)
    case iterator.Done:
        break Play
    default:
        return err
    }
}
```

You can find more examples of working with the iterator in the guidelines doc linked above.

**Note:** it would be an interesting exercise to consider if we can have Pager work with `query.Decode` to support struct-properties. It is plain to do with the object returned from `Next`.

An important detail is that the `iterator` package has, presumably, been published before Go got generics, so Pager is not generic in the type of the objects it produces. Instead, it [relies on reflection to assign the result to its destination](https://github.com/googleapis/google-api-go-client/blob/8f434ff91fe8dc299942ecd7c87ebab151ff38e5/iterator/iterator.go#L207-L225). My understanding is that any performance overhead from using reflection is amortized over the size of the batch, i.e. we fetch 100 objects and assign them once, and then reflection is not used until the next batch is fetched. We can decide to fork / adapt the code from the `iterator` package in the future to avoid that, but I think it is a reasonable solution at the moment.

Reference RFC: https://app.notion.com/p/weaviate/RFC-Iterator-Pagination-35170562ccd6802aa8e9e840d7ff5683