### PR TITLE
v6: Cluster API

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/weaviate/weaviate-go-client/v6/alias"
 	"github.com/weaviate/weaviate-go-client/v6/backup"
+	"github.com/weaviate/weaviate-go-client/v6/cluster"
 	"github.com/weaviate/weaviate-go-client/v6/collections"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
@@ -29,6 +30,7 @@ type Client struct {
 	Roles       *rbac.RolesClient
 	Users       *rbac.UsersClient
 	Groups      *rbac.GroupsClient
+	Cluster     *cluster.Client
 }
 
 var _ io.Closer = (*Client)(nil)
@@ -143,6 +145,7 @@ func newClient(ctx context.Context, options []Option) (*Client, error) {
 		Roles:       rbac.NewRolesClient(t),
 		Users:       rbac.NewUsersClient(t),
 		Groups:      rbac.NewGroupsClient(t),
+		Cluster:     cluster.NewClient(t),
 	}, nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -218,6 +218,7 @@ func TestNewWeaviateCloud(t *testing.T) {
 		assert.NotNil(t, c.Roles, "nil roles")
 		assert.NotNil(t, c.Users, "nil users")
 		assert.NotNil(t, c.Groups, "nil groups")
+		assert.NotNil(t, c.Cluster, "nil cluster")
 	})
 }
 

--- a/cluster/client.go
+++ b/cluster/client.go
@@ -24,7 +24,7 @@ type ShardReplica api.ShardReplica
 
 type ListShardReplicasOptions struct {
 	Collection string // Required parameter.
-	Shard      string // Optional: if ommitted, all shards are returned.
+	Shard      string // Optional: if omitted, all shards are returned.
 }
 
 // ListShardReplicas returns a list of shards and all their replicas.
