### PR TITLE
v6: Aliases

### DIFF
--- a/alias/client.go
+++ b/alias/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/weaviate/weaviate-go-client/v6/collections"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
@@ -18,10 +19,8 @@ type Client struct {
 	transport internal.Transport
 }
 
-type Alias api.Alias
-
 // Create a new alias for a collection.
-func (c *Client) Create(ctx context.Context, a Alias) error {
+func (c *Client) Create(ctx context.Context, a collections.Alias) error {
 	req := &api.CreateAliasRequest{
 		Alias: api.Alias(a),
 	}
@@ -32,30 +31,30 @@ func (c *Client) Create(ctx context.Context, a Alias) error {
 }
 
 // Get the alias by name if one exists.
-func (c *Client) Get(ctx context.Context, alias string) (*Alias, error) {
+func (c *Client) Get(ctx context.Context, alias string) (*collections.Alias, error) {
 	var a api.Alias
 	if err := c.transport.Do(ctx, api.GetAliasRequest(alias), &a); err != nil {
 		return nil, fmt.Errorf("get alias: %w", err)
 	}
-	return (*Alias)(&a), nil
+	return (*collections.Alias)(&a), nil
 }
 
 // List all defined aliases.
-func (c *Client) List(ctx context.Context) ([]Alias, error) {
+func (c *Client) List(ctx context.Context) ([]collections.Alias, error) {
 	var list api.ListAliasesResponse
 	if err := c.transport.Do(ctx, api.ListAliasesRequest, &list); err != nil {
 		return nil, fmt.Errorf("list aliases: %w", err)
 	}
 
-	aliases := make([]Alias, len(list))
+	aliases := make([]collections.Alias, len(list))
 	for i := range list {
-		aliases[i] = Alias(list[i])
+		aliases[i] = collections.Alias(list[i])
 	}
 	return aliases, nil
 }
 
 // Update re-assigns the alias to a different collection.
-func (c *Client) Update(ctx context.Context, a Alias) error {
+func (c *Client) Update(ctx context.Context, a collections.Alias) error {
 	req := &api.UpdateAliasRequest{
 		Alias: api.Alias(a),
 	}

--- a/alias/client.go
+++ b/alias/client.go
@@ -1,0 +1,74 @@
+package alias
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
+)
+
+func NewClient(t internal.Transport) *Client {
+	dev.AssertNotNil(t, "transport")
+	return &Client{transport: t}
+}
+
+type Client struct {
+	transport internal.Transport
+}
+
+type Alias api.Alias
+
+// Create a new alias for a collection.
+func (c *Client) Create(ctx context.Context, a Alias) error {
+	req := &api.CreateAliasRequest{
+		Alias: api.Alias(a),
+	}
+	if err := c.transport.Do(ctx, req, nil); err != nil {
+		return fmt.Errorf("create alias: %w", err)
+	}
+	return nil
+}
+
+// Get the alias by name if one exists.
+func (c *Client) Get(ctx context.Context, alias string) (*Alias, error) {
+	var a api.Alias
+	if err := c.transport.Do(ctx, api.GetAliasRequest(alias), &a); err != nil {
+		return nil, fmt.Errorf("get alias: %w", err)
+	}
+	return (*Alias)(&a), nil
+}
+
+// List all defined aliases.
+func (c *Client) List(ctx context.Context) ([]Alias, error) {
+	var list api.ListAliasesResponse
+	if err := c.transport.Do(ctx, api.ListAliasesRequest, &list); err != nil {
+		return nil, fmt.Errorf("list aliases: %w", err)
+	}
+
+	aliases := make([]Alias, len(list))
+	for i := range list {
+		aliases[i] = Alias(list[i])
+	}
+	return aliases, nil
+}
+
+// Update re-assigns the alias to a different collection.
+func (c *Client) Update(ctx context.Context, a Alias) error {
+	req := &api.UpdateAliasRequest{
+		Alias: api.Alias(a),
+	}
+	if err := c.transport.Do(ctx, req, nil); err != nil {
+		return fmt.Errorf("update alias: %w", err)
+	}
+	return nil
+}
+
+// Delete the alias by name.
+func (c *Client) Delete(ctx context.Context, alias string) error {
+	if err := c.transport.Do(ctx, api.DeleteAliasRequest(alias), nil); err != nil {
+		return fmt.Errorf("delete alias: %w", err)
+	}
+	return nil
+}

--- a/alias/client_test.go
+++ b/alias/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate-go-client/v6/alias"
+	"github.com/weaviate/weaviate-go-client/v6/collections"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
 )
@@ -18,13 +19,13 @@ func TestNewClient(t *testing.T) {
 func TestClient_Create(t *testing.T) {
 	for _, tt := range []struct {
 		name  string
-		alias alias.Alias
+		alias collections.Alias
 		stubs []testkit.Stub[api.CreateAliasRequest, any]
 		err   testkit.Error // Expected error.
 	}{
 		{
 			name: "successfully",
-			alias: alias.Alias{
+			alias: collections.Alias{
 				Collection: "GeorgeBarnes",
 				Alias:      "MachineGunKelly",
 			},
@@ -63,7 +64,7 @@ func TestClient_Get(t *testing.T) {
 		name  string
 		alias string
 		stubs []testkit.Stub[any, api.Alias]
-		want  *alias.Alias
+		want  *collections.Alias
 		err   testkit.Error // Expected error.
 	}{
 		{
@@ -78,7 +79,7 @@ func TestClient_Get(t *testing.T) {
 					},
 				},
 			},
-			want: &alias.Alias{
+			want: &collections.Alias{
 				Collection: "GeorgeBarnes",
 				Alias:      "MachineGunKelly",
 			},
@@ -109,7 +110,7 @@ func TestClient_List(t *testing.T) {
 		name  string
 		alias string
 		stubs []testkit.Stub[any, api.ListAliasesResponse]
-		want  []alias.Alias
+		want  []collections.Alias
 		err   testkit.Error // Expected error.
 	}{
 		{
@@ -124,7 +125,7 @@ func TestClient_List(t *testing.T) {
 					},
 				},
 			},
-			want: []alias.Alias{
+			want: []collections.Alias{
 				{Collection: "GeorgeBarnes", Alias: "MachineGunKelly"},
 				{Collection: "LouisAttanasio", Alias: "LouieHaHa"},
 			},
@@ -153,13 +154,13 @@ func TestClient_List(t *testing.T) {
 func TestClient_Update(t *testing.T) {
 	for _, tt := range []struct {
 		name  string
-		alias alias.Alias
+		alias collections.Alias
 		stubs []testkit.Stub[api.UpdateAliasRequest, any]
 		err   testkit.Error // Expected error.
 	}{
 		{
 			name: "successfully",
-			alias: alias.Alias{
+			alias: collections.Alias{
 				Collection: "GeorgeBarnes",
 				Alias:      "MachineGunKelly",
 			},

--- a/alias/client_test.go
+++ b/alias/client_test.go
@@ -1,0 +1,230 @@
+package alias_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/alias"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+)
+
+func TestNewClient(t *testing.T) {
+	require.Panics(t, func() {
+		alias.NewClient(nil)
+	}, "nil transport")
+}
+
+func TestClient_Create(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		alias alias.Alias
+		stubs []testkit.Stub[api.CreateAliasRequest, any]
+		err   testkit.Error // Expected error.
+	}{
+		{
+			name: "successfully",
+			alias: alias.Alias{
+				Collection: "GeorgeBarnes",
+				Alias:      "MachineGunKelly",
+			},
+			stubs: []testkit.Stub[api.CreateAliasRequest, any]{
+				{
+					Request: &api.CreateAliasRequest{
+						Alias: api.Alias{
+							Collection: "GeorgeBarnes",
+							Alias:      "MachineGunKelly",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.CreateAliasRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := alias.NewClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			err := c.Create(t.Context(), tt.alias)
+			tt.err.Require(t, err, "create error")
+		})
+	}
+}
+
+func TestClient_Get(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		alias string
+		stubs []testkit.Stub[any, api.Alias]
+		want  *alias.Alias
+		err   testkit.Error // Expected error.
+	}{
+		{
+			name:  "successfully",
+			alias: "MachineGunKelly",
+			stubs: []testkit.Stub[any, api.Alias]{
+				{
+					Request: testkit.Ptr(api.GetAliasRequest("MachineGunKelly")),
+					Response: api.Alias{
+						Collection: "GeorgeBarnes",
+						Alias:      "MachineGunKelly",
+					},
+				},
+			},
+			want: &alias.Alias{
+				Collection: "GeorgeBarnes",
+				Alias:      "MachineGunKelly",
+			},
+		},
+		{
+			name:  "with error",
+			alias: "MachineGunKelly",
+			stubs: []testkit.Stub[any, api.Alias]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := alias.NewClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.Get(t.Context(), tt.alias)
+			tt.err.Require(t, err, "get error")
+			require.EqualExportedValues(t, tt.want, got, "returned alias")
+		})
+	}
+}
+
+func TestClient_List(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		alias string
+		stubs []testkit.Stub[any, api.ListAliasesResponse]
+		want  []alias.Alias
+		err   testkit.Error // Expected error.
+	}{
+		{
+			name:  "successfully",
+			alias: "MachineGunKelly",
+			stubs: []testkit.Stub[any, api.ListAliasesResponse]{
+				{
+					Request: testkit.Ptr[any](api.ListAliasesRequest),
+					Response: api.ListAliasesResponse{
+						{Collection: "GeorgeBarnes", Alias: "MachineGunKelly"},
+						{Collection: "LouisAttanasio", Alias: "LouieHaHa"},
+					},
+				},
+			},
+			want: []alias.Alias{
+				{Collection: "GeorgeBarnes", Alias: "MachineGunKelly"},
+				{Collection: "LouisAttanasio", Alias: "LouieHaHa"},
+			},
+		},
+		{
+			name:  "with error",
+			alias: "MachineGunKelly",
+			stubs: []testkit.Stub[any, api.ListAliasesResponse]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := alias.NewClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.List(t.Context())
+			tt.err.Require(t, err, "list error")
+			require.EqualExportedValues(t, tt.want, got, "returned aliases")
+		})
+	}
+}
+
+func TestClient_Update(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		alias alias.Alias
+		stubs []testkit.Stub[api.UpdateAliasRequest, any]
+		err   testkit.Error // Expected error.
+	}{
+		{
+			name: "successfully",
+			alias: alias.Alias{
+				Collection: "GeorgeBarnes",
+				Alias:      "MachineGunKelly",
+			},
+			stubs: []testkit.Stub[api.UpdateAliasRequest, any]{
+				{
+					Request: &api.UpdateAliasRequest{
+						Alias: api.Alias{
+							Collection: "GeorgeBarnes",
+							Alias:      "MachineGunKelly",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.UpdateAliasRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := alias.NewClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			err := c.Update(t.Context(), tt.alias)
+			tt.err.Require(t, err, "update error")
+		})
+	}
+}
+
+func TestClient_Delete(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		alias string
+		stubs []testkit.Stub[any, any]
+		err   testkit.Error // Expected error.
+	}{
+		{
+			name:  "successfully",
+			alias: "MachineGunKelly",
+			stubs: []testkit.Stub[any, any]{
+				{
+					Request: testkit.Ptr(api.DeleteAliasRequest("MachineGunKelly")),
+				},
+			},
+		},
+		{
+			name:  "with error",
+			alias: "MachineGunKelly",
+			stubs: []testkit.Stub[any, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := alias.NewClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			err := c.Delete(t.Context(), tt.alias)
+			tt.err.Require(t, err, "delete error")
+		})
+	}
+}

--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/weaviate/weaviate-go-client/v6/alias"
 	"github.com/weaviate/weaviate-go-client/v6/backup"
 	"github.com/weaviate/weaviate-go-client/v6/collections"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
@@ -22,6 +23,7 @@ import (
 type Client struct {
 	transport internal.Transport
 
+	Alias       *alias.Client
 	Backup      *backup.Client
 	Collections *collections.Client
 	Roles       *rbac.RolesClient
@@ -135,6 +137,7 @@ func newClient(ctx context.Context, options []Option) (*Client, error) {
 
 	return &Client{
 		transport:   t,
+		Alias:       alias.NewClient(t),
 		Collections: collections.NewClient(t),
 		Backup:      backup.NewClient(t),
 		Roles:       rbac.NewRolesClient(t),

--- a/client_test.go
+++ b/client_test.go
@@ -212,8 +212,9 @@ func TestNewWeaviateCloud(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, c, "nil client")
 
-		assert.NotNil(t, c.Collections, "nil collections")
+		assert.NotNil(t, c.Alias, "nil alias")
 		assert.NotNil(t, c.Backup, "nil backup")
+		assert.NotNil(t, c.Collections, "nil collections")
 		assert.NotNil(t, c.Roles, "nil roles")
 		assert.NotNil(t, c.Users, "nil users")
 		assert.NotNil(t, c.Groups, "nil groups")

--- a/collections/collection.go
+++ b/collections/collection.go
@@ -5,6 +5,9 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
 )
 
+// Alias defines an alias for a collection.
+type Alias api.Alias
+
 type (
 	Collection struct {
 		Name          string

--- a/internal/api/alias.go
+++ b/internal/api/alias.go
@@ -70,3 +70,17 @@ func (a *Alias) UnmarshalJSON(data []byte) error {
 	}
 	return nil
 }
+
+func (r *ListAliasesResponse) UnmarshalJSON(data []byte) error {
+	var list rest.AliasResponse
+	if err := json.Unmarshal(data, &list); err != nil {
+		return err
+	}
+	for _, a := range list.Aliases {
+		*r = append(*r, Alias{
+			Collection: a.Class,
+			Alias:      a.Alias,
+		})
+	}
+	return nil
+}

--- a/internal/api/alias.go
+++ b/internal/api/alias.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/rest"
+	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
+)
+
+type Alias struct {
+	Collection string
+	Alias      string
+}
+
+type CreateAliasRequest struct {
+	transports.BaseEndpoint
+	Alias
+}
+
+var _ transports.Endpoint = (*CreateAliasRequest)(nil)
+
+func (CreateAliasRequest) Method() string { return http.MethodPost }
+func (CreateAliasRequest) Path() string   { return "/aliases" }
+func (r *CreateAliasRequest) Body() any {
+	return &rest.AliasesCreateJSONRequestBody{
+		Class: r.Collection,
+		Alias: r.Alias.Alias,
+	}
+}
+
+var (
+	// GetAliasRequest retrieves an alias by name.
+	// Use with [Alias] response dest.
+	GetAliasRequest = transports.IdentityEndpoint[string](http.MethodGet, "/aliases/%s")
+	// DeleteAliasesRequests deletes an alias by name.
+	DeleteAliasRequest = transports.IdentityEndpoint[string](http.MethodDelete, "/aliases/%s")
+	// ListAliasesRequests lists all defined aliases.
+	// Use with [ListAliasesResponse].
+	ListAliasesRequest = transports.StaticEndpoint(http.MethodGet, "/aliases")
+)
+
+// ListAliasesResponse unmarshals a collection of aliases.
+type ListAliasesResponse []Alias
+
+// UpdateAliasRequests assigns an existing alias to a different collection.
+type UpdateAliasRequest struct {
+	transports.BaseEndpoint
+	Alias
+}
+
+var _ transports.Endpoint = (*UpdateAliasRequest)(nil)
+
+func (UpdateAliasRequest) Method() string  { return http.MethodPut }
+func (r *UpdateAliasRequest) Path() string { return "/aliases/" + r.Alias.Alias }
+func (r *UpdateAliasRequest) Body() any {
+	return &rest.AliasesUpdateJSONRequestBody{
+		Class: r.Collection,
+	}
+}
+
+func (a *Alias) UnmarshalJSON(data []byte) error {
+	var alias rest.Alias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*a = Alias{
+		Collection: alias.Class,
+		Alias:      alias.Alias,
+	}
+	return nil
+}

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -1065,6 +1065,53 @@ func TestRESTRequests(t *testing.T) {
 			wantPath:   "/users/db",
 			wantQuery:  url.Values{"includeLastUsedTime": {"true"}},
 		},
+		{
+			name:       "list aliases",
+			req:        api.ListAliasesRequest,
+			wantMethod: http.MethodGet,
+			wantPath:   "/aliases",
+		},
+		{
+			name: "create alias",
+			req: &api.CreateAliasRequest{
+				Alias: api.Alias{
+					Collection: "GeorgeBarnes",
+					Alias:      "MachineGunKelly",
+				},
+			},
+			wantMethod: http.MethodPost,
+			wantPath:   "/aliases",
+			wantBody: rest.AliasesCreateJSONRequestBody{
+				Class: "GeorgeBarnes",
+				Alias: "MachineGunKelly",
+			},
+		},
+		{
+			name:       "get an alias",
+			req:        api.GetAliasRequest("MachineGunKelly"),
+			wantMethod: http.MethodGet,
+			wantPath:   "/aliases/MachineGunKelly",
+		},
+		{
+			name: "update an alias",
+			req: &api.UpdateAliasRequest{
+				Alias: api.Alias{
+					Alias:      "MachineGunKelly",
+					Collection: "ColsonBaker",
+				},
+			},
+			wantMethod: http.MethodPut,
+			wantPath:   "/aliases/MachineGunKelly",
+			wantBody: rest.AliasesUpdateJSONRequestBody{
+				Class: "ColsonBaker",
+			},
+		},
+		{
+			name:       "delete an alias",
+			req:        api.DeleteAliasRequest("MachineGunKelly"),
+			wantMethod: http.MethodDelete,
+			wantPath:   "/aliases/MachineGunKelly",
+		},
 	}) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Implements(t, (*transports.Endpoint)(nil), tt.req)

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -1136,7 +1136,9 @@ func TestRESTRequests(t *testing.T) {
 // TestRESTResponses verifies that response objects in the 'api' package
 // unmarshal response JSONs correctly.
 func TestRESTResponses(t *testing.T) {
-	for _, tt := range []struct {
+	for _, tt := range testkit.WithOnly(t, []struct {
+		testkit.Only
+
 		name string
 		body any // Response body.
 		dest any // Set dest to a pointer to the response struct.
@@ -1869,7 +1871,33 @@ func TestRESTResponses(t *testing.T) {
 			dest: new(api.ListGroupsResponse),
 			want: &api.ListGroupsResponse{"internal", "external"},
 		},
-	} {
+		{
+			name: "get alias",
+			body: &rest.Alias{
+				Class: "GeorgeBarnes",
+				Alias: "MachineGunKelly",
+			},
+			dest: new(api.Alias),
+			want: &api.Alias{
+				Collection: "GeorgeBarnes",
+				Alias:      "MachineGunKelly",
+			},
+		},
+		{
+			name: "list aliases",
+			body: &rest.AliasResponse{
+				Aliases: []rest.Alias{
+					{Class: "GeorgeBarnes", Alias: "MachineGunKelly"},
+					{Class: "LouisAttanasio", Alias: "LouieHaHa"},
+				},
+			},
+			dest: new(api.ListAliasesResponse),
+			want: &api.ListAliasesResponse{
+				{Collection: "GeorgeBarnes", Alias: "MachineGunKelly"},
+				{Collection: "LouisAttanasio", Alias: "LouieHaHa"},
+			},
+		},
+	}) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.NotNil(t, tt.body, "incomplete test case: body is nil")
 			testkit.RequirePointer(t, tt.body, "body")


### PR DESCRIPTION
This PR adds a CRUD client for `/aliases` endpoints.

```go
c.Alias.Create(ctx, alias.Alias{Collection: "Alex", Alias: "A"})
c.Alias.Get(ctx, "A")
c.Alias.List(ctx)
c.Alias.Update(ctx, alias.Alias{Alias: "A", Collection: "Anna"})
c.Alias.Delete(ctx, "A")
```