### PR TITLE
v6: Tenants API

### DIFF
--- a/collections/client.go
+++ b/collections/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
 	"github.com/weaviate/weaviate-go-client/v6/query"
+	"github.com/weaviate/weaviate-go-client/v6/tenant"
 	"github.com/weaviate/weaviate-go-client/v6/types"
 )
 
@@ -53,6 +54,7 @@ type Handle struct {
 	Aggregate *aggregate.Client
 	Data      *data.Client
 	Query     *query.Client
+	Tenants   *tenant.Client
 }
 
 func newHandle(t internal.Transport, rd api.RequestDefaults) *Handle {
@@ -65,6 +67,7 @@ func newHandle(t internal.Transport, rd api.RequestDefaults) *Handle {
 		Aggregate: aggregate.NewClient(t, rd),
 		Data:      data.NewClient(t, rd),
 		Query:     query.NewClient(t, rd),
+		Tenants:   tenant.NewClient(t, rd.CollectionName),
 	}
 }
 

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -1112,6 +1112,50 @@ func TestRESTRequests(t *testing.T) {
 			wantMethod: http.MethodDelete,
 			wantPath:   "/aliases/MachineGunKelly",
 		},
+		{
+			name: "create tenants",
+			req: &api.CreateTenantsRequest{
+				Collection: "Songs",
+				Tenants: []api.Tenant{
+					{Name: "john_doe", Status: api.TenantStatusActive},
+					{Name: "jane_doe", Status: api.TenantStatusFrozen},
+				},
+			},
+			wantMethod: http.MethodPost,
+			wantPath:   "/schema/Songs/tenants",
+			wantBody: rest.TenantsCreateJSONRequestBody{
+				{Name: "john_doe", ActivityStatus: rest.ACTIVE},
+				{Name: "jane_doe", ActivityStatus: rest.FROZEN},
+			},
+		},
+		{
+			name: "update tenants",
+			req: &api.UpdateTenantsRequest{
+				Collection: "Songs",
+				Tenants: []api.Tenant{
+					{Name: "john_doe", Status: api.TenantStatusActive},
+					{Name: "jane_doe", Status: api.TenantStatusFrozen},
+				},
+			},
+			wantMethod: http.MethodPut,
+			wantPath:   "/schema/Songs/tenants",
+			wantBody: rest.TenantsUpdateJSONRequestBody{
+				{Name: "john_doe", ActivityStatus: rest.ACTIVE},
+				{Name: "jane_doe", ActivityStatus: rest.FROZEN},
+			},
+		},
+		{
+			name: "delete tenants",
+			req: &api.DeleteTenantsRequest{
+				Collection: "Songs",
+				Tenants:    []string{"john_doe", "jane_doe"},
+			},
+			wantMethod: http.MethodDelete,
+			wantPath:   "/schema/Songs/tenants",
+			wantBody: rest.TenantsDeleteJSONRequestBody{
+				"john_doe", "jane_doe",
+			},
+		},
 	}) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Implements(t, (*transports.Endpoint)(nil), tt.req)

--- a/internal/api/internal/gen/proto/v1/tenants.pb.go
+++ b/internal/api/internal/gen/proto/v1/tenants.pb.go
@@ -7,11 +7,12 @@
 package protocol
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -365,15 +366,17 @@ func file_v1_tenants_proto_rawDescGZIP() []byte {
 	return file_v1_tenants_proto_rawDescData
 }
 