@@ -36,7 +36,7 @@ func (c *Client) ListShardReplicas(ctx context.Context, options ListShardReplica
 
 	var resp api.GetShardsResponse
 	if err := c.transport.Do(ctx, req, &resp); err != nil {
-		return nil, fmt.Errorf("get sharding state: %w", err)
+		return nil, fmt.Errorf("list shard replicas: %w", err)
 	}
 
 	out := make([]ShardReplica, len(resp))
@@ -98,7 +98,7 @@ const (
 )
 
 type ListNodesOptions struct {
-	Collection string // Optional: if ommitted, all nodes are returned.
+	Collection string // Optional: if omitted, all nodes are returned.
 	Shard      string // Optional: if set, only nodes containing this shard are returned.
 	Verbose    bool   // Optional: set to true to fetch complete node info.
 }
@@ -117,7 +117,7 @@ func (c *Client) ListNodes(ctx context.Context, options ListNodesOptions) ([]Nod
 
 	var resp api.GetNodesResponse
 	if err := c.transport.Do(ctx, req, &resp); err != nil {
-		return nil, fmt.Errorf("get sharding state: %w", err)
+		return nil, fmt.Errorf("list nodes: %w", err)
 	}
 
 	out := make([]Node, len(resp))

--- a/cluster/client.go
+++ b/cluster/client.go
@@ -1,0 +1,156 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
+)
+
+func NewClient(t internal.Transport) *Client {
+	dev.AssertNotNil(t, "transport")
+	return &Client{transport: t}
+}
+
+type Client struct {
+	transport internal.Transport
+}
+
+type ShardReplica api.ShardReplica
+
+type ListShardReplicasOptions struct {
+	Collection string // Required parameter.
+	Shard      string // Optional: if ommitted, all shards are returned.
+}
+
+// ListShardReplicas returns a list of shards and all their replicas.
+func (c *Client) ListShardReplicas(ctx context.Context, options ListShardReplicasOptions) ([]ShardReplica, error) {
+	req := &api.GetShardsRequest{
+		Collection: options.Collection,
+		Shard:      options.Shard,
+	}
+
+	var resp api.GetShardsResponse
+	if err := c.transport.Do(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("get sharding state: %w", err)
+	}
+
+	out := make([]ShardReplica, len(resp))
+	for i, shard := range resp {
+		out[i] = ShardReplica(shard)
+	}
+	return out, nil
+}
+
+type Node struct {
+	Name       string
+	Status     NodeStatus
+	GitHash    string
+	Version    string
+	Mode       NodeMode
+	Stats      NodeStats
+	Shards     []Shard
+	BatchStats BatchStats
+}
+
+type (
+	BatchStats api.BatchStats
+	NodeStats  api.NodeStats
+)
+
+type Shard struct {
+	Name                 string
+	Collection           string
+	ObjectCount          int64
+	Compressed           bool
+	Loaded               bool
+	VectorIndexingStatus string
+	VectorQueueLength    int64
+	OngoingReplications  []ReplicationStatus
+}
+
+type ReplicationStatus struct {
+	TargetNode         string
+	ObjectsPropagated  int64
+	LastIterationStart time.Time
+}
+
+type NodeStatus = api.NodeStatus
+
+const (
+	NodeStatusHealthy     = NodeStatus(api.NodeStatusHealthy)
+	NodeStatusTimeout     = NodeStatus(api.NodeStatusTimeout)
+	NodeStatusUnavailable = NodeStatus(api.NodeStatusUnavailable)
+	NodeStatusUnhealthy   = NodeStatus(api.NodeStatusUnhealthy)
+)
+
+type NodeMode api.NodeMode
+
+const (
+	NodeModeReadOnly  = NodeMode(api.NodeModeReadOnly)
+	NodeModeReadWrite = NodeMode(api.NodeModeReadWrite)
+	NodeModeScaleOut  = NodeMode(api.NodeModeScaleOut)
+	NodeModeWriteOnly = NodeMode(api.NodeModeWriteOnly)
+)
+
+type ListNodesOptions struct {
+	Collection string // Optional: if ommitted, all nodes are returned.
+	Shard      string // Optional: if set, only nodes containing this shard are returned.
+	Verbose    bool   // Optional: set to true to fetch complete node info.
+}
+
+// ListNodes retrieves the information about nodes in this cluster.
+func (c *Client) ListNodes(ctx context.Context, options ListNodesOptions) ([]Node, error) {
+	req := &api.GetNodesRequest{
+		Collection: options.Collection,
+		Shard:      options.Shard,
+		Verbosity:  api.NodeVerbosityMinimal,
+	}
+
+	if options.Verbose {
+		req.Verbosity = api.NodeVerbosityVerbose
+	}
+
+	var resp api.GetNodesResponse
+	if err := c.transport.Do(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("get sharding state: %w", err)
+	}
+
+	out := make([]Node, len(resp))
+	for i, node := range resp {
+		shards := slices.Grow([]Shard(nil), len(node.Shards))
+		for si, s := range node.Shards {
+			replications := slices.Grow([]ReplicationStatus(nil), len(s.OngoingReplications))
+			for ri, r := range s.OngoingReplications {
+				replications[ri] = ReplicationStatus(r)
+			}
+
+			shards[si] = Shard{
+				Name:                 s.Name,
+				Collection:           s.Collection,
+				ObjectCount:          s.ObjectCount,
+				Compressed:           s.Compressed,
+				Loaded:               s.Loaded,
+				VectorIndexingStatus: s.VectorIndexingStatus,
+				VectorQueueLength:    s.VectorQueueLength,
+				OngoingReplications:  replications,
+			}
+		}
+
+		out[i] = Node{
+			Name:       node.Name,
+			Status:     NodeStatus(node.Status),
+			GitHash:    node.GitHash,
+			Version:    node.Version,
+			Mode:       NodeMode(node.Mode),
+			Stats:      NodeStats(node.Stats),
+			Shards:     shards,
+			BatchStats: BatchStats(node.BatchStats),
+		}
+	}
+	return out, nil
+}

--- a/cluster/client_test.go
+++ b/cluster/client_test.go
@@ -1,0 +1,130 @@
+package cluster_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/cluster"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+)
+
+func TestNewClient(t *testing.T) {
+	require.Panics(t, func() {
+		cluster.NewClient(nil)
+	}, "nil transport")
+}
+
+func TestClient_ListShardReplicas(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options cluster.ListShardReplicasOptions
+		stubs   []testkit.Stub[api.GetShardsRequest, api.GetShardsResponse]
+		want    []cluster.ShardReplica
+		err     testkit.Error // Expected error.
+	}{
+		{
+			name: "successfully",
+			options: cluster.ListShardReplicasOptions{
+				Collection: "Songs",
+				Shard:      "xyz",
+			},
+			stubs: []testkit.Stub[api.GetShardsRequest, api.GetShardsResponse]{
+				{
+					Request: &api.GetShardsRequest{
+						Collection: "Songs",
+						Shard:      "xyz",
+					},
+					Response: api.GetShardsResponse{
+						{Shard: "abc", Replicas: []string{"abc-1", "abc-2"}},
+						{Shard: "xyz", Replicas: []string{"xyz-1", "xyz-2"}},
+					},
+				},
+			},
+			want: []cluster.ShardReplica{
+				{Shard: "abc", Replicas: []string{"abc-1", "abc-2"}},
+				{Shard: "xyz", Replicas: []string{"xyz-1", "xyz-2"}},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.GetShardsRequest, api.GetShardsResponse]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := cluster.NewClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.ListShardReplicas(t.Context(), tt.options)
+			tt.err.Require(t, err, "list-shards error")
+			require.EqualExportedValues(t, tt.want, got, "returned shards")
+		})
+	}
+}
+
+func TestClient_ListNodes(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options cluster.ListNodesOptions
+		stubs   []testkit.Stub[api.GetNodesRequest, api.GetNodesResponse]
+		want    []cluster.Node
+		err     testkit.Error // Expected error.
+	}{
+		{
+			name: "successfully",
+			options: cluster.ListNodesOptions{
+				Collection: "Songs",
+				Shard:      "xyz",
+				Verbose:    true,
+			},
+			stubs: []testkit.Stub[api.GetNodesRequest, api.GetNodesResponse]{
+				{
+					Request: &api.GetNodesRequest{
+						Collection: "Songs",
+						Shard:      "xyz",
+						Verbosity:  api.NodeVerbosityVerbose,
+					},
+					Response: api.GetNodesResponse{
+						{
+							Name:    "node-1",
+							Status:  api.NodeStatusHealthy,
+							GitHash: "5cc3aa3",
+							Version: "1.37.3",
+							Mode:    api.NodeModeScaleOut,
+						},
+					},
+				},
+			},
+			want: []cluster.Node{
+				{
+					Name:    "node-1",
+					Status:  cluster.NodeStatusHealthy,
+					GitHash: "5cc3aa3",
+					Version: "1.37.3",
+					Mode:    cluster.NodeModeScaleOut,
+				},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.GetNodesRequest, api.GetNodesResponse]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := cluster.NewClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.ListNodes(t.Context(), tt.options)
+			tt.err.Require(t, err, "list-shards error")
+			require.EqualExportedValues(t, tt.want, got, "returned nodes")
+		})
+	}
+}

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -1,0 +1,191 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/rest"
+	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
+)
+
+type ShardReplica struct {
+	Shard    string   // Shard name.
+	Replicas []string // Nodes which contain a replica of this shard.
+}
+
+// GetShardsRequest fetches information about collection's shards
+// and their replicas.
+// Use with [GetShardsResponse].
+type GetShardsRequest struct {
+	transports.BaseEndpoint
+	Collection string // Required parameter.
+	Shard      string // Optional: if ommitted, all shards are returned.
+}
+
+var _ transports.Endpoint = (*GetShardsRequest)(nil)
+
+func (GetShardsRequest) Method() string { return http.MethodGet }
+func (GetShardsRequest) Path() string   { return "/replication/sharding-state" }
+func (r *GetShardsRequest) Query() url.Values {
+	v := url.Values{
+		"collection": {r.Collection},
+	}
+	if r.Shard != "" {
+		v["shard"] = []string{r.Shard}
+	}
+	return v
+}
+
+type GetShardsResponse []ShardReplica
+
+var _ json.Unmarshaler = (*GetShardsResponse)(nil)
+
+type Node struct {
+	Name       string
+	Status     NodeStatus
+	GitHash    string
+	Version    string
+	Mode       NodeMode
+	Stats      NodeStats
+	Shards     []Shard
+	BatchStats BatchStats
+}
+
+type (
+	BatchStats rest.BatchStats
+	NodeStats  rest.NodeStats
+)
+
+type Shard struct {
+	Name                 string
+	Collection           string
+	ObjectCount          int64
+	Compressed           bool
+	Loaded               bool
+	VectorIndexingStatus string
+	VectorQueueLength    int64
+	OngoingReplications  []ReplicationStatus
+}
+
+type ReplicationStatus struct {
+	TargetNode         string
+	ObjectsPropagated  int64
+	LastIterationStart time.Time
+}
+
+type NodeStatus = rest.NodeStatusStatus
+
+const (
+	NodeStatusHealthy     = NodeStatus(rest.NodeStatusStatusHEALTHY)
+	NodeStatusTimeout     = NodeStatus(rest.NodeStatusStatusTIMEOUT)
+	NodeStatusUnavailable = NodeStatus(rest.NodeStatusStatusUNAVAILABLE)
+	NodeStatusUnhealthy   = NodeStatus(rest.NodeStatusStatusUNHEALTHY)
+)
+
+type NodeMode rest.NodeStatusOperationalMode
+
+const (
+	NodeModeReadOnly  = NodeMode(rest.ReadOnly)
+	NodeModeReadWrite = NodeMode(rest.ReadWrite)
+	NodeModeScaleOut  = NodeMode(rest.ScaleOut)
+	NodeModeWriteOnly = NodeMode(rest.WriteOnly)
+)
+
+type GetNodesRequest struct {
+	transports.BaseEndpoint
+	Collection string // Optional: if ommitted, all nodes are returned.
+	Shard      string // Optional: if set, only nodes containing this shard are returned.
+	Verbosity  NodeVerbosity
+}
+
+var _ transports.Endpoint = (*GetNodesRequest)(nil)
+
+func (GetNodesRequest) Method() string { return http.MethodGet }
+func (r *GetNodesRequest) Path() string {
+	p := "/nodes"
+	if r.Collection != "" {
+		p += "/" + r.Collection
+	}
+	return p
+}
+
+func (r *GetNodesRequest) Query() url.Values {
+	if r.Shard == "" && r.Verbosity == "" {
+		return nil
+	}
+
+	v := make(url.Values)
+	if r.Shard != "" {
+		v["shardName"] = []string{r.Shard}
+	}
+	if r.Verbosity != "" {
+		v["output"] = []string{string(r.Verbosity)}
+	}
+	return v
+}
+
+type GetNodesResponse []Node
+
+func (r *GetNodesResponse) UnmarshalJSON(data []byte) error {
+	var resp rest.NodesStatusResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return err
+	}
+
+	*r = make(GetNodesResponse, len(resp.Nodes))
+
+	for i, n := range resp.Nodes {
+		shards := make([]Shard, len(n.Shards))
+		for si, s := range n.Shards {
+			replications := make([]ReplicationStatus, len(s.AsyncReplicationStatus))
+			for ri, r := range s.AsyncReplicationStatus {
+				replications[ri] = ReplicationStatus{
+					TargetNode:         r.TargetNode,
+					ObjectsPropagated:  r.ObjectsPropagated,
+					LastIterationStart: time.UnixMilli(r.StartDiffTimeUnixMillis),
+				}
+			}
+
+			shards[si] = Shard{
+				Name:                 s.Name,
+				Collection:           s.Class,
+				ObjectCount:          s.ObjectCount,
+				Compressed:           s.Compressed,
+				Loaded:               s.Loaded,
+				VectorIndexingStatus: s.VectorIndexingStatus,
+				VectorQueueLength:    s.VectorQueueLength,
+				OngoingReplications:  replications,
+			}
+		}
+
+		(*r)[i] = Node{
+			Name:       n.Name,
+			Status:     NodeStatus(n.Status),
+			GitHash:    n.GitHash,
+			Version:    n.Version,
+			Mode:       NodeMode(n.OperationalMode),
+			Stats:      NodeStats(n.Stats),
+			Shards:     shards,
+			BatchStats: BatchStats(n.BatchStats),
+		}
+	}
+	return nil
+}
+
+func (r *GetShardsResponse) UnmarshalJSON(data []byte) error {
+	var resp rest.ReplicationShardingStateResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return err
+	}
+
+	*r = make(GetShardsResponse, len(resp.ShardingState.Shards))
+	for i, s := range resp.ShardingState.Shards {
+		(*r)[i] = ShardReplica{
+			Shard:    s.Shard,
+			Replicas: s.Replicas,
+		}
+	}
+	return nil
+}

