### PR TITLE
v6: Replication APIs

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/transport"
 	"github.com/weaviate/weaviate-go-client/v6/internal/auth"
 	"github.com/weaviate/weaviate-go-client/v6/rbac"
+	"github.com/weaviate/weaviate-go-client/v6/replication"
 	"golang.org/x/oauth2"
 )
 
@@ -31,6 +32,7 @@ type Client struct {
 	Users       *rbac.UsersClient
 	Groups      *rbac.GroupsClient
 	Cluster     *cluster.Client
+	Replication *replication.Client
 }
 
 var _ io.Closer = (*Client)(nil)
@@ -146,6 +148,7 @@ func newClient(ctx context.Context, options []Option) (*Client, error) {
 		Users:       rbac.NewUsersClient(t),
 		Groups:      rbac.NewGroupsClient(t),
 		Cluster:     cluster.NewClient(t),
+		Replication: replication.NewClient(t),
 	}, nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -219,6 +219,7 @@ func TestNewWeaviateCloud(t *testing.T) {
 		assert.NotNil(t, c.Users, "nil users")
 		assert.NotNil(t, c.Groups, "nil groups")
 		assert.NotNil(t, c.Cluster, "nil cluster")
+		assert.NotNil(t, c.Replication, "nil replication")
 	})
 }
 