-var file_v1_tenants_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_v1_tenants_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
-var file_v1_tenants_proto_goTypes = []any{
-	(TenantActivityStatus)(0), // 0: weaviate.v1.TenantActivityStatus
-	(*TenantsGetRequest)(nil), // 1: weaviate.v1.TenantsGetRequest
-	(*TenantNames)(nil),       // 2: weaviate.v1.TenantNames
-	(*TenantsGetReply)(nil),   // 3: weaviate.v1.TenantsGetReply
-	(*Tenant)(nil),            // 4: weaviate.v1.Tenant
-}
+var (
+	file_v1_tenants_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+	file_v1_tenants_proto_msgTypes  = make([]protoimpl.MessageInfo, 4)
+	file_v1_tenants_proto_goTypes   = []any{
+		(TenantActivityStatus)(0), // 0: weaviate.v1.TenantActivityStatus
+		(*TenantsGetRequest)(nil), // 1: weaviate.v1.TenantsGetRequest
+		(*TenantNames)(nil),       // 2: weaviate.v1.TenantNames
+		(*TenantsGetReply)(nil),   // 3: weaviate.v1.TenantsGetReply
+		(*Tenant)(nil),            // 4: weaviate.v1.Tenant
+	}
+)
 var file_v1_tenants_proto_depIdxs = []int32{
 	2, // 0: weaviate.v1.TenantsGetRequest.names:type_name -> weaviate.v1.TenantNames
 	4, // 1: weaviate.v1.TenantsGetReply.tenants:type_name -> weaviate.v1.Tenant

--- a/internal/api/internal/gen/proto/v1/tenants.pb.go
+++ b/internal/api/internal/gen/proto/v1/tenants.pb.go
@@ -7,12 +7,11 @@
 package protocol
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -366,17 +365,15 @@ func file_v1_tenants_proto_rawDescGZIP() []byte {
 	return file_v1_tenants_proto_rawDescData
 }
 
-var (
-	file_v1_tenants_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_v1_tenants_proto_msgTypes  = make([]protoimpl.MessageInfo, 4)
-	file_v1_tenants_proto_goTypes   = []any{
-		(TenantActivityStatus)(0), // 0: weaviate.v1.TenantActivityStatus
-		(*TenantsGetRequest)(nil), // 1: weaviate.v1.TenantsGetRequest
-		(*TenantNames)(nil),       // 2: weaviate.v1.TenantNames
-		(*TenantsGetReply)(nil),   // 3: weaviate.v1.TenantsGetReply
-		(*Tenant)(nil),            // 4: weaviate.v1.Tenant
-	}
-)
+var file_v1_tenants_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_v1_tenants_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_v1_tenants_proto_goTypes = []any{
+	(TenantActivityStatus)(0), // 0: weaviate.v1.TenantActivityStatus
+	(*TenantsGetRequest)(nil), // 1: weaviate.v1.TenantsGetRequest
+	(*TenantNames)(nil),       // 2: weaviate.v1.TenantNames
+	(*TenantsGetReply)(nil),   // 3: weaviate.v1.TenantsGetReply
+	(*Tenant)(nil),            // 4: weaviate.v1.Tenant
+}
 var file_v1_tenants_proto_depIdxs = []int32{
 	2, // 0: weaviate.v1.TenantsGetRequest.names:type_name -> weaviate.v1.TenantNames
 	4, // 1: weaviate.v1.TenantsGetReply.tenants:type_name -> weaviate.v1.Tenant

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -1538,6 +1538,31 @@ func TestDeleteObjectsRequest_MarshalMessage(t *testing.T) {
 	})
 }
 
+func TestGetTenantsRequest_MarshalMessage(t *testing.T) {
+	testMessageMarshaler(t, []MessageMarshalerTest[proto.TenantsGetRequest, proto.TenantsGetReply]{
+		{
+			name: "with tenant names",
+			req: &api.GetTenantsRequest{
+				Collection: "Songs",
+				Tenants:    []string{"john_doe", "jane_doe"},
+			},
+			want: &proto.TenantsGetRequest{
+				Collection: "Songs",
+				Params: &proto.TenantsGetRequest_Names{
+					Names: &proto.TenantNames{
+						Values: []string{"john_doe", "jane_doe"},
+					},
+				},
+			},
+		},
+		{
+			name: "list all",
+			req:  &api.GetTenantsRequest{Collection: "Songs"},
+			want: &proto.TenantsGetRequest{Collection: "Songs"},
+		},
+	})
+}
+
 // ----------------------------------------------------------------------------
 
 type MessageUnmarshalerTest[Out transport.ReplyMessage] struct {
@@ -2472,6 +2497,25 @@ func TestDeleteObjectsResponse_UnmarshalMessage(t *testing.T) {
 			reply: &proto.BatchDeleteReply{Took: 92},
 			dest:  new(api.DeleteObjectsResponse),
 			want:  &api.DeleteObjectsResponse{Took: 92 * time.Second},
+		},
+	})
+}
+
+func TestGetTenantsResponse_UnmarshalMessage(t *testing.T) {
+	testMessageUnmarshaler(t, []MessageUnmarshalerTest[proto.TenantsGetReply]{
+		{
+			name: "tenants",
+			reply: &proto.TenantsGetReply{
+				Tenants: []*proto.Tenant{
+					{Name: "john_doe", ActivityStatus: proto.TenantActivityStatus_TENANT_ACTIVITY_STATUS_COLD},
+					{Name: "jane_doe", ActivityStatus: proto.TenantActivityStatus_TENANT_ACTIVITY_STATUS_FROZEN},
+				},
+			},
+			dest: new(api.GetTenantsResponse),
+			want: &api.GetTenantsResponse{
+				{Name: "john_doe", Status: api.TenantStatusCold},
+				{Name: "jane_doe", Status: api.TenantStatusFrozen},
+			},
 		},
 	})
 }