--- a/internal/api/cluster.go
+++ b/internal/api/cluster.go
@@ -21,7 +21,7 @@ type ShardReplica struct {
 type GetShardsRequest struct {
 	transports.BaseEndpoint
 	Collection string // Required parameter.
-	Shard      string // Optional: if ommitted, all shards are returned.
+	Shard      string // Optional: if omitted, all shards are returned.
 }
 
 var _ transports.Endpoint = (*GetShardsRequest)(nil)
@@ -95,7 +95,7 @@ const (
 
 type GetNodesRequest struct {
 	transports.BaseEndpoint
-	Collection string // Optional: if ommitted, all nodes are returned.
+	Collection string // Optional: if omitted, all nodes are returned.
 	Shard      string // Optional: if set, only nodes containing this shard are returned.
 	Verbosity  NodeVerbosity
 }

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -200,7 +200,6 @@ func TestRESTRequests(t *testing.T) {
 						VirtualPerPhysical:  50,
 					},
 					Replication: &api.ReplicationConfig{
-						AsyncEnabled:     false,
 						Factor:           6,
 						DeletionStrategy: api.TimeBasedResolution,
 						AsyncReplication: &api.AsyncReplicationConfig{
@@ -281,7 +280,6 @@ func TestRESTRequests(t *testing.T) {
 					"virtualPerPhysical":  50,
 				},
 				ReplicationConfig: rest.ReplicationConfig{
-					AsyncEnabled:     false,
 					Factor:           6,
 					DeletionStrategy: rest.TimeBasedResolution,
 					AsyncConfig: rest.ReplicationAsyncConfig{
@@ -1274,7 +1272,6 @@ func TestRESTResponses(t *testing.T) {
 					"virtualPerPhysical":  50,
 				},
 				ReplicationConfig: rest.ReplicationConfig{
-					AsyncEnabled:     false,
 					Factor:           6,
 					DeletionStrategy: rest.TimeBasedResolution,
 					AsyncConfig: rest.ReplicationAsyncConfig{
@@ -1355,7 +1352,6 @@ func TestRESTResponses(t *testing.T) {
 					VirtualPerPhysical:  50,
 				},
 				Replication: &api.ReplicationConfig{
-					AsyncEnabled:     false,
 					Factor:           6,
 					DeletionStrategy: api.TimeBasedResolution,
 					AsyncReplication: &api.AsyncReplicationConfig{

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -1156,6 +1156,52 @@ func TestRESTRequests(t *testing.T) {
 				"john_doe", "jane_doe",
 			},
 		},
+		{
+			name:       "get all shards",
+			req:        &api.GetShardsRequest{Collection: "Songs"},
+			wantMethod: http.MethodGet,
+			wantPath:   "/replication/sharding-state",
+			wantQuery:  url.Values{"collection": {"Songs"}},
+		},
+		{
+			name: "get one shard",
+			req: &api.GetShardsRequest{
+				Collection: "Songs",
+				Shard:      "xyz",
+			},
+			wantMethod: http.MethodGet,
+			wantPath:   "/replication/sharding-state",
+			wantQuery: url.Values{
+				"collection": {"Songs"},
+				"shard":      {"xyz"},
+			},
+		},
+		{
+			name: "get all nodes in the cluster",
+			req: &api.GetNodesRequest{
+				Verbosity: api.NodeVerbosityVerbose,
+			},
+			wantMethod: http.MethodGet,
+			wantPath:   "/nodes",
+			wantQuery:  url.Values{"output": {"verbose"}},
+		},
+		{
+			name: "get all nodes in a collection",
+			req: &api.GetNodesRequest{
+				Collection: "Songs",
+			},
+			wantMethod: http.MethodGet,
+			wantPath:   "/nodes/Songs",
+		},
+		{
+			name: "get all nodes for shard",
+			req: &api.GetNodesRequest{
+				Shard: "xyz",
+			},
+			wantMethod: http.MethodGet,
+			wantPath:   "/nodes",
+			wantQuery:  url.Values{"shardName": {"xyz"}},
+		},
 	}) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Implements(t, (*transports.Endpoint)(nil), tt.req)
@@ -1939,6 +1985,98 @@ func TestRESTResponses(t *testing.T) {
 			want: &api.ListAliasesResponse{
 				{Collection: "GeorgeBarnes", Alias: "MachineGunKelly"},
 				{Collection: "LouisAttanasio", Alias: "LouieHaHa"},
+			},
+		},
+		{
+			name: "shard replicas",
+			body: &rest.ReplicationShardingStateResponse{
+				ShardingState: rest.ReplicationShardingState{
+					Shards: []rest.ReplicationShardReplicas{
+						{Shard: "abc", Replicas: []string{"abc-1", "abc-2"}},
+						{Shard: "xyz", Replicas: []string{"xyz-1", "xyz-2"}},
+					},
+				},
+			},
+			dest: new(api.GetShardsResponse),
+			want: &api.GetShardsResponse{
+				{Shard: "abc", Replicas: []string{"abc-1", "abc-2"}},
+				{Shard: "xyz", Replicas: []string{"xyz-1", "xyz-2"}},
+			},
+		},
+		{
+			name: "nodes",
+			body: &rest.NodesStatusResponse{
+				Nodes: []rest.NodeStatus{
+					{
+						Name:            "node-1",
+						Status:          rest.NodeStatusStatusHEALTHY,
+						GitHash:         "5cc3aa3",
+						Version:         "1.37.3",
+						OperationalMode: rest.ScaleOut,
+						Stats: rest.NodeStats{
+							ObjectCount: 4096,
+							ShardCount:  8,
+						},
+						Shards: []rest.NodeShardStatus{
+							{
+								Name:                 "abc",
+								Class:                "Song",
+								ObjectCount:          256,
+								Compressed:           true,
+								Loaded:               true,
+								VectorIndexingStatus: "ok",
+								VectorQueueLength:    16,
+								AsyncReplicationStatus: []rest.AsyncReplicationStatus{
+									{
+										TargetNode:              "node-2",
+										ObjectsPropagated:       1024,
+										StartDiffTimeUnixMillis: 3600,
+									},
+								},
+							},
+						},
+						BatchStats: rest.BatchStats{
+							QueueLength:   512,
+							RatePerSecond: 64,
+						},
+					},
+				},
+			},
+			dest: new(api.GetNodesResponse),
+			want: &api.GetNodesResponse{
+				{
+					Name:    "node-1",
+					Status:  api.NodeStatusHealthy,
+					GitHash: "5cc3aa3",
+					Version: "1.37.3",
+					Mode:    api.NodeModeScaleOut,
+					Stats: api.NodeStats{
+						ObjectCount: 4096,
+						ShardCount:  8,
+					},
+					Shards: []api.Shard{
+						{
+							Name:                 "abc",
+							Collection:           "Song",
+							ObjectCount:          256,
+							Compressed:           true,
+							Loaded:               true,
+							VectorIndexingStatus: "ok",
+							VectorQueueLength:    16,
+							OngoingReplications: []api.ReplicationStatus{
+								{
+									TargetNode:         "node-2",
+									ObjectsPropagated:  1024,
+									LastIterationStart: time.UnixMilli(3600),
+								},
+							},
+						},
+					},
+					BatchStats: api.BatchStats{
+						QueueLength:   512,
+						RatePerSecond: 64,
+					},
+				},
 			},
 		},
 	}) {


### PR DESCRIPTION
This PR adds a client for listing nodes and shards in a cluster.

```go
shards, err := c.Cluster.ListShardReplicas(ctx, cluster.ListShardReplicasOptions{
  Collection: "Songs",
  Shard: "xyz", 
})

nodes, err := c.Cluster.ListNodes(ctx, cluster.ListNodesReplicasOptions{
  Collection: "Songs",
  Shard: "xyz",
  Verbose: true,
})
```