### PR TITLE
v6: Vectorizer modules

### DIFF
--- a/collections/client.go
+++ b/collections/client.go
@@ -117,7 +117,12 @@ func (h *Handle) Count(ctx context.Context) (int64, error) {
 //
 // Avoid passing multiple options arguments at once -- only the last one will be applied.
 func (c *Client) Create(ctx context.Context, collection Collection) (*Handle, error) {
-	req := &api.CreateCollectionRequest{Collection: collectionToAPI(&collection)}
+	x, err := collectionToAPI(&collection)
+	if err != nil {
+		return nil, err
+	}
+
+	req := &api.CreateCollectionRequest{Collection: x}
 
 	// No need to read the result of the request, we only need the name to create a handle.
 	if err := c.t.Do(ctx, req, nil); err != nil {
@@ -133,7 +138,10 @@ func (c *Client) GetConfig(ctx context.Context, collectionName string) (*Collect
 	if err := c.t.Do(ctx, api.GetCollectionRequest(collectionName), &resp); err != nil {
 		return nil, fmt.Errorf("get collection config: %w", err)
 	}
-	collection := collectionFromAPI(&resp)
+	collection, err := collectionFromAPI(&resp)
+	if err != nil {
+		return nil, err
+	}
 	return &collection, nil
 }
 
@@ -150,7 +158,11 @@ func (c *Client) List(ctx context.Context) ([]Collection, error) {
 
 	out := make([]Collection, len(resp))
 	for i, c := range resp {
-		out[i] = collectionFromAPI(&c)
+		x, err := collectionFromAPI(&c)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = x
 	}
 	return out, nil
 }

--- a/collections/client_test.go
+++ b/collections/client_test.go
@@ -126,6 +126,14 @@ func TestClient_Create(t *testing.T) {
 						Collections: []string{"Singers", "Bands"},
 					},
 				},
+				Vectors: map[string]collections.VectorConfig{
+					"lyrics_vec": {},
+					"title_vec": {
+						Vectorizer: testkit.Module{
+							"url": "example.com",
+						},
+					},
+				},
 				Sharding: &collections.ShardingConfig{
 					DesiredCount:        3,
 					DesiredVirtualCount: 150,
@@ -206,6 +214,14 @@ func TestClient_Create(t *testing.T) {
 								{
 									Name:        "artist",
 									Collections: []string{"Singers", "Bands"},
+								},
+							},
+							Vectors: map[string]api.VectorConfig{
+								"lyrics_vec": {},
+								"title_vec": {
+									Vectorizer: testkit.Module{
+										"url": "example.com",
+									},
 								},
 							},
 							Sharding: &api.ShardingConfig{
@@ -355,6 +371,14 @@ func TestClient_GetConfig(t *testing.T) {
 								Collections: []string{"Singers", "Bands"},
 							},
 						},
+						Vectors: map[string]api.VectorConfig{
+							"lyrics_vec": {},
+							"title_vec": {
+								Vectorizer: testkit.Module{
+									"url": "example.com",
+								},
+							},
+						},
 						Sharding: &api.ShardingConfig{
 							DesiredCount:        3,
 							DesiredVirtualCount: 150,
@@ -434,6 +458,14 @@ func TestClient_GetConfig(t *testing.T) {
 					{
 						Name:        "artist",
 						Collections: []string{"Singers", "Bands"},
+					},
+				},
+				Vectors: map[string]collections.VectorConfig{
+					"lyrics_vec": {},
+					"title_vec": {
+						Vectorizer: testkit.Module{
+							"url": "example.com",
+						},
 					},
 				},
 				Sharding: &collections.ShardingConfig{

--- a/collections/client_test.go
+++ b/collections/client_test.go
@@ -217,10 +217,15 @@ func TestClient_Create(t *testing.T) {
 								},
 							},
 							Vectors: map[string]api.VectorConfig{
-								"lyrics_vec": {},
+								"lyrics_vec": {
+									Vectorizer: api.NoneVectorizer,
+								},
 								"title_vec": {
-									Vectorizer: testkit.Module{
-										"url": "example.com",
+									Vectorizer: api.Module{
+										Name: testkit.ModuleName,
+										Conf: map[string]any{
+											"url": "example.com",
+										},
 									},
 								},
 							},
@@ -372,10 +377,15 @@ func TestClient_GetConfig(t *testing.T) {
 							},
 						},
 						Vectors: map[string]api.VectorConfig{
-							"lyrics_vec": {},
+							"lyrics_vec": {
+								Vectorizer: api.NoneVectorizer,
+							},
 							"title_vec": {
-								Vectorizer: testkit.Module{
-									"url": "example.com",
+								Vectorizer: api.Module{
+									Name: testkit.ModuleName,
+									Conf: map[string]any{
+										"url": "example.com",
+									},
 								},
 							},
 						},

--- a/collections/collection.go
+++ b/collections/collection.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
 )
@@ -14,6 +15,7 @@ type (
 		Description   string
 		Properties    []Property
 		References    []Reference
+		Vectors       map[string]VectorConfig
 		Sharding      *ShardingConfig
 		Replication   *ReplicationConfig
 		InvertedIndex *InvertedIndexConfig
@@ -57,6 +59,8 @@ type (
 	StopwordConfig     api.StopwordConfig
 	MultiTenancyConfig api.MultiTenancyConfig
 )
+
+type VectorConfig api.VectorConfig
 
 // DataType defines supported property data types.
 type DataType api.DataType
@@ -128,11 +132,17 @@ func collectionToAPI(c *Collection) api.Collection {
 		}
 	}
 
+	vectors := internal.MakeMap[string, api.VectorConfig](len(c.Vectors))
+	for k, v := range c.Vectors {
+		vectors[k] = api.VectorConfig(v)
+	}
+
 	out := api.Collection{
 		Name:         c.Name,
 		Description:  c.Description,
 		Properties:   properties,
 		References:   references,
+		Vectors:      vectors,
 		MultiTenancy: (*api.MultiTenancyConfig)(c.MultiTenancy),
 	}
 
@@ -199,6 +209,11 @@ func collectionFromAPI(c *api.Collection) Collection {
 		}
 	}
 
+	vectors := internal.MakeMap[string, VectorConfig](len(c.Vectors))
+	for k, v := range c.Vectors {
+		vectors[k] = VectorConfig(v)
+	}
+
 	var sharding *ShardingConfig
 	if c.Sharding != nil {
 		sharding = &ShardingConfig{
@@ -235,6 +250,7 @@ func collectionFromAPI(c *api.Collection) Collection {
 		Description:   c.Description,
 		Properties:    properties,
 		References:    references,
+		Vectors:       vectors,
 		Sharding:      sharding,
 		Replication:   replication,
 		InvertedIndex: invertedIndex,

--- a/collections/collection.go
+++ b/collections/collection.go
@@ -4,6 +4,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
+	"github.com/weaviate/weaviate-go-client/v6/modules"
 )
 
 // Alias defines an alias for a collection.
@@ -60,7 +61,16 @@ type (
 	MultiTenancyConfig api.MultiTenancyConfig
 )
 
-type VectorConfig api.VectorConfig
+type VectorConfig struct {
+	// Index any // TODO(dyma)
+	// Compression any // TODO(dyma)
+
+	// Vectorizer module. If no module is selected, the field should be set
+	// to an implementation encoding the "none" option for this module kind.
+	// The value is encoded via [modules.Encode] and does not receive any
+	// special treatment in this package.
+	Vectorizer modules.Module
+}
 
 // DataType defines supported property data types.
 type DataType api.DataType
@@ -103,7 +113,7 @@ const (
 	TimeBasedResolution   DeletionStrategy = DeletionStrategy(api.TimeBasedResolution)
 )
 
-func collectionToAPI(c *Collection) api.Collection {
+func collectionToAPI(c *Collection) (api.Collection, error) {
 	var properties []api.Property
 	if len(c.Properties) > 0 {
 		properties = make([]api.Property, len(c.Properties))
@@ -134,7 +144,29 @@ func collectionToAPI(c *Collection) api.Collection {
 
 	vectors := internal.MakeMap[string, api.VectorConfig](len(c.Vectors))
 	for k, v := range c.Vectors {
-		vectors[k] = api.VectorConfig(v)
+		// var indexType string
+		// var indexConf map[string]any
+		// if v.Index != nil {
+		// 	indexType = v.Index.Type()
+		// }
+
+		var vectorizer api.Module
+		if v.Vectorizer == nil {
+			vectorizer = api.NoneVectorizer
+		} else {
+			conf, err := modules.Encode(v.Vectorizer)
+			if err != nil {
+				return api.Collection{}, err
+			}
+			vectorizer = api.Module{
+				Name: v.Vectorizer.Name(),
+				Conf: conf,
+			}
+		}
+
+		vectors[k] = api.VectorConfig{
+			Vectorizer: vectorizer,
+		}
 	}
 
 	out := api.Collection{
@@ -174,11 +206,11 @@ func collectionToAPI(c *Collection) api.Collection {
 		}
 	}
 
-	return out
+	return out, nil
 }
 
 // collectionFromAPI converts api.Collection into Collection.
-func collectionFromAPI(c *api.Collection) Collection {
+func collectionFromAPI(c *api.Collection) (Collection, error) {
 	dev.AssertNotNil(c, "c")
 
 	var properties []Property
@@ -211,7 +243,18 @@ func collectionFromAPI(c *api.Collection) Collection {
 
 	vectors := internal.MakeMap[string, VectorConfig](len(c.Vectors))
 	for k, v := range c.Vectors {
-		vectors[k] = VectorConfig(v)
+
+		var vectorizer modules.Module
+		if v.Vectorizer.Name != api.NoneVectorizer.Name {
+			conf, err := modules.Decode(v.Vectorizer.Name, v.Vectorizer.Conf)
+			if err != nil {
+				return Collection{}, err
+			}
+			vectorizer = conf
+		}
+		vectors[k] = VectorConfig{
+			Vectorizer: vectorizer,
+		}
 	}
 
 	var sharding *ShardingConfig
@@ -255,7 +298,7 @@ func collectionFromAPI(c *api.Collection) Collection {
 		Replication:   replication,
 		InvertedIndex: invertedIndex,
 		MultiTenancy:  (*MultiTenancyConfig)(c.MultiTenancy),
-	}
+	}, nil
 }
 
 func nestedPropertiesFromAPI(nested []api.Property) []Property {

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -5,9 +5,15 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/rest"
 	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
+	"github.com/weaviate/weaviate-go-client/v6/modules"
 )
+
+func init() {
+	modules.Register(*new(noneVectorizer))
+}
 
 type (
 	Collection struct {
@@ -15,6 +21,7 @@ type (
 		Description   string
 		Properties    []Property
 		References    []ReferenceProperty
+		Vectors       map[string]VectorConfig
 		Sharding      *ShardingConfig
 		Replication   *ReplicationConfig
 		InvertedIndex *InvertedIndexConfig
@@ -71,6 +78,33 @@ type (
 	StopwordConfig     rest.StopwordConfig
 	MultiTenancyConfig rest.MultiTenancyConfig
 )
+
+type VectorConfig struct {
+	// Index any // TODO(dyma)
+	// Compression any // TODO(dyma)
+
+	// Vectorizer module. If no module is selected, the field should be set
+	// to an implementation encoding the "none" option for this module kind.
+	// The value is encoded via [modules.Encode] and does not receive any
+	// special treatment in this package.
+	Vectorizer modules.Module
+}
+
+// noneVectorizer serializes as `"none": {}`, which is a special value
+// the server expects if no vectorizer module should be configured.
+//
+// The client will replace any nil [VectorConfig.Vectorizer] with noneVectorizer on write.
+// On read, the custom Decode hook ensures the user continues to see a nil.
+//
+// It is defined here in internal/api and not in the public modules package
+// because it really is a quirk of the server that the end user should not
+// need to be concerned with.
+type noneVectorizer struct{}
+
+var _ modules.Module = (*noneVectorizer)(nil)
+
+func (noneVectorizer) Name() string                                   { return "none" }
+func (noneVectorizer) Decode(map[string]any) (internal.Module, error) { return nil, nil }
 
 const (
 	FieldUUID          = "_id"
@@ -178,7 +212,7 @@ var (
 	_ json.Unmarshaler = (*Collection)(nil)
 )
 
-// MarshaJSON marshals Collection via [rest.Class].
+// MarshalJSON marshals Collection via [rest.Class].
 func (c *Collection) MarshalJSON() ([]byte, error) {
 	properties := make([]rest.Property, len(c.Properties)+len(c.References))
 	for i, p := range c.Properties {
@@ -200,10 +234,36 @@ func (c *Collection) MarshalJSON() ([]byte, error) {
 		}
 	}
 
+	vectors := internal.MakeMap[string, rest.VectorConfig](len(c.Vectors))
+	for k, v := range c.Vectors {
+		var indexType string
+		var indexConf map[string]any
+		// if v.Index != nil {
+		// 	indexType = v.Index.Type()
+		// }
+
+		if v.Vectorizer == nil {
+			v.Vectorizer = new(noneVectorizer)
+		}
+		vectorizer, err := modules.Encode(v.Vectorizer)
+		if err != nil {
+			return nil, err
+		}
+
+		vectors[k] = rest.VectorConfig{
+			VectorIndexType:   indexType,
+			VectorIndexConfig: indexConf,
+			Vectorizer: map[string]any{
+				v.Vectorizer.Name(): vectorizer,
+			},
+		}
+	}
+
 	out := &rest.Class{
-		Class:       c.Name,
-		Description: c.Description,
-		Properties:  properties,
+		Class:        c.Name,
+		Description:  c.Description,
+		Properties:   properties,
+		VectorConfig: vectors,
 	}
 
 	if c.Sharding != nil {
@@ -317,6 +377,25 @@ func (c *Collection) UnmarshalJSON(data []byte) error {
 		}
 	}
 
+	vectors := internal.MakeMap[string, VectorConfig](len(class.VectorConfig))
+	for k, v := range class.VectorConfig {
+		var vectorizer modules.Module
+		var err error
+		for name, raw := range v.Vectorizer {
+			if m, ok := raw.(map[string]any); ok {
+				vectorizer, err = modules.Decode(name, m)
+			}
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		vectors[k] = VectorConfig{
+			Vectorizer: vectorizer,
+		}
+	}
+
 	var sharding ShardingConfig
 	if len(class.ShardingConfig) > 0 {
 		// In case any of the fields are not ints, the cast will return a zero value.
@@ -331,6 +410,7 @@ func (c *Collection) UnmarshalJSON(data []byte) error {
 		Description: class.Description,
 		Properties:  properties,
 		References:  references,
+		Vectors:     vectors,
 		Replication: &ReplicationConfig{
 			Factor:           class.ReplicationConfig.Factor,
 			DeletionStrategy: DeletionStrategy(class.ReplicationConfig.DeletionStrategy),

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -8,12 +8,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/rest"
 	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
-	"github.com/weaviate/weaviate-go-client/v6/modules"
 )
-
-func init() {
-	modules.Register(*new(noneVectorizer))
-}
 
 type (
 	Collection struct {
@@ -83,14 +78,16 @@ type VectorConfig struct {
 	// Index any // TODO(dyma)
 	// Compression any // TODO(dyma)
 
-	// Vectorizer module. If no module is selected, the field should be set
-	// to an implementation encoding the "none" option for this module kind.
-	// The value is encoded via [modules.Encode] and does not receive any
-	// special treatment in this package.
-	Vectorizer modules.Module
+	// Vectorizer module.
+	Vectorizer Module
 }
 
-// noneVectorizer serializes as `"none": {}`, which is a special value
+type Module struct {
+	Name string         // Module name.
+	Conf map[string]any // Module configuration.
+}
+
+// NoneVectorizer serializes as `"none": {}`, which is a special value
 // the server expects if no vectorizer module should be configured.
 //
 // The client will replace any nil [VectorConfig.Vectorizer] with noneVectorizer on write.
@@ -99,12 +96,7 @@ type VectorConfig struct {
 // It is defined here in internal/api and not in the public modules package
 // because it really is a quirk of the server that the end user should not
 // need to be concerned with.
-type noneVectorizer struct{}
-
-var _ modules.Module = (*noneVectorizer)(nil)
-
-func (noneVectorizer) Name() string                                   { return "none" }
-func (noneVectorizer) Decode(map[string]any) (internal.Module, error) { return nil, nil }
+var NoneVectorizer = Module{Name: "none", Conf: make(map[string]any)}
 
 const (
 	FieldUUID          = "_id"
@@ -236,25 +228,14 @@ func (c *Collection) MarshalJSON() ([]byte, error) {
 
 	vectors := internal.MakeMap[string, rest.VectorConfig](len(c.Vectors))
 	for k, v := range c.Vectors {
-		var indexType string
-		var indexConf map[string]any
-		// if v.Index != nil {
-		// 	indexType = v.Index.Type()
-		// }
-
-		if v.Vectorizer == nil {
-			v.Vectorizer = new(noneVectorizer)
-		}
-		vectorizer, err := modules.Encode(v.Vectorizer)
-		if err != nil {
-			return nil, err
-		}
+		var indexType string         // TODO(dyma)
+		var indexConf map[string]any // TODO(dyma)
 
 		vectors[k] = rest.VectorConfig{
 			VectorIndexType:   indexType,
 			VectorIndexConfig: indexConf,
 			Vectorizer: map[string]any{
-				v.Vectorizer.Name(): vectorizer,
+				v.Vectorizer.Name: v.Vectorizer.Conf,
 			},
 		}
 	}
@@ -379,11 +360,14 @@ func (c *Collection) UnmarshalJSON(data []byte) error {
 
 	vectors := internal.MakeMap[string, VectorConfig](len(class.VectorConfig))
 	for k, v := range class.VectorConfig {
-		var vectorizer modules.Module
+		var vectorizer Module
 		var err error
 		for name, raw := range v.Vectorizer {
-			if m, ok := raw.(map[string]any); ok {
-				vectorizer, err = modules.Decode(name, m)
+			if conf, ok := raw.(map[string]any); ok {
+				vectorizer = Module{
+					Name: name,
+					Conf: conf,
+				}
 			}
 			break
 		}

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -196,11 +196,16 @@ func TestRESTRequests(t *testing.T) {
 					},
 					Vectors: map[string]api.VectorConfig{
 						"lyrics_vec": {
-							Vectorizer: testkit.Module{
-								"url": "example.com",
+							Vectorizer: api.Module{
+								Name: testkit.ModuleName,
+								Conf: map[string]any{
+									"url": "example.com",
+								},
 							},
 						},
-						"title_vec": {}, // none vectorizer
+						"title_vec": {
+							Vectorizer: api.NoneVectorizer,
+						},
 					},
 					Sharding: &api.ShardingConfig{
 						DesiredCount:        3,
@@ -1444,11 +1449,16 @@ func TestRESTResponses(t *testing.T) {
 				},
 				Vectors: map[string]api.VectorConfig{
 					"lyrics_vec": {
-						Vectorizer: testkit.Module{
-							"url": "example.com",
+						Vectorizer: api.Module{
+							Name: testkit.ModuleName,
+							Conf: map[string]any{
+								"url": "example.com",
+							},
 						},
 					},
-					"title_vec": {},
+					"title_vec": {
+						Vectorizer: api.NoneVectorizer,
+					},
 				},
 				Sharding: &api.ShardingConfig{
 					DesiredCount:        3,

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -194,6 +194,14 @@ func TestRESTRequests(t *testing.T) {
 							Collections: []string{"Singers", "Bands"},
 						},
 					},
+					Vectors: map[string]api.VectorConfig{
+						"lyrics_vec": {
+							Vectorizer: testkit.Module{
+								"url": "example.com",
+							},
+						},
+						"title_vec": {}, // none vectorizer
+					},
 					Sharding: &api.ShardingConfig{
 						DesiredCount:        3,
 						DesiredVirtualCount: 150,
@@ -272,6 +280,20 @@ func TestRESTRequests(t *testing.T) {
 					{
 						Name:     "artist",
 						DataType: []string{"Singers", "Bands"},
+					},
+				},
+				VectorConfig: map[string]rest.VectorConfig{
+					"lyrics_vec": {
+						Vectorizer: map[string]any{
+							testkit.ModuleName: map[string]any{
+								"url": "example.com",
+							},
+						},
+					},
+					"title_vec": {
+						Vectorizer: map[string]any{
+							"none": map[string]any{},
+						},
 					},
 				},
 				ShardingConfig: map[string]any{
@@ -1326,6 +1348,20 @@ func TestRESTResponses(t *testing.T) {
 						DataType: []string{"Singers", "Bands"},
 					},
 				},
+				VectorConfig: map[string]rest.VectorConfig{
+					"lyrics_vec": {
+						Vectorizer: map[string]any{
+							testkit.ModuleName: map[string]any{
+								"url": "example.com",
+							},
+						},
+					},
+					"title_vec": {
+						Vectorizer: map[string]any{
+							"none": map[string]any{},
+						},
+					},
+				},
 				ShardingConfig: map[string]any{
 					"desiredCount":        3,
 					"desiredVirtualCount": 150,
@@ -1405,6 +1441,14 @@ func TestRESTResponses(t *testing.T) {
 						Name:        "artist",
 						Collections: []string{"Singers", "Bands"},
 					},
+				},
+				Vectors: map[string]api.VectorConfig{
+					"lyrics_vec": {
+						Vectorizer: testkit.Module{
+							"url": "example.com",
+						},
+					},
+					"title_vec": {},
 				},
 				Sharding: &api.ShardingConfig{
 					DesiredCount:        3,

--- a/internal/modules.go
+++ b/internal/modules.go
@@ -1,0 +1,89 @@
+package internal
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+
+	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
+)
+
+type Module interface {
+	Name() string
+}
+
+// CustomModule stores data for a module that
+// isn't registered with a [Modules] registry.
+type CustomModule interface {
+	Module
+	Raw() map[string]any
+}
+
+type Modules struct {
+	registry sync.Map // Module registry.
+}
+
+// Register adds the module to the registry. The module must be either
+// a struct or a map. Modules relies on value copy after map lookup,
+// so m must be the value and not a pointer, e.g. *new(struct) or make(map).
+//
+// This function uses reflection because all modules are registerred at
+// package init time: doing the checks right away and failing quickly
+// prevents potential runtime bugs. This is also not on the hotpath.
+func (ms *Modules) Register(m Module) {
+	t := reflect.TypeOf(m)
+	if t == nil {
+		panic("register: module is nil")
+	}
+	switch t.Kind() {
+	case reflect.Struct, reflect.Map: // ok
+	case reflect.Pointer:
+		panic(fmt.Sprintf("register %s: module must be passed by value", m.Name()))
+	default:
+		panic(fmt.Sprintf("register %s: module must be a struct or a map", m.Name()))
+	}
+	ms.registry.Store(m.Name(), m)
+}
+
+func (ms *Modules) Decode(name string, raw map[string]any) (Module, error) {
+	m, ok := ms.registry.Load(name)
+	if !ok {
+		return &customModule{
+			name: name,
+			raw:  raw,
+		}, nil
+	}
+
+	dev.AssertType[Module](m, "module")
+
+	// Delegate to custom Decode hook if the module has one.
+	if d, ok := m.(interface {
+		Decode(map[string]any) (Module, error)
+	}); ok {
+		return d.Decode(raw)
+	}
+
+	// Decode using our mapstructure wrapper.
+	if err := Decode(raw, &m); err != nil {
+		return nil, err
+	}
+
+	return m.(Module), nil
+}
+
+func (*Modules) Encode(m Module) (map[string]any, error) {
+	v := make(map[string]any)
+	if err := Encode(m, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// customModule implements a simple [CustomModule].
+type customModule struct {
+	name string
+	raw  map[string]any
+}
+
+func (cm *customModule) Name() string        { return cm.name }
+func (cm *customModule) Raw() map[string]any { return cm.raw }

--- a/internal/modules.go
+++ b/internal/modules.go
@@ -67,13 +67,6 @@ func (ms *Modules) Decode(name string, raw map[string]any) (Module, error) {
 
 	dev.AssertType[Module](m, "module")
 
-	// Delegate to custom Decode hook if the module has one.
-	if d, ok := m.(interface {
-		Decode(map[string]any) (Module, error)
-	}); ok {
-		return d.Decode(raw)
-	}
-
 	// Decode using our mapstructure wrapper.
 	if err := Decode(raw, &m); err != nil {
 		return nil, err

--- a/internal/modules.go
+++ b/internal/modules.go
@@ -19,6 +19,17 @@ type CustomModule interface {
 	Raw() map[string]any
 }
 
+// Modules is a registry of modules keyed by their [Module.Name].
+//
+// In addition to module registration, it supports encoding the
+// module as a map[string]any and decoding a map back into the type
+// registerred for the key.
+//
+// N.B.: before being sent to the server, each module is ultimately
+// encoded into a JSON string, and is decoded from a JSON string on read.
+// The reason Encode/Decode do not work with [json.RawMessage] or a plain
+// []byte is that internal/gen/rest/modules.go reads module configuration
+// into interface{}, which json package specializes to map[string]any.
 type Modules struct {
 	registry sync.Map // Module registry.
 }

--- a/internal/modules_test.go
+++ b/internal/modules_test.go
@@ -53,21 +53,6 @@ func TestModules(t *testing.T) {
 			assert.Subset(t, decoded.(internal.CustomModule).Raw(), raw, "map is preserved")
 		}
 	})
-
-	t.Run("custom decode hook", func(t *testing.T) {
-		helloworld := decoder{"hello": "world"}
-		ms.Register(helloworld)
-
-		foobar := decoder{"foo": "bar"}
-		encoded, err := ms.Encode(foobar)
-		require.NoError(t, err, "encode")
-		require.EqualValues(t, foobar, encoded, "encoded to its actual contents")
-
-		decoded, err := ms.Decode("decoder-module", encoded)
-		require.NoError(t, err, "decode")
-		require.Subset(t, decoded, helloworld, "contains custom values")
-		require.NotSubset(t, decoded, foobar, "contains unexpected values")
-	})
 }
 
 // module implements [internal.Module] for a simple struct.
@@ -85,13 +70,3 @@ type invalid int
 var _ internal.Module = (*invalid)(nil)
 
 func (invalid) Name() string { return "bad-module" }
-
-// decoder always returns its initial value on Decode.
-type decoder map[string]any
-
-var _ internal.Module = (*decoder)(nil)
-
-func (decoder) Name() string { return "decoder-module" }
-func (d decoder) Decode(map[string]any) (internal.Module, error) {
-	return d, nil
-}

--- a/internal/modules_test.go
+++ b/internal/modules_test.go
@@ -86,7 +86,7 @@ var _ internal.Module = (*invalid)(nil)
 
 func (invalid) Name() string { return "bad-module" }
 
-// decoder always decodes to the same map set by v.
+// decoder always returns its initial value on Decode.
 type decoder map[string]any
 
 var _ internal.Module = (*decoder)(nil)

--- a/internal/modules_test.go
+++ b/internal/modules_test.go
@@ -1,0 +1,97 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+)
+
+func TestModules(t *testing.T) {
+	var ms internal.Modules
+	ms.Register(*new(module))
+
+	t.Run("non-struct module", func(t *testing.T) {
+		assert.Panics(t, func() {
+			ms.Register(*new(invalid))
+		})
+	})
+
+	t.Run("pass module by pointer reference", func(t *testing.T) {
+		assert.Panics(t, func() {
+			ms.Register(new(module))
+		})
+	})
+
+	t.Run("register a nil module", func(t *testing.T) {
+		assert.Panics(t, func() {
+			ms.Register(nil)
+		})
+	})
+
+	t.Run("registered module roundtrip", func(t *testing.T) {
+		five := module{5}
+		encoded, err := ms.Encode(five)
+		require.NoError(t, err, "encode")
+		assert.Subset(t, encoded, map[string]any{"value": 5}, "encoded map")
+
+		decoded, err := ms.Decode("test-module", encoded)
+		assert.NoError(t, err, "decode")
+		assert.Equal(t, five, decoded, "decoded value")
+	})
+
+	t.Run("decode unknown module", func(t *testing.T) {
+		raw := map[string]any{"value": 5}
+
+		decoded, err := ms.Decode("unknown", raw)
+
+		assert.NoError(t, err, "decode")
+		require.NotNil(t, decoded, "decoded value")
+		assert.Equal(t, "unknown", decoded.Name(), "module name")
+		if assert.Implements(t, (*internal.CustomModule)(nil), decoded) {
+			assert.Subset(t, decoded.(internal.CustomModule).Raw(), raw, "map is preserved")
+		}
+	})
+
+	t.Run("custom decode hook", func(t *testing.T) {
+		helloworld := decoder{"hello": "world"}
+		ms.Register(helloworld)
+
+		foobar := decoder{"foo": "bar"}
+		encoded, err := ms.Encode(foobar)
+		require.NoError(t, err, "encode")
+		require.EqualValues(t, foobar, encoded, "encoded to its actual contents")
+
+		decoded, err := ms.Decode("decoder-module", encoded)
+		require.NoError(t, err, "decode")
+		require.Subset(t, decoded, helloworld, "contains custom values")
+		require.NotSubset(t, decoded, foobar, "contains unexpected values")
+	})
+}
+
+// module implements [internal.Module] for a simple struct.
+type module struct {
+	Value int `json:"value"`
+}
+
+var _ internal.Module = (*module)(nil)
+
+func (module) Name() string { return "test-module" }
+
+// invalid implements [internal.Module] for an integer.
+type invalid int
+
+var _ internal.Module = (*invalid)(nil)
+
+func (invalid) Name() string { return "bad-module" }
+
+// decoder always decodes to the same map set by v.
+type decoder map[string]any
+
+var _ internal.Module = (*decoder)(nil)
+
+func (decoder) Name() string { return "decoder-module" }
+func (d decoder) Decode(map[string]any) (internal.Module, error) {
+	return d, nil
+}

--- a/internal/orm.go
+++ b/internal/orm.go
@@ -27,7 +27,7 @@ func Decode[T any](m map[string]any, dest *T) error {
 // Decode is a thin wrapper around mapstructure.Decode
 // that encodes a Go struct into a map[string]any.
 // It uses "json" tags instead of the default "mapstructure".
-func Encode[T any](v *T, dest map[string]any) error {
+func Encode(v any, dest map[string]any) error {
 	d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		TagName: tagName,
 		Result:  &dest,

--- a/internal/testkit/module.go
+++ b/internal/testkit/module.go
@@ -1,0 +1,16 @@
+package testkit
+
+import "github.com/weaviate/weaviate-go-client/v6/modules"
+
+func init() {
+	// modules package is shared, so we can register test packages as well.
+	modules.Register(make(Module))
+}
+
+const ModuleName = "testkit-module"
+
+// Module implements [internal.Module] for map of arbitrary values.
+// "testkit-module" is registerred in the modules.registry.
+type Module map[string]any
+
+func (Module) Name() string { return ModuleName }

--- a/modules/model2vec/module.go
+++ b/modules/model2vec/module.go
@@ -1,0 +1,16 @@
+package model2vec
+
+import "github.com/weaviate/weaviate-go-client/v6/modules"
+
+func init() {
+	modules.Register(*new(Text2Vec))
+}
+
+// Text2Vec is a vectorizer for text properties
+// based on the text2vec-model2vec module.
+type Text2Vec struct {
+	URL        string   `json:"inferenceURL"`
+	Properties []string `json:"properties"`
+}
+
+func (Text2Vec) Name() string { return "text2vec-model2vec" }

--- a/modules/register.go
+++ b/modules/register.go
@@ -1,0 +1,38 @@
+// modules provides a registry for third-party modules integrated with Weaviate.
+//
+// To register a new module:
+//
+//	import "github.com/weaviate/weaviate-go-client/v6/modules"
+//
+//	modules.Register(*new(CustomModule))
+//
+// A module must be a struct and implement [Module] with a value receiver.
+// The function panics if [Register] is passed a pointer and not a value,
+// as the registry expects to copy the value before decoding into it.
+package modules
+
+import (
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+)
+
+type (
+	Module internal.Module
+	Custom internal.CustomModule
+)
+
+var registry internal.Modules
+
+func Register(m Module) {
+	registry.Register(m)
+}
+
+// Encode creates a map of all public fields of the module struct.
+func Encode(m Module) (map[string]any, error) {
+	return registry.Encode(m)
+}
+
+// Decode creates a new instance of the module struct.
+// The type depends on the type registered for the name.
+func Decode(name string, raw map[string]any) (Module, error) {
+	return registry.Decode(name, raw)
+}


### PR DESCRIPTION
This PR extends collection configuration to include vectorizers. It also provides one vectorizer module, `text2vec-module2vec`, as an example of the pattern in action.

We include support for "none" vectorizer, or self-provided vectors, which is achieved by simply not setting a vectorizer.

```go
c.Collections.Create(ctx, collections.Collection{
    Vectors: map[string]collections.VectorConfig{
        // Default vector index + text2vec-model2vec vectorizer
        "lyrics_vec": {
            Vectorizer: model2vec.Text2Vec{
                URL: "example.com",
                Properties: []string{"lyrics", "meaning"},
            },
        },
        // "none" vectorizer (+ default vector index) will be configured
        "title_vec": {}, 
    },
})
```

The fact that Vectorizer accepts a `modules.Module` interface means we can easily accommodate "custom" modules both on read and write paths. E.g., suppose a new `text2vec-gzip` module is available in Weaviate, but the Go client hasn't been updated yet. The user can implement their own module and use it with the client.

```go
package my_gzip

import "github.com/weaviate/weaviate-go-client/v6/modules"

func init() { modules.Register(*new(Text2Vec)) }

type Text2Vec struct {
    CompressionLevel int `json:"compression_level"`
    Properties []string  `json:"properties"`
}

func (Text2Vec) Name() string { return "text2vec-gzip" }
```

The client can also read modules which it doesn't know about into a catch-all CustomModule:

```go
config, _ := songs.Config.Get(ctx) // Config.Get is not implemented yet
lyricsVec := config.Vectors["lyrics"]

// Suppose we have created the `text2vec-gzip` vector in a different app altogether,
// so this instance of Go client doesn't know about my_gzip.Text2Vec.
custom, ok := lyricsVec.Vectorizer.(modules.Custom)
if !ok {
    log.Fatalf("Not a modules.Custom, this is actually %T", lyricsVec.Vectorizer)
}

log.Print(custom.Name()) // Outputs: text2vec-gzip
log.Print(custom.Raw())  // Outputs: map[string]any{ "compression_level": 9 }
```

Here I'm trying out the "modules" pattern, where every 3rd party provider (openai/digitalocean/model2vec) declares their modules (vectorizer, reranker, etc) in a "shared" `modules` package, so that the user can easily discover different modules from the same provider.

E.g. `cohere.` + Tab will show all possible modules Cohere has.

___

I did a small change in `internal.Encode` such that it no longer requires a generic parameter like Decode does. The actual type is irrelevant for encoding.