--- a/internal/api/tenants.go
+++ b/internal/api/tenants.go
@@ -1,0 +1,164 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	proto "github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/proto/v1"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api/transport"
+	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
+
+	"github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/rest"
+	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
+)
+
+type Tenant struct {
+	Name   string
+	Status TenantStatus
+}
+
+var _ json.Marshaler = (*Tenant)(nil)
+
+type TenantStatus rest.TenantActivityStatus
+
+const (
+	TenantStatusActive     = TenantStatus(rest.ACTIVE)
+	TenantStatusCold       = TenantStatus(rest.COLD)
+	TenantStatusFreezing   = TenantStatus(rest.FREEZING)
+	TenantStatusFrozen     = TenantStatus(rest.FROZEN)
+	TenantStatusHot        = TenantStatus(rest.HOT)
+	TenantStatusInactive   = TenantStatus(rest.INACTIVE)
+	TenantStatusOffloaded  = TenantStatus(rest.OFFLOADED)
+	TenantStatusOffloading = TenantStatus(rest.OFFLOADING)
+	TenantStatusOnloading  = TenantStatus(rest.ONLOADING)
+	TenantStatusUnfreezing = TenantStatus(rest.UNFREEZING)
+)
+
+// CreateTenantsRequest creates new tenants in the collection.
+type CreateTenantsRequest struct {
+	transports.BaseEndpoint
+
+	Collection string
+	Tenants    []Tenant
+}
+
+var _ transports.Endpoint = (*CreateTenantsRequest)(nil)
+
+func (CreateTenantsRequest) Method() string  { return http.MethodPost }
+func (r *CreateTenantsRequest) Path() string { return "/schema/" + r.Collection + "/tenants" }
+func (r *CreateTenantsRequest) Body() any    { return r.Tenants }
+
+// UpdateTenantsRequest sets new statuses for the existing tenants.
+type UpdateTenantsRequest struct {
+	transports.BaseEndpoint
+
+	Collection string
+	Tenants    []Tenant
+}
+
+var _ transports.Endpoint = (*UpdateTenantsRequest)(nil)
+
+func (UpdateTenantsRequest) Method() string  { return http.MethodPut }
+func (r *UpdateTenantsRequest) Path() string { return "/schema/" + r.Collection + "/tenants" }
+func (r *UpdateTenantsRequest) Body() any    { return r.Tenants }
+
+// DeleteTenantsRequest batch deletes tenants by their name.
+type DeleteTenantsRequest struct {
+	transports.BaseEndpoint
+
+	Collection string
+	Tenants    []string
+}
+
+var _ transports.Endpoint = (*DeleteTenantsRequest)(nil)
+
+func (DeleteTenantsRequest) Method() string  { return http.MethodDelete }
+func (r *DeleteTenantsRequest) Path() string { return "/schema/" + r.Collection + "/tenants" }
+func (r *DeleteTenantsRequest) Body() any    { return r.Tenants }
+
+func (t *Tenant) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rest.Tenant{
+		Name:           t.Name,
+		ActivityStatus: rest.TenantActivityStatus(t.Status),
+	})
+}
+
+// GetTenantsRequest retrieves tenant information for selected tenants.
+// Leave Tenants field unset to fetch all tenants.
+// Use with [GetTenantsResponse].
+type GetTenantsRequest struct {
+	Collection string
+	Tenants    []string
+}
+
+var (
+	_ transport.Message[proto.TenantsGetRequest, proto.TenantsGetReply] = (*GetTenantsRequest)(nil)
+	_ transport.MessageMarshaler[proto.TenantsGetRequest]               = (*GetTenantsRequest)(nil)
+)
+
+func (r *GetTenantsRequest) Method() transport.MethodFunc[proto.TenantsGetRequest, proto.TenantsGetReply] {
+	return proto.WeaviateClient.TenantsGet
+}
+
+func (r *GetTenantsRequest) Body() transport.MessageMarshaler[proto.TenantsGetRequest] {
+	return r
+}
+
+func (r *GetTenantsRequest) MarshalMessage() (*proto.TenantsGetRequest, error) {
+	req := &proto.TenantsGetRequest{
+		Collection: r.Collection,
+	}
+
+	if len(r.Tenants) > 0 {
+		req.Params = &proto.TenantsGetRequest_Names{
+			Names: &proto.TenantNames{
+				Values: r.Tenants,
+			},
+		}
+	}
+	return req, nil
+}
+
+type GetTenantsResponse []Tenant
+
+var _ transport.MessageUnmarshaler[proto.TenantsGetReply] = (*GetTenantsResponse)(nil)
+
+func (r *GetTenantsResponse) UnmarshalMessage(reply *proto.TenantsGetReply) error {
+	dev.AssertNotNil(reply, "reply")
+	if len(reply.Tenants) == 0 {
+		return nil
+	}
+
+	*r = make([]Tenant, len(reply.Tenants))
+	for i, t := range reply.Tenants {
+		var status TenantStatus
+		switch t.ActivityStatus {
+		case proto.TenantActivityStatus_TENANT_ACTIVITY_STATUS_HOT:
+			status = TenantStatusHot
+		case proto.TenantActivityStatus_TENANT_ACTIVITY_STATUS_COLD:
+			status = TenantStatusCold
+		case proto.TenantActivityStatus_TENANT_ACTIVITY_STATUS_FROZEN:
+			status = TenantStatusFrozen
+		case proto.TenantActivityStatus_TENANT_ACTIVITY_STATUS_UNFREEZING:
+			status = TenantStatusUnfreezing
+		case proto.TenantActivityStatus_TENANT_ACTIVITY_STATUS_FREEZING:
+			status = TenantStatusFreezing
+		case proto.TenantActivityStatus_TENANT_ACTIVITY_STATUS_ACTIVE:
+			status = TenantStatusActive
+		case proto.TenantActivityStatus_TENANT_ACTIVITY_STATUS_INACTIVE:
+			status = TenantStatusInactive
+		case proto.TenantActivityStatus_TENANT_ACTIVITY_STATUS_OFFLOADED:
+			status = TenantStatusOffloaded
+		case proto.TenantActivityStatus_TENANT_ACTIVITY_STATUS_OFFLOADING:
+			status = TenantStatusOffloading
+		case proto.TenantActivityStatus_TENANT_ACTIVITY_STATUS_ONLOADING:
+			status = TenantStatusOnloading
+		}
+
+		(*r)[i] = Tenant{
+			Name:   t.Name,
+			Status: status,
+		}
+	}
+	return nil
+}

