### PR TITLE
feat(backup): add IncrementalBaseBackupID to list/status responses

### DIFF
--- a/backup/client.go
+++ b/backup/client.go
@@ -38,6 +38,12 @@ type Info struct {
 	// this value only exists for completed backups.
 	SizeGiB *float32
 
+	// IncrementalBaseBackupID is the ID of the base backup this incremental
+	// backup was built on. It is empty when the backup is not incremental.
+	// It is populated for status and list responses on backups created with
+	// PrefixIncremental set.
+	IncrementalBaseBackupID string
+
 	c         *Client
 	operation api.BackupOperation
 }
@@ -254,6 +260,8 @@ func infoFromAPI(bak *api.BackupInfo, c *Client, op api.BackupOperation) Info {
 		CompletedAt:         bak.CompletedAt,
 		IncludesCollections: bak.IncludesCollections,
 		SizeGiB:             bak.SizeGiB,
+
+		IncrementalBaseBackupID: bak.IncrementalBaseBackupID,
 
 		operation: op,
 		c:         c,

--- a/backup/client_test.go
+++ b/backup/client_test.go
@@ -223,6 +223,111 @@ func TestClient_List(t *testing.T) {
 	}
 }
 
+// TestClient_IncrementalBaseBackupID verifies that the IncrementalBaseBackupID
+// returned by the server is surfaced on backup.Info for both the create-status
+// getter and the list endpoint, and that it stays empty for non-incremental
+// backups. This mirrors the behavior added on main (commit 480aa7e), adapted to
+// v6's mock-based client tests.
+func TestClient_IncrementalBaseBackupID(t *testing.T) {
+	const (
+		backend      = "filesystem"
+		baseBackupID = "incr-base-1"
+		incrBackupID = "incr-child-1"
+	)
+
+	t.Run("create status surfaces IncrementalBaseBackupID", func(t *testing.T) {
+		stubs := []testkit.Stub[api.BackupStatusRequest, api.BackupInfo]{
+			{
+				Request: &api.BackupStatusRequest{
+					Backend:   backend,
+					ID:        incrBackupID,
+					Operation: api.BackupOperationCreate,
+				},
+				Response: api.BackupInfo{
+					Backend:                 backend,
+					ID:                      incrBackupID,
+					Status:                  api.BackupStatusSuccess,
+					IncrementalBaseBackupID: baseBackupID,
+				},
+			},
+		}
+		transport := testkit.NewTransport(t, stubs)
+		c := backup.NewClient(transport)
+		require.NotNil(t, c, "nil client")
+
+		got, err := c.GetCreateStatus(t.Context(), backup.GetStatus{
+			Backend: backend,
+			ID:      incrBackupID,
+		})
+		require.NoError(t, err, "get create status")
+		require.NotNil(t, got, "nil info")
+		require.Equal(t, baseBackupID, got.IncrementalBaseBackupID,
+			"IncrementalBaseBackupID should match the base backup ID")
+	})
+
+	t.Run("create status leaves IncrementalBaseBackupID empty for base backup", func(t *testing.T) {
+		stubs := []testkit.Stub[api.BackupStatusRequest, api.BackupInfo]{
+			{
+				Request: &api.BackupStatusRequest{
+					Backend:   backend,
+					ID:        baseBackupID,
+					Operation: api.BackupOperationCreate,
+				},
+				Response: api.BackupInfo{
+					Backend: backend,
+					ID:      baseBackupID,
+					Status:  api.BackupStatusSuccess,
+				},
+			},
+		}
+		transport := testkit.NewTransport(t, stubs)
+		c := backup.NewClient(transport)
+		require.NotNil(t, c, "nil client")
+
+		got, err := c.GetCreateStatus(t.Context(), backup.GetStatus{
+			Backend: backend,
+			ID:      baseBackupID,
+		})
+		require.NoError(t, err, "get create status")
+		require.NotNil(t, got, "nil info")
+		require.Empty(t, got.IncrementalBaseBackupID,
+			"base backup should not have IncrementalBaseBackupID")
+	})
+
+	t.Run("list surfaces IncrementalBaseBackupID", func(t *testing.T) {
+		stubs := []testkit.Stub[api.ListBackupsRequest, []api.BackupInfo]{
+			{
+				Request: &api.ListBackupsRequest{Backend: backend},
+				Response: []api.BackupInfo{
+					{ID: baseBackupID, Status: api.BackupStatusSuccess},
+					{
+						ID:                      incrBackupID,
+						Status:                  api.BackupStatusSuccess,
+						IncrementalBaseBackupID: baseBackupID,
+					},
+				},
+			},
+		}
+		transport := testkit.NewTransport(t, stubs)
+		c := backup.NewClient(transport)
+		require.NotNil(t, c, "nil client")
+
+		got, err := c.List(t.Context(), backup.List{Backend: backend})
+		require.NoError(t, err, "list backups")
+		require.Len(t, got, 2, "returned backups")
+
+		byID := make(map[string]backup.Info, len(got))
+		for _, b := range got {
+			byID[b.ID] = b
+		}
+
+		require.Equal(t, baseBackupID, byID[incrBackupID].IncrementalBaseBackupID,
+			"incremental backup should reference the base backup ID")
+		require.Empty(t, byID[baseBackupID].IncrementalBaseBackupID,
+			"base backup should not have IncrementalBaseBackupID")
+	})
+}
+
 func TestClient_Cancel(t *testing.T) {
 	for _, tt := range []struct {
 		name   string

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -22,6 +22,10 @@ type BackupInfo struct {
 	CompletedAt         *time.Time
 	IncludesCollections []string
 	SizeGiB             *float32
+
+	// IncrementalBaseBackupID is the ID of the base backup this incremental
+	// backup was built on; empty if the backup is not incremental.
+	IncrementalBaseBackupID string
 }
 
 var _ json.Unmarshaler = (*BackupInfo)(nil)
@@ -232,6 +236,8 @@ func (b *BackupInfo) UnmarshalJSON(data []byte) error {
 		StartedAt           *time.Time `json:"startedAt,omitempty"`
 		CompletedAt         *time.Time `json:"completedAt,omitempty"`
 		SizeGiB             *float32   `json:"size,omitempty"`
+
+		IncrementalBaseBackupID string `json:"incremental_base_backup_id,omitempty"`
 	}
 
 	if err := json.Unmarshal(data, &bak); err != nil {
@@ -249,6 +255,8 @@ func (b *BackupInfo) UnmarshalJSON(data []byte) error {
 		CompletedAt:         bak.CompletedAt,
 		IncludesCollections: bak.IncludesCollections,
 		SizeGiB:             bak.SizeGiB,
+
+		IncrementalBaseBackupID: bak.IncrementalBaseBackupID,
 	}
 	return nil
 }


### PR DESCRIPTION
## What

Ports the `IncrementalBaseBackupID` field into the v6 backup API. This is the v6 equivalent of #409 (`480aa7e`) on `main`, which could not be cherry-picked because v6 is a rewrite with a different module path and no dependency on `github.com/weaviate/weaviate`.
