### PR TITLE
fix(client): wire Users and Groups into newClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -138,6 +138,8 @@ func newClient(ctx context.Context, options []Option) (*Client, error) {
 		Collections: collections.NewClient(t),
 		Backup:      backup.NewClient(t),
 		Roles:       rbac.NewRolesClient(t),
+		Users:       rbac.NewUsersClient(t),
+		Groups:      rbac.NewGroupsClient(t),
 	}, nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -215,6 +215,8 @@ func TestNewWeaviateCloud(t *testing.T) {
 		assert.NotNil(t, c.Collections, "nil collections")
 		assert.NotNil(t, c.Backup, "nil backup")
 		assert.NotNil(t, c.Roles, "nil roles")
+		assert.NotNil(t, c.Users, "nil users")
+		assert.NotNil(t, c.Groups, "nil groups")
 	})
 }
 


### PR DESCRIPTION
## What

Wire the `Users` and `Groups` RBAC sub-clients into `newClient` so that `client.Users` and `client.Groups` are non-nil after construction.

## Why

The `Client` struct already declared the `Users *rbac.UsersClient` and `Groups *rbac.GroupsClient` fields, but `newClient` never initialised them, leaving both zero-valued. This adds the two missing constructor calls (`rbac.NewUsersClient` / `rbac.NewGroupsClient`), matching the existing wiring for `Roles`, `Backup`, and `Collections`. `Users.DB` and `Users.OIDC` are both initialised by the constructor.

## Tests

- Added `NotNil` assertions for `Users` and `Groups` to the existing `TestNewWeaviateCloud` "namespaces" sub-test, consistent with how the other subsystems are checked at this level.
- Underlying behaviour of `UsersClient` / `GroupsClient` is already covered in `rbac/users_test.go` and `rbac/groups_test.go`.
- `go test ./...` and `go vet ./...` pass.