--- a/internal/api/transport/message.go
+++ b/internal/api/transport/message.go
@@ -34,7 +34,8 @@ type RequestMessage interface {
 		proto.AggregateRequest |
 		proto.BatchObjectsRequest |
 		proto.BatchReferencesRequest |
-		proto.BatchDeleteRequest
+		proto.BatchDeleteRequest |
+		proto.TenantsGetRequest
 }
 
 // ReplyMessage enumerates gRPC replies supported by [proto.WeaviateClient].
@@ -43,7 +44,8 @@ type ReplyMessage interface {
 		proto.AggregateReply |
 		proto.BatchObjectsReply |
 		proto.BatchReferencesReply |
-		proto.BatchDeleteReply
+		proto.BatchDeleteReply |
+		proto.TenantsGetReply
 }
 
 // MethodFunc is a method of the proto.WeaviateClient interface

--- a/tenant/client.go
+++ b/tenant/client.go
@@ -1,0 +1,146 @@
+package tenant
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
+)
+
+func NewClient(t internal.Transport, collection string) *Client {
+	dev.AssertNotNil(t, "transport")
+	return &Client{
+		transport:  t,
+		collection: collection,
+	}
+}
+
+type Client struct {
+	transport  internal.Transport
+	collection string
+}
+
+type Tenant struct {
+	Name   string
+	Status Status
+}
+
+type Status api.TenantStatus
+
+const (
+	Active     = Status(api.TenantStatusActive)
+	Cold       = Status(api.TenantStatusCold)
+	Freezing   = Status(api.TenantStatusFreezing)
+	Frozen     = Status(api.TenantStatusFrozen)
+	Hot        = Status(api.TenantStatusHot)
+	Inactive   = Status(api.TenantStatusInactive)
+	Offloaded  = Status(api.TenantStatusOffloaded)
+	Offloading = Status(api.TenantStatusOffloading)
+	Onloading  = Status(api.TenantStatusOnloading)
+	Unfreezing = Status(api.TenantStatusUnfreezing)
+)
+
+// Create new tenants in the collection.
+func (c *Client) Create(ctx context.Context, tenants ...Tenant) error {
+	req := &api.CreateTenantsRequest{
+		Collection: c.collection,
+		Tenants:    make([]api.Tenant, len(tenants)),
+	}
+	for i, t := range tenants {
+		req.Tenants[i] = api.Tenant{
+			Name:   t.Name,
+			Status: api.TenantStatus(t.Status),
+		}
+	}
+	if err := c.transport.Do(ctx, req, nil); err != nil {
+		return fmt.Errorf("create tenants: %w", err)
+	}
+	return nil
+}
+
+// TODO(dyma): do we want to hedge for the possibility of some cursor-based API
+// and accept an options struct instead?
+func (c *Client) Get(ctx context.Context, tenants ...string) ([]Tenant, error) {
+	req := &api.GetTenantsRequest{
+		Collection: c.collection,
+		Tenants:    tenants,
+	}
+	var resp api.GetTenantsResponse
+	if err := c.transport.Do(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("get tenants: %w", err)
+	}
+
+	out := make([]Tenant, len(resp))
+	for i, t := range resp {
+		out[i] = Tenant{
+			Name:   t.Name,
+			Status: Status(t.Status),
+		}
+	}
+	return out, nil
+}
+
+// Update statuses of existing tenants to either [Active], [Inactive], or [Offloaded].
+// All other statuses should be considered "read-only".
+func (c *Client) Update(ctx context.Context, tenants ...Tenant) error {
+	req := &api.UpdateTenantsRequest{
+		Collection: c.collection,
+		Tenants:    make([]api.Tenant, len(tenants)),
+	}
+	for i, t := range tenants {
+		req.Tenants[i] = api.Tenant{
+			Name:   t.Name,
+			Status: api.TenantStatus(t.Status),
+		}
+	}
+	if err := c.transport.Do(ctx, req, nil); err != nil {
+		return fmt.Errorf("update tenants: %w", err)
+	}
+	return nil
+}
+
+// Activate tenants.
+func (c *Client) Activate(ctx context.Context, tenants ...string) error {
+	return c.setStatus(ctx, "activate", Active, tenants)
+}
+
+// Deactivate tenants.
+func (c *Client) Deactivate(ctx context.Context, tenants ...string) error {
+	return c.setStatus(ctx, "deactivate", Inactive, tenants)
+}
+
+// Offload tenants to the configured backend storage.
+func (c *Client) Offload(ctx context.Context, tenants ...string) error {
+	return c.setStatus(ctx, "offload", Offloaded, tenants)
+}
+
+func (c *Client) setStatus(ctx context.Context, verb string, s Status, tenants []string) error {
+	req := &api.UpdateTenantsRequest{
+		Collection: c.collection,
+		Tenants:    make([]api.Tenant, len(tenants)),
+	}
+	for i := range tenants {
+		req.Tenants[i] = api.Tenant{
+			Name:   tenants[i],
+			Status: api.TenantStatus(s),
+		}
+	}
+	if err := c.transport.Do(ctx, req, nil); err != nil {
+		return fmt.Errorf("%s tenants: %w", verb, err)
+	}
+	return nil
+}
+
+// Delete tenants and their data.
+func (c *Client) Delete(ctx context.Context, tenants ...string) error {
+	req := &api.DeleteTenantsRequest{
+		Collection: c.collection,
+		Tenants:    tenants,
+	}
+	if err := c.transport.Do(ctx, req, nil); err != nil {
+		return fmt.Errorf("delete tenants: %w", err)
+	}
+	return nil
+}

--- a/tenant/client_test.go
+++ b/tenant/client_test.go
@@ -1,0 +1,190 @@
+package tenant_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+	"github.com/weaviate/weaviate-go-client/v6/tenant"
+)
+
+func TestNewClient(t *testing.T) {
+	require.Panics(t, func() {
+		tenant.NewClient(nil, "Songs")
+	}, "nil transport")
+}
+
+func TestClient_Create(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		tenants []tenant.Tenant
+		stubs   []testkit.Stub[api.CreateTenantsRequest, any]
+		err     testkit.Error // Expected error.
+	}{
+		{
+			name: "successfully",
+			tenants: []tenant.Tenant{
+				{Name: "john_doe", Status: tenant.Active},
+				{Name: "jane_doe", Status: tenant.Frozen},
+			},
+			stubs: []testkit.Stub[api.CreateTenantsRequest, any]{
+				{
+					Request: &api.CreateTenantsRequest{
+						Collection: "Songs",
+						Tenants: []api.Tenant{
+							{Name: "john_doe", Status: api.TenantStatusActive},
+							{Name: "jane_doe", Status: api.TenantStatusFrozen},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.CreateTenantsRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := tenant.NewClient(transport, "Songs")
+			require.NotNil(t, c, "nil client")
+
+			err := c.Create(t.Context(), tt.tenants...)
+			tt.err.Require(t, err, "create error")
+		})
+	}
+}
+
+func TestClient_Update(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		tenants []tenant.Tenant
+		stubs   []testkit.Stub[api.UpdateTenantsRequest, any]
+		err     testkit.Error // Expected error.
+	}{
+		{
+			name: "successfully",
+			tenants: []tenant.Tenant{
+				{Name: "john_doe", Status: tenant.Active},
+				{Name: "jane_doe", Status: tenant.Frozen},
+			},
+			stubs: []testkit.Stub[api.UpdateTenantsRequest, any]{
+				{
+					Request: &api.UpdateTenantsRequest{
+						Collection: "Songs",
+						Tenants: []api.Tenant{
+							{Name: "john_doe", Status: api.TenantStatusActive},
+							{Name: "jane_doe", Status: api.TenantStatusFrozen},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.UpdateTenantsRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := tenant.NewClient(transport, "Songs")
+			require.NotNil(t, c, "nil client")
+
+			err := c.Update(t.Context(), tt.tenants...)
+			tt.err.Require(t, err, "update error")
+		})
+	}
+}
+
+func TestClient_Get(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		tenants []string
+		stubs   []testkit.Stub[api.GetTenantsRequest, api.GetTenantsResponse]
+		want    []tenant.Tenant
+		err     testkit.Error // Expected error.
+	}{
+		{
+			name:    "successfully",
+			tenants: []string{"john_doe", "jane_doe"},
+			stubs: []testkit.Stub[api.GetTenantsRequest, api.GetTenantsResponse]{
+				{
+					Request: &api.GetTenantsRequest{
+						Collection: "Songs",
+						Tenants:    []string{"john_doe", "jane_doe"},
+					},
+					Response: api.GetTenantsResponse{
+						{Name: "john_doe", Status: api.TenantStatusActive},
+						{Name: "jane_doe", Status: api.TenantStatusFrozen},
+					},
+				},
+			},
+			want: []tenant.Tenant{
+				{Name: "john_doe", Status: tenant.Active},
+				{Name: "jane_doe", Status: tenant.Frozen},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.GetTenantsRequest, api.GetTenantsResponse]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := tenant.NewClient(transport, "Songs")
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.Get(t.Context(), tt.tenants...)
+			tt.err.Require(t, err, "get-tenants error")
+			require.EqualExportedValues(t, tt.want, got, "returned tenants")
+		})
+	}
+}
+
+func TestClient_Delete(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		tenants []string
+		stubs   []testkit.Stub[api.DeleteTenantsRequest, any]
+		err     testkit.Error // Expected error.
+	}{
+		{
+			name:    "successfully",
+			tenants: []string{"john_doe", "jane_doe"},
+			stubs: []testkit.Stub[api.DeleteTenantsRequest, any]{
+				{
+					Request: &api.DeleteTenantsRequest{
+						Collection: "Songs",
+						Tenants:    []string{"john_doe", "jane_doe"},
+					},
+				},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.DeleteTenantsRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := tenant.NewClient(transport, "Songs")
+			require.NotNil(t, c, "nil client")
+
+			err := c.Delete(t.Context(), tt.tenants...)
+			tt.err.Require(t, err, "delete error")
+		})
+	}
+}


### PR DESCRIPTION
This PR implements a client for `/schema/<collection>/tenants` set of APIs.

```go
songs := c.Collections.Use("Songs")
songs.Tenants.Create(ctx, tenant.Tenant{
  Name: "john_doe",
  Status: tenant.Inactive,
)

// Also has shorthand methods to Deactivate and Offload tenants.
songs.Tenants.Activate(ctx, "john_doe")

// Every method in the Tenants namespace is variadic to allow managing tenants in batch.
// A Get(ctx) returns all tenants defined for the collection.
ts, err := songs.Tenants.Get(ctx, "john_doe", "jane_doe")
fmt.Printf("tenant %q is %s\n", ts[0].Name, ts[0].Status)

songs.Tenants.Delete(ctx, "john_doe")
```