### PR TITLE
feat(client): export HTTPError type

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package weaviate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/transport"
 	"github.com/weaviate/weaviate-go-client/v6/internal/auth"
+	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
 	"github.com/weaviate/weaviate-go-client/v6/rbac"
 	"golang.org/x/oauth2"
 )
@@ -118,17 +120,7 @@ func newClient(ctx context.Context, options []Option) (*Client, error) {
 		c.Header.Add(headerWeaviateClusterURL, clusterURL)
 	}
 
-	t, err := transport.New(ctx, transport.Config{
-		Scheme:   c.Scheme,
-		RESTHost: c.RESTHost,
-		RESTPort: c.RESTPort,
-		GRPCHost: c.GRPCHost,
-		GRPCPort: c.GRPCPort,
-		Header:   c.Header,
-		Auth:     c.Auth,
-		Timeout:  c.Timeout,
-		Version:  api.Version,
-	})
+	t, err := newTransport(ctx, c)
 	if err != nil {
 		return nil, fmt.Errorf("weaviate: new client: %w", err)
 	}
@@ -313,4 +305,64 @@ func (c *Client) Close() error {
 		return cl.Close()
 	}
 	return nil
+}
+
+// HTTPError is returned if the underlying REST request returns an unexpected error code.
+type HTTPError struct {
+	httpErr *transports.HTTPError
+
+	Code int    // HTTP status code.
+	Body string // Response body, if any.
+}
+
+func (err *HTTPError) Error() string {
+	return err.httpErr.Error()
+}
+
+// errorTransport maps errors returned by the underlying transport to their public variants.
+type errorTransport struct{ t internal.Transport }
+
+func (et *errorTransport) Do(ctx context.Context, req, dest any) error {
+	err := et.t.Do(ctx, req, dest)
+	if err == nil {
+		return nil
+	}
+
+	var httpErr *transports.HTTPError
+	switch {
+	case errors.As(err, &httpErr):
+		err = &HTTPError{
+			httpErr: httpErr,
+			Code:    httpErr.Code,
+			Body:    httpErr.Body,
+		}
+	}
+	return err
+}
+
+func (et *errorTransport) Close() error {
+	if cl, ok := et.t.(io.Closer); ok {
+		return cl.Close()
+	}
+	return nil
+}
+
+// newTransport returns an [internal.Transport] for REST and gRPC requests.
+func newTransport(ctx context.Context, c config) (internal.Transport, error) {
+	t, err := transport.New(ctx, transport.Config{
+		Scheme:   c.Scheme,
+		RESTHost: c.RESTHost,
+		RESTPort: c.RESTPort,
+		GRPCHost: c.GRPCHost,
+		GRPCPort: c.GRPCPort,
+		Header:   c.Header,
+		Auth:     c.Auth,
+		Timeout:  c.Timeout,
+		Version:  api.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &errorTransport{t}, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package weaviate_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/transport"
 	"github.com/weaviate/weaviate-go-client/v6/internal/auth"
 	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
 	"golang.org/x/oauth2"
 )
 
@@ -422,4 +424,62 @@ type spyCloser bool
 func (spy *spyCloser) Close() error {
 	*spy = true
 	return nil
+}
+
+func TestClientHTTPError(t *testing.T) {
+	newFunc := transport.New
+	t.Cleanup(func() { transport.New = newFunc })
+
+	for _, tt := range []struct {
+		err  error
+		want *weaviate.HTTPError
+	}{
+		{
+			err: &transports.HTTPError{
+				Code: http.StatusBadRequest,
+				Body: "Bad Request",
+			},
+			want: &weaviate.HTTPError{
+				Code: http.StatusBadRequest,
+				Body: "Bad Request",
+			},
+		},
+		{
+			err: fmt.Errorf("more context: %w", &transports.HTTPError{
+				Code: http.StatusBadRequest,
+				Body: "Bad Request",
+			}),
+			want: &weaviate.HTTPError{
+				Code: http.StatusBadRequest,
+				Body: "Bad Request",
+			},
+		},
+		{
+			err:  testkit.ErrWhaam,
+			want: nil,
+		},
+	} {
+		t.Run(fmt.Sprintf("%T=%t", tt.err, tt.want == nil), func(t *testing.T) {
+			transport.New = func(context.Context, transport.Config) (internal.Transport, error) {
+				return testkit.TransportFunc(func(context.Context, any, any) error {
+					return tt.err
+				}), nil
+			}
+
+			c, err := weaviate.NewClient(t.Context())
+			assert.NoError(t, err, "new client")
+			require.NotNil(t, c, "nil client")
+
+			_, err = c.IsLive(t.Context())
+
+			if tt.want == nil {
+				assert.NotErrorIs(t, err, tt.want)
+			} else {
+				var got *weaviate.HTTPError
+				if assert.ErrorAs(t, err, &got) {
+					assert.EqualExportedValues(t, tt.want, got)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR exports HTTPError via the public API (`weaviate.HTTPError`) so that the user can check if the underlying error was an HTTP error and access its code and response body.

```go
_, err := c.Roles.Delete(ctx, "role-i-have-no-access-to")

var httpErr *weaviate.HTTPError
if errors.As(err, &httpErr) {
  log.Print(httpErr.Code)
  log.Print(httpErr.Body)
}
```