--- a/cluster/client.go
+++ b/cluster/client.go
@@ -123,13 +123,13 @@ func (c *Client) ListNodes(ctx context.Context, options ListNodesOptions) ([]Nod
 	out := make([]Node, len(resp))
 	for i, node := range resp {
 		shards := slices.Grow([]Shard(nil), len(node.Shards))
-		for si, s := range node.Shards {
+		for _, s := range node.Shards {
 			replications := slices.Grow([]ReplicationStatus(nil), len(s.OngoingReplications))
-			for ri, r := range s.OngoingReplications {
-				replications[ri] = ReplicationStatus(r)
+			for _, r := range s.OngoingReplications {
+				replications = append(replications, ReplicationStatus(r))
 			}
 
-			shards[si] = Shard{
+			shards = append(shards, Shard{
 				Name:                 s.Name,
 				Collection:           s.Collection,
 				ObjectCount:          s.ObjectCount,
@@ -138,7 +138,7 @@ func (c *Client) ListNodes(ctx context.Context, options ListNodesOptions) ([]Nod
 				VectorIndexingStatus: s.VectorIndexingStatus,
 				VectorQueueLength:    s.VectorQueueLength,
 				OngoingReplications:  replications,
-			}
+			})
 		}
 
 		out[i] = Node{

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -2135,6 +2135,60 @@ func TestRESTResponses(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "replication info",
+			body: &rest.ReplicationReplicateDetailsReplicaResponse{
+				Type:               rest.ReplicationReplicateDetailsReplicaResponseTypeMOVE,
+				Id:                 &testkit.UUID,
+				Collection:         "Songs",
+				Shard:              "abc",
+				SourceNode:         "node-0",
+				TargetNode:         "node-1",
+				Uncancelable:       true,
+				ScheduledForCancel: true,
+				ScheduledForDelete: true,
+				WhenStartedUnixMs:  testkit.Now.UnixMilli(),
+				Status: rest.ReplicationReplicateDetailsReplicaStatus{
+					State:             rest.FINALIZING,
+					WhenStartedUnixMs: testkit.Now.UnixMilli(),
+				},
+				StatusHistory: []rest.ReplicationReplicateDetailsReplicaStatus{
+					{
+						State: rest.INTEGRATING,
+						Errors: []rest.ReplicationReplicateDetailsReplicaStatusError{
+							{Message: "Whaam!", WhenErroredUnixMs: testkit.Now.UnixMilli()},
+						},
+						WhenStartedUnixMs: testkit.Now.UnixMilli(),
+					},
+				},
+			},
+			dest: new(api.Replication),
+			want: &api.Replication{
+				Type:            api.ReplicationMove,
+				ID:              testkit.UUID,
+				Collection:      "Songs",
+				Shard:           "abc",
+				Source:          "node-0",
+				Target:          "node-1",
+				CanCancel:       false,
+				CancelScheduled: true,
+				DeleteScheduled: true,
+				StartedAt:       testkit.Now,
+				Current: api.ReplicationStage{
+					State:     api.ReplicationStateFinalizing,
+					StartedAt: testkit.Now,
+				},
+				History: []api.ReplicationStage{
+					{
+						State:     api.ReplicationStateIntegrating,
+						StartedAt: testkit.Now,
+						Errors: []api.ReplicationError{
+							{Message: "Whaam!", Time: testkit.Now},
+						},
+					},
+				},
+			},
+		},
 	}) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.NotNil(t, tt.body, "incomplete test case: body is nil")

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -1200,6 +1200,66 @@ func TestRESTRequests(t *testing.T) {
 			wantPath:   "/nodes",
 			wantQuery:  url.Values{"shardName": {"xyz"}},
 		},
+		{
+			name: "create replication",
+			req: &api.CreateReplicationRequest{
+				Type:       api.ReplicationCopy,
+				Collection: "Songs",
+				Shard:      "abc",
+				Source:     "node-0",
+				Target:     "node-2",
+			},
+			wantMethod: http.MethodPost,
+			wantPath:   "/replication/replicate",
+			wantBody: rest.ReplicateJSONRequestBody{
+				Type:       rest.ReplicationReplicateReplicaRequestTypeCOPY,
+				Collection: "Songs",
+				Shard:      "abc",
+				SourceNode: "node-0",
+				TargetNode: "node-2",
+			},
+		},
+		{
+			name:       "get replication",
+			req:        &api.GetReplicationRequest{UUID: testkit.UUID},
+			wantMethod: http.MethodGet,
+			wantPath:   "/replication/replicate/" + testkit.UUID.String(),
+			wantQuery:  url.Values{"includeHistory": {"false"}},
+		},
+		{
+			name: "list replications",
+			req: &api.ListReplicationsRequest{
+				Collection:     "Songs",
+				Target:         "node-1",
+				IncludeHistory: true,
+			},
+			wantMethod: http.MethodGet,
+			wantPath:   "/replication/replicate/list",
+			wantQuery: url.Values{
+				"includeHistory": {"true"},
+				"collection":     {"Songs"},
+				"targetNode":     {"node-1"},
+				// "shard" is not included because it's empty
+			},
+		},
+		{
+			name:       "cancel replication",
+			req:        api.CancelReplicationRequest(testkit.UUID),
+			wantMethod: http.MethodPost,
+			wantPath:   "/replication/replicate/" + testkit.UUID.String() + "/cancel",
+		},
+		{
+			name:       "delete a replication",
+			req:        api.DeleteReplicationRequest(testkit.UUID),
+			wantMethod: http.MethodDelete,
+			wantPath:   "/replication/replicate/" + testkit.UUID.String(),
+		},
+		{
+			name:       "delete all replications",
+			req:        api.DeleteAllReplicationsRequest,
+			wantMethod: http.MethodDelete,
+			wantPath:   "/replication/replicate",
+		},
 	}) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Implements(t, (*transports.Endpoint)(nil), tt.req)

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -1221,7 +1221,7 @@ func TestRESTRequests(t *testing.T) {
 		},
 		{
 			name:       "get replication",
-			req:        &api.GetReplicationRequest{UUID: testkit.UUID},
+			req:        &api.GetReplicationRequest{ID: testkit.UUID},
 			wantMethod: http.MethodGet,
 			wantPath:   "/replication/replicate/" + testkit.UUID.String(),
 			wantQuery:  url.Values{"includeHistory": {"false"}},

--- a/internal/api/replication.go
+++ b/internal/api/replication.go
@@ -1,23 +1,56 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/rest"
 	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
 )
 
+type Replication struct {
+	ID              uuid.UUID
+	Type            ReplicationType
+	Collection      string             // The collection being replicated.
+	Shard           string             // The shard being replicated.
+	Source          string             // The source node.
+	Target          string             // The target node.
+	CanCancel       bool               // Whether this replication can be canceled.
+	CancelScheduled bool               // Whether this replication is scheduled for cancelation.
+	DeleteScheduled bool               // Whether this replication is scheduled for deletion.
+	StartedAt       time.Time          // Time at which the replication was initiated.
+	Current         ReplicationStage   // Current stage of the replication.
+	History         []ReplicationStage // History of previous replication stages.
+}
+
+var _ json.Unmarshaler = (*Replication)(nil)
+
+type ReplicationStage struct {
+	State     ReplicationState
+	Errors    []ReplicationError
+	StartedAt time.Time
+}
+
+type ReplicationError struct {
+	Message string    // Error message.
+	Time    time.Time // Time when the error has occurred.
+}
+
+// CreateReplicationRequest starts a new replication.
+// Use with [Replication] as response destination.
 type CreateReplicationRequest struct {
 	transports.BaseEndpoint
 
-	Type       ReplicationType
-	Collection string // Collection to be replicated.
-	Shard      string // Shard to be replicated.
-	Source     string // The source node.
-	Target     string // The target node.
+	Type       ReplicationType // Operation type.
+	Collection string          // Collection to be replicated.
+	Shard      string          // Shard to be replicated.
+	Source     string          // The source node.
+	Target     string          // The target node.
 }
 
 var _ transports.Endpoint = (*CreateReplicationRequest)(nil)
@@ -34,6 +67,18 @@ func (r *CreateReplicationRequest) Body() any {
 	}
 }
 
+type ReplicationState rest.ReplicationReplicateDetailsReplicaStatusState
+
+const (
+	ReplicationStateCanceled    = ReplicationState(rest.CANCELLED)
+	ReplicationStateDehydrating = ReplicationState(rest.DEHYDRATING)
+	ReplicationStateFinalizing  = ReplicationState(rest.FINALIZING)
+	ReplicationStateHydrating   = ReplicationState(rest.HYDRATING)
+	ReplicationStateIntegrating = ReplicationState(rest.INTEGRATING)
+	ReplicationStateReady       = ReplicationState(rest.READY)
+	ReplicationStateRegistered  = ReplicationState(rest.REGISTERED)
+)
+
 type ReplicationType rest.ReplicationReplicateReplicaRequestType
 
 const (
@@ -42,12 +87,15 @@ const (
 )
 
 // GetReplicationRequest retrieves a replication operation by its UUID.
+// Use with [Replication] as response destination.
 type GetReplicationRequest struct {
 	transports.BaseEndpoint
 
 	UUID           uuid.UUID // Replication ID.
 	IncludeHistory bool      // Include history of status changes in the reply.
 }
+
+var _ transports.Endpoint = (*GetReplicationRequest)(nil)
 
 func (GetReplicationRequest) Method() string  { return http.MethodGet }
 func (r *GetReplicationRequest) Path() string { return "/replication/replicate/" + r.UUID.String() }
@@ -57,6 +105,8 @@ func (r *GetReplicationRequest) Query() url.Values {
 	}
 }
 
+// ListReplicationsRequest retrieves all replications, optionally filtered.
+// Use with [ListReplicationsResponse].
 type ListReplicationsRequest struct {
 	transports.BaseEndpoint
 
@@ -65,6 +115,8 @@ type ListReplicationsRequest struct {
 	Target         string // The target node.
 	IncludeHistory bool   // Include history of status changes in the reply.
 }
+
+var _ transports.Endpoint = (*ListReplicationsRequest)(nil)
 
 func (ListReplicationsRequest) Method() string  { return http.MethodGet }
 func (r *ListReplicationsRequest) Path() string { return "/replication/replicate/list" }
@@ -87,8 +139,62 @@ func (r *ListReplicationsRequest) Query() url.Values {
 	return v
 }
 
+type ListReplicationsResponse []Replication
+
 var (
-	CancelReplicationRequest     = transports.IdentityEndpoint[uuid.UUID](http.MethodPost, "/replication/replicate/%s/cancel")
-	DeleteReplicationRequest     = transports.IdentityEndpoint[uuid.UUID](http.MethodDelete, "/replication/replicate/%s")
+	// Cancel a replication by its UUID.
+	CancelReplicationRequest = transports.IdentityEndpoint[uuid.UUID](http.MethodPost, "/replication/replicate/%s/cancel")
+	// Delete a replication by its UUID.
+	DeleteReplicationRequest = transports.IdentityEndpoint[uuid.UUID](http.MethodDelete, "/replication/replicate/%s")
+	// Delete all replication operations in a cluster.
 	DeleteAllReplicationsRequest = transports.StaticEndpoint(http.MethodDelete, "/replication/replicate")
 )
+
+func (r *Replication) UnmarshalJSON(data []byte) error {
+	var resp rest.ReplicationReplicateDetailsReplicaResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return err
+	}
+
+	var id uuid.UUID
+	if resp.Id != nil {
+		id = *resp.Id
+	}
+
+	stage := func(s rest.ReplicationReplicateDetailsReplicaStatus) ReplicationStage {
+		errs := slices.Grow([]ReplicationError(nil), len(s.Errors))
+		for _, e := range s.Errors {
+			errs = append(errs, ReplicationError{
+				Message: e.Message,
+				Time:    time.UnixMilli(e.WhenErroredUnixMs),
+			})
+		}
+
+		return ReplicationStage{
+			State:     ReplicationState(s.State),
+			StartedAt: time.UnixMilli(s.WhenStartedUnixMs),
+			Errors:    errs,
+		}
+	}
+
+	history := slices.Grow([]ReplicationStage(nil), len(resp.StatusHistory))
+	for _, s := range resp.StatusHistory {
+		history = append(history, stage(s))
+	}
+
+	*r = Replication{
+		Type:            ReplicationType(resp.Type),
+		ID:              id,
+		Collection:      resp.Collection,
+		Shard:           resp.Shard,
+		Source:          resp.SourceNode,
+		Target:          resp.TargetNode,
+		CanCancel:       !resp.Uncancelable,
+		CancelScheduled: resp.ScheduledForCancel,
+		DeleteScheduled: resp.ScheduledForDelete,
+		StartedAt:       time.UnixMilli(resp.WhenStartedUnixMs),
+		Current:         stage(resp.Status),
+		History:         history,
+	}
+	return nil
+}

--- a/internal/api/replication.go
+++ b/internal/api/replication.go
@@ -91,14 +91,14 @@ const (
 type GetReplicationRequest struct {
 	transports.BaseEndpoint
 
-	UUID           uuid.UUID // Replication ID.
+	ID             uuid.UUID // Replication ID.
 	IncludeHistory bool      // Include history of status changes in the reply.
 }
 
 var _ transports.Endpoint = (*GetReplicationRequest)(nil)
 
 func (GetReplicationRequest) Method() string  { return http.MethodGet }
-func (r *GetReplicationRequest) Path() string { return "/replication/replicate/" + r.UUID.String() }
+func (r *GetReplicationRequest) Path() string { return "/replication/replicate/" + r.ID.String() }
 func (r *GetReplicationRequest) Query() url.Values {
 	return url.Values{
 		"includeHistory": {fmt.Sprintf("%t", r.IncludeHistory)},

--- a/internal/api/replication.go
+++ b/internal/api/replication.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/google/uuid"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/rest"
+	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
+)
+
+type CreateReplicationRequest struct {
+	transports.BaseEndpoint
+
+	Type       ReplicationType
+	Collection string // Collection to be replicated.
+	Shard      string // Shard to be replicated.
+	Source     string // The source node.
+	Target     string // The target node.
+}
+
+var _ transports.Endpoint = (*CreateReplicationRequest)(nil)
+
+func (CreateReplicationRequest) Method() string  { return http.MethodPost }
+func (r *CreateReplicationRequest) Path() string { return "/replication/replicate" }
+func (r *CreateReplicationRequest) Body() any {
+	return &rest.ReplicateJSONRequestBody{
+		Type:       rest.ReplicationReplicateReplicaRequestType(r.Type),
+		Collection: r.Collection,
+		Shard:      r.Shard,
+		SourceNode: r.Source,
+		TargetNode: r.Target,
+	}
+}
+
+type ReplicationType rest.ReplicationReplicateReplicaRequestType
+
+const (
+	ReplicationCopy = ReplicationType(rest.ReplicationReplicateReplicaRequestTypeCOPY)
+	ReplicationMove = ReplicationType(rest.ReplicationReplicateReplicaRequestTypeMOVE)
+)
+
+// GetReplicationRequest retrieves a replication operation by its UUID.
+type GetReplicationRequest struct {
+	transports.BaseEndpoint
+
+	UUID           uuid.UUID // Replication ID.
+	IncludeHistory bool      // Include history of status changes in the reply.
+}
+
+func (GetReplicationRequest) Method() string  { return http.MethodGet }
+func (r *GetReplicationRequest) Path() string { return "/replication/replicate/" + r.UUID.String() }
+func (r *GetReplicationRequest) Query() url.Values {
+	return url.Values{
+		"includeHistory": {fmt.Sprintf("%t", r.IncludeHistory)},
+	}
+}
+
+type ListReplicationsRequest struct {
+	transports.BaseEndpoint
+
+	Collection     string // Collection to be replicated.
+	Shard          string // Shard to be replicated.
+	Target         string // The target node.
+	IncludeHistory bool   // Include history of status changes in the reply.
+}
+
+func (ListReplicationsRequest) Method() string  { return http.MethodGet }
+func (r *ListReplicationsRequest) Path() string { return "/replication/replicate/list" }
+func (r *ListReplicationsRequest) Query() url.Values {
+	v := url.Values{
+		"includeHistory": {fmt.Sprintf("%t", r.IncludeHistory)},
+	}
+	if r.Collection == "" && r.Shard == "" && r.Target == "" {
+		return nil
+	}
+	if r.Collection != "" {
+		v.Set("collection", r.Collection)
+	}
+	if r.Shard != "" {
+		v.Set("shard", r.Shard)
+	}
+	if r.Target != "" {
+		v.Set("targetNode", r.Target)
+	}
+	return v
+}
+
+var (
+	CancelReplicationRequest     = transports.IdentityEndpoint[uuid.UUID](http.MethodPost, "/replication/replicate/%s/cancel")
+	DeleteReplicationRequest     = transports.IdentityEndpoint[uuid.UUID](http.MethodDelete, "/replication/replicate/%s")
+	DeleteAllReplicationsRequest = transports.StaticEndpoint(http.MethodDelete, "/replication/replicate")
+)

--- a/replication/client.go
+++ b/replication/client.go
@@ -102,7 +102,7 @@ func (c *Client) Get(ctx context.Context, options GetOptions) (*Operation, error
 
 	var resp api.Replication
 	if err := c.transport.Do(ctx, req, &resp); err != nil {
-		return nil, fmt.Errorf("create replication: %w", err)
+		return nil, fmt.Errorf("get replication: %w", err)
 	}
 
 	op := newOperation(&resp)
@@ -127,7 +127,7 @@ func (c *Client) List(ctx context.Context, options ListOptions) ([]Operation, er
 
 	var resp api.ListReplicationsResponse
 	if err := c.transport.Do(ctx, req, &resp); err != nil {
-		return nil, fmt.Errorf("create replication: %w", err)
+		return nil, fmt.Errorf("list replications: %w", err)
 	}
 
 	out := slices.Grow([]Operation(nil), len(resp))
@@ -194,7 +194,7 @@ func (c *Client) Delete(ctx context.Context, id uuid.UUID) error {
 
 // DeleteAll deletes information about all replication operations.
 func (c *Client) DeleteAll(ctx context.Context) error {
-	if err := c.transport.Do(ctx, api.DeleteReplicationRequest, nil); err != nil {
+	if err := c.transport.Do(ctx, api.DeleteAllReplicationsRequest, nil); err != nil {
 		return fmt.Errorf("delete all replications: %w", err)
 	}
 	return nil

--- a/replication/client.go
+++ b/replication/client.go
@@ -62,18 +62,32 @@ const (
 	Move = Type(api.ReplicationMove)
 )
 
+type (
+	MoveOptions CreateOptions
+	CopyOptions CreateOptions
+)
+
+// Move starts a MOVE operation for the shard data.
+func (c *Client) Move(ctx context.Context, options MoveOptions) (*Operation, error) {
+	return c.create(ctx, api.ReplicationMove, CreateOptions(options))
+}
+
+// Copy starts a COPY operation for the shard data.
+func (c *Client) Copy(ctx context.Context, options CopyOptions) (*Operation, error) {
+	return c.create(ctx, api.ReplicationCopy, CreateOptions(options))
+}
+
 type CreateOptions struct {
-	Type       Type   // Required: Operation type.
 	Collection string // Required: Collection to be replicated.
 	Shard      string // Required: Shard to be replicated.
 	Source     string // Required: The source node.
 	Target     string // Required: The target node.
 }
 
-// Create starts a new replicatio operation.
-func (c *Client) Create(ctx context.Context, options CreateOptions) (*Operation, error) {
+// create starts a new replication operation.
+func (c *Client) create(ctx context.Context, rt api.ReplicationType, options CreateOptions) (*Operation, error) {
 	req := &api.CreateReplicationRequest{
-		Type:       api.ReplicationType(options.Type),
+		Type:       rt,
 		Collection: options.Collection,
 		Shard:      options.Shard,
 		Source:     options.Source,

--- a/replication/client.go
+++ b/replication/client.go
@@ -1,0 +1,201 @@
+package replication
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
+)
+
+func NewClient(t internal.Transport) *Client {
+	dev.AssertNotNil(t, "transport")
+	return &Client{transport: t}
+}
+
+type Client struct {
+	transport internal.Transport
+}
+type Operation struct {
+	ID              uuid.UUID
+	Type            Type
+	Collection      string    // The collection being replicated.
+	Shard           string    // The shard being replicated.
+	Source          string    // The source node.
+	Target          string    // The target node.
+	CanCancel       bool      // Whether this replication can be canceled.
+	CancelScheduled bool      // Whether this replication is scheduled for cancelation.
+	DeleteScheduled bool      // Whether this replication is scheduled for deletion.
+	StartedAt       time.Time // Time at which the replication was initiated.
+	Current         Stage     // Current stage of the replication.
+	History         []Stage   // History of previous replication stages.
+}
+
+type Stage struct {
+	State     State
+	Errors    []Error
+	StartedAt time.Time
+}
+
+type Error api.ReplicationError
+
+type State api.ReplicationState
+
+const (
+	StateCanceled    = State(api.ReplicationStateCanceled)
+	StateDehydrating = State(api.ReplicationStateDehydrating)
+	StateFinalizing  = State(api.ReplicationStateFinalizing)
+	StateHydrating   = State(api.ReplicationStateHydrating)
+	StateIntegrating = State(api.ReplicationStateIntegrating)
+	StateReady       = State(api.ReplicationStateReady)
+	StateRegistered  = State(api.ReplicationStateRegistered)
+)
+
+type Type api.ReplicationType
+
+const (
+	Copy = Type(api.ReplicationCopy)
+	Move = Type(api.ReplicationMove)
+)
+
+type CreateOptions struct {
+	Type       Type   // Required: Operation type.
+	Collection string // Required: Collection to be replicated.
+	Shard      string // Required: Shard to be replicated.
+	Source     string // Required: The source node.
+	Target     string // Required: The target node.
+}
+
+// Create starts a new replicatio operation.
+func (c *Client) Create(ctx context.Context, options CreateOptions) (*Operation, error) {
+	req := &api.CreateReplicationRequest{
+		Type:       api.ReplicationType(options.Type),
+		Collection: options.Collection,
+		Shard:      options.Shard,
+		Source:     options.Source,
+		Target:     options.Target,
+	}
+
+	var resp api.Replication
+	if err := c.transport.Do(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("create replication: %w", err)
+	}
+	op := newOperation(&resp)
+	return &op, nil
+}
+
+type GetOptions struct {
+	ID             uuid.UUID // Required: Operation ID.
+	IncludeHistory bool      // Include history of status changes in the reply.
+}
+
+// Get information about the replication by its ID.
+func (c *Client) Get(ctx context.Context, options GetOptions) (*Operation, error) {
+	req := &api.GetReplicationRequest{
+		ID:             options.ID,
+		IncludeHistory: options.IncludeHistory,
+	}
+
+	var resp api.Replication
+	if err := c.transport.Do(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("create replication: %w", err)
+	}
+
+	op := newOperation(&resp)
+	return &op, nil
+}
+
+type ListOptions struct {
+	Collection     string // Collection to be replicated.
+	Shard          string // Shard to be replicated.
+	Target         string // The target node.
+	IncludeHistory bool   // Include history of status changes in the reply.
+}
+
+// List replication operations which match the filters.
+func (c *Client) List(ctx context.Context, options ListOptions) ([]Operation, error) {
+	req := &api.ListReplicationsRequest{
+		Collection:     options.Collection,
+		Shard:          options.Shard,
+		Target:         options.Target,
+		IncludeHistory: options.IncludeHistory,
+	}
+
+	var resp api.ListReplicationsResponse
+	if err := c.transport.Do(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("create replication: %w", err)
+	}
+
+	out := slices.Grow([]Operation(nil), len(resp))
+	for i := range resp {
+		out = append(out, newOperation(&resp[i]))
+	}
+	return out, nil
+}
+
+func newOperation(r *api.Replication) Operation {
+	stage := func(s api.ReplicationStage) Stage {
+		errs := slices.Grow([]Error(nil), len(s.Errors))
+		for i := range s.Errors {
+			errs = append(errs, Error(s.Errors[i]))
+		}
+
+		return Stage{
+			State:     State(s.State),
+			StartedAt: s.StartedAt,
+			Errors:    errs,
+		}
+	}
+
+	history := slices.Grow([]Stage(nil), len(r.History))
+	for i := range history {
+		history = append(history, stage(r.History[i]))
+	}
+
+	return Operation{
+		Type:            Type(r.Type),
+		ID:              r.ID,
+		Collection:      r.Collection,
+		Shard:           r.Shard,
+		Source:          r.Source,
+		Target:          r.Target,
+		CanCancel:       r.CanCancel,
+		CancelScheduled: r.CancelScheduled,
+		DeleteScheduled: r.DeleteScheduled,
+		StartedAt:       r.StartedAt,
+		Current:         stage(r.Current),
+		History:         history,
+	}
+}
+
+// Cancel a replication operation by its ID.
+func (c *Client) Cancel(ctx context.Context, id uuid.UUID) error {
+	req := api.CancelReplicationRequest(id)
+
+	if err := c.transport.Do(ctx, req, nil); err != nil {
+		return fmt.Errorf("cancel replication: %w", err)
+	}
+	return nil
+}
+
+// Delete deletes information about a replication operation by its ID.
+func (c *Client) Delete(ctx context.Context, id uuid.UUID) error {
+	req := api.DeleteReplicationRequest(id)
+
+	if err := c.transport.Do(ctx, req, nil); err != nil {
+		return fmt.Errorf("delete replication: %w", err)
+	}
+	return nil
+}
+
+// DeleteAll deletes information about all replication operations.
+func (c *Client) DeleteAll(ctx context.Context) error {
+	if err := c.transport.Do(ctx, api.DeleteReplicationRequest, nil); err != nil {
+		return fmt.Errorf("delete all replications: %w", err)
+	}
+	return nil
+}

--- a/replication/client_test.go
+++ b/replication/client_test.go
@@ -16,18 +16,19 @@ func TestNewClient(t *testing.T) {
 	}, "nil transport")
 }
 
-func TestClient_Create(t *testing.T) {
+// Move and Copy and both thin wrappers around the CreateReplication
+// request, so its enought that we test one of them.
+func TestClient_Move(t *testing.T) {
 	for _, tt := range []struct {
 		name    string
-		options replication.CreateOptions
+		options replication.MoveOptions
 		stubs   []testkit.Stub[api.CreateReplicationRequest, any]
 		want    *replication.Operation
 		err     testkit.Error // Expected error.
 	}{
 		{
 			name: "successfully",
-			options: replication.CreateOptions{
-				Type:       replication.Copy,
+			options: replication.MoveOptions{
 				Collection: "Songs",
 				Shard:      "abc",
 				Source:     "node-0",
@@ -36,15 +37,15 @@ func TestClient_Create(t *testing.T) {
 			stubs: []testkit.Stub[api.CreateReplicationRequest, any]{
 				{
 					Request: &api.CreateReplicationRequest{
-						Type:       api.ReplicationCopy,
+						Type:       api.ReplicationMove,
 						Collection: "Songs",
 						Shard:      "abc",
 						Source:     "node-0",
 						Target:     "node-1",
 					},
 					Response: api.Replication{
+						Type:       api.ReplicationMove,
 						ID:         testkit.UUID,
-						Type:       api.ReplicationCopy,
 						Collection: "Songs",
 						Shard:      "abc",
 						Source:     "node-0",
@@ -54,8 +55,8 @@ func TestClient_Create(t *testing.T) {
 				},
 			},
 			want: &replication.Operation{
+				Type:       replication.Move,
 				ID:         testkit.UUID,
-				Type:       replication.Copy,
 				Collection: "Songs",
 				Shard:      "abc",
 				Source:     "node-0",
@@ -76,8 +77,8 @@ func TestClient_Create(t *testing.T) {
 			c := replication.NewClient(transport)
 			require.NotNil(t, c, "nil client")
 
-			got, err := c.Create(t.Context(), tt.options)
-			tt.err.Require(t, err, "create error")
+			got, err := c.Move(t.Context(), tt.options)
+			tt.err.Require(t, err, "move error")
 			require.EqualExportedValues(t, tt.want, got, "returned operation")
 		})
 	}
@@ -104,8 +105,8 @@ func TestClient_Get(t *testing.T) {
 						IncludeHistory: false,
 					},
 					Response: api.Replication{
-						ID:         testkit.UUID,
 						Type:       api.ReplicationCopy,
+						ID:         testkit.UUID,
 						Collection: "Songs",
 						Shard:      "abc",
 						Source:     "node-0",
@@ -115,8 +116,8 @@ func TestClient_Get(t *testing.T) {
 				},
 			},
 			want: &replication.Operation{
-				ID:         testkit.UUID,
 				Type:       replication.Copy,
+				ID:         testkit.UUID,
 				Collection: "Songs",
 				Shard:      "abc",
 				Source:     "node-0",
@@ -168,8 +169,8 @@ func TestClient_List(t *testing.T) {
 					},
 					Response: []api.Replication{
 						{
-							ID:         testkit.UUID,
 							Type:       api.ReplicationCopy,
+							ID:         testkit.UUID,
 							Collection: "Songs",
 							Shard:      "abc",
 							Source:     "node-0",
@@ -184,8 +185,8 @@ func TestClient_List(t *testing.T) {
 			},
 			want: []replication.Operation{
 				{
-					ID:         testkit.UUID,
 					Type:       replication.Copy,
+					ID:         testkit.UUID,
 					Collection: "Songs",
 					Shard:      "abc",
 					Source:     "node-0",

--- a/replication/client_test.go
+++ b/replication/client_test.go
@@ -1,0 +1,317 @@
+package replication_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+	"github.com/weaviate/weaviate-go-client/v6/replication"
+)
+
+func TestNewClient(t *testing.T) {
+	require.Panics(t, func() {
+		replication.NewClient(nil)
+	}, "nil transport")
+}
+
+func TestClient_Create(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options replication.CreateOptions
+		stubs   []testkit.Stub[api.CreateReplicationRequest, any]
+		want    *replication.Operation
+		err     testkit.Error // Expected error.
+	}{
+		{
+			name: "successfully",
+			options: replication.CreateOptions{
+				Type:       replication.Copy,
+				Collection: "Songs",
+				Shard:      "abc",
+				Source:     "node-0",
+				Target:     "node-1",
+			},
+			stubs: []testkit.Stub[api.CreateReplicationRequest, any]{
+				{
+					Request: &api.CreateReplicationRequest{
+						Type:       api.ReplicationCopy,
+						Collection: "Songs",
+						Shard:      "abc",
+						Source:     "node-0",
+						Target:     "node-1",
+					},
+					Response: api.Replication{
+						ID:         testkit.UUID,
+						Type:       api.ReplicationCopy,
+						Collection: "Songs",
+						Shard:      "abc",
+						Source:     "node-0",
+						Target:     "node-1",
+						StartedAt:  testkit.Now,
+					},
+				},
+			},
+			want: &replication.Operation{
+				ID:         testkit.UUID,
+				Type:       replication.Copy,
+				Collection: "Songs",
+				Shard:      "abc",
+				Source:     "node-0",
+				Target:     "node-1",
+				StartedAt:  testkit.Now,
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.CreateReplicationRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := replication.NewClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.Create(t.Context(), tt.options)
+			tt.err.Require(t, err, "create error")
+			require.EqualExportedValues(t, tt.want, got, "returned operation")
+		})
+	}
+}
+
+func TestClient_Get(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options replication.GetOptions
+		stubs   []testkit.Stub[api.GetReplicationRequest, any]
+		want    *replication.Operation
+		err     testkit.Error // Expected error.
+	}{
+		{
+			name: "successfully",
+			options: replication.GetOptions{
+				ID:             testkit.UUID,
+				IncludeHistory: false,
+			},
+			stubs: []testkit.Stub[api.GetReplicationRequest, any]{
+				{
+					Request: &api.GetReplicationRequest{
+						ID:             testkit.UUID,
+						IncludeHistory: false,
+					},
+					Response: api.Replication{
+						ID:         testkit.UUID,
+						Type:       api.ReplicationCopy,
+						Collection: "Songs",
+						Shard:      "abc",
+						Source:     "node-0",
+						Target:     "node-1",
+						StartedAt:  testkit.Now,
+					},
+				},
+			},
+			want: &replication.Operation{
+				ID:         testkit.UUID,
+				Type:       replication.Copy,
+				Collection: "Songs",
+				Shard:      "abc",
+				Source:     "node-0",
+				Target:     "node-1",
+				StartedAt:  testkit.Now,
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.GetReplicationRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := replication.NewClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.Get(t.Context(), tt.options)
+			tt.err.Require(t, err, "get error")
+			require.EqualExportedValues(t, tt.want, got, "returned operation")
+		})
+	}
+}
+
+func TestClient_List(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options replication.ListOptions
+		stubs   []testkit.Stub[api.ListReplicationsRequest, any]
+		want    []replication.Operation
+		err     testkit.Error // Expected error.
+	}{
+		{
+			name: "successfully",
+			options: replication.ListOptions{
+				Collection: "Songs",
+				Shard:      "abc",
+				Target:     "node-1",
+			},
+			stubs: []testkit.Stub[api.ListReplicationsRequest, any]{
+				{
+					Request: &api.ListReplicationsRequest{
+						Collection: "Songs",
+						Shard:      "abc",
+						Target:     "node-1",
+					},
+					Response: []api.Replication{
+						{
+							ID:         testkit.UUID,
+							Type:       api.ReplicationCopy,
+							Collection: "Songs",
+							Shard:      "abc",
+							Source:     "node-0",
+							Target:     "node-1",
+							StartedAt:  testkit.Now,
+							Current: api.ReplicationStage{
+								State: api.ReplicationStateFinalizing,
+							},
+						},
+					},
+				},
+			},
+			want: []replication.Operation{
+				{
+					ID:         testkit.UUID,
+					Type:       replication.Copy,
+					Collection: "Songs",
+					Shard:      "abc",
+					Source:     "node-0",
+					Target:     "node-1",
+					StartedAt:  testkit.Now,
+					Current: replication.Stage{
+						State: replication.StateFinalizing,
+					},
+				},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[api.ListReplicationsRequest, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := replication.NewClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			got, err := c.List(t.Context(), tt.options)
+			tt.err.Require(t, err, "list error")
+			require.EqualExportedValues(t, tt.want, got, "returned operations")
+		})
+	}
+}
+
+func TestClient_Cancel(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		id    uuid.UUID
+		stubs []testkit.Stub[any, any]
+		err   testkit.Error // Expected error.
+	}{
+		{
+			name: "successfully",
+			id:   testkit.UUID,
+			stubs: []testkit.Stub[any, any]{
+				{Request: testkit.Ptr(api.CancelReplicationRequest(testkit.UUID))},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[any, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := replication.NewClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			err := c.Cancel(t.Context(), tt.id)
+			tt.err.Require(t, err, "cancel error")
+		})
+	}
+}
+
+func TestClient_Delete(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		id    uuid.UUID
+		stubs []testkit.Stub[any, any]
+		err   testkit.Error // Expected error.
+	}{
+		{
+			name: "successfully",
+			id:   testkit.UUID,
+			stubs: []testkit.Stub[any, any]{
+				{Request: testkit.Ptr(api.DeleteReplicationRequest(testkit.UUID))},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[any, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := replication.NewClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			err := c.Delete(t.Context(), tt.id)
+			tt.err.Require(t, err, "delete error")
+		})
+	}
+}
+
+func TestClient_DeleteAll(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		id    uuid.UUID
+		stubs []testkit.Stub[any, any]
+		err   testkit.Error // Expected error.
+	}{
+		{
+			name: "successfully",
+			id:   testkit.UUID,
+			stubs: []testkit.Stub[any, any]{
+				{Request: testkit.Ptr[any](api.DeleteAllReplicationsRequest)},
+			},
+		},
+		{
+			name: "with error",
+			stubs: []testkit.Stub[any, any]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+			c := replication.NewClient(transport)
+			require.NotNil(t, c, "nil client")
+
+			err := c.DeleteAll(t.Context())
+			tt.err.Require(t, err, "delete all error")
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a client for `/replication` endpoints.

```go
// Start a COPY replication.
c.Replication.Copy(ctx, replication.CopyOptions{
    Collection: "Songs",
    Shard: "xyz",
    Source: "node-0",
    Target: "node-1",
})

// Log all replications.
rs, _ := c.Replication.List(ctx, replication.ListOptions{
    Shard: "xyz",
    IncludeHistory: true,
})
for _, r := range rs {
    fmt.Printf("replication %s (%s) has %d errors\n", r.ID, r.Current.State, len(r.Current.Errors))
    for _, e := range r.Stage.Errors {
        fmt.Printf("[%v] %s", e.Time, e.Message)
    }
    
    logHistory(r.History)
}

// Cancel the second operation.
c.Replication.Cancel(ctx, rs[1].ID)

// Delete all replications.
c.Replication.DeleteAll(ctx)
```