### PR TITLE
v6: minimize the impact of timing on the unit test

### DIFF
--- a/internal/api/transport/token_refresh_test.go
+++ b/internal/api/transport/token_refresh_test.go
@@ -29,23 +29,31 @@ func TestTokenKeepalive(t *testing.T) {
 			Expiry:    testkit.Now.Add(92 * time.Second),
 		}}
 
-		// Act
-		go tokenKeepalive(ctx, &src, func(d time.Duration) <-chan time.Time {
-			assert.Equal(t, time.Duration(92)*time.Second, d, "must try to sleep for %ds", 92)
-			return time.After(2 * time.Millisecond)
-		})
+		c := make(chan time.Time)
+		defer close(c)
 
-		time.Sleep(10 * time.Millisecond)
+		// tick asserts that the caller tried to set the timer for the right duration,
+		// then returns a channel that can be read from immediately.
+		tick := func(d time.Duration) <-chan time.Time {
+			assert.Equal(t, time.Duration(92)*time.Second, d, "must try to sleep for %ds", 92)
+
+			// time.After(0) and the underlying time.NewTicker(0) panic on 0 input.
+			return c
+		}
+
+		// Act
+		go tokenKeepalive(ctx, &src, tick)
+
+		// Wait until tokenKeepaline has received from this channel at least once.
+		// Then cancel the context.
+		c <- time.Now()
 		cancel()
 
 		// Assert
-		require.Greater(t, src.used, 1, "expect src.Token() to be used in the background")
+		assert.GreaterOrEqual(t, src.used, 1, "expect src.Token() to be used in the background")
 
 		src.used = 0
-		time.Sleep(5 * time.Millisecond)
-
-		// FIXME(dyma): this can flake
-		require.Zero(t, src.used, "no src.Token() after context is canceled")
+		assert.Zero(t, src.used, "no src.Token() after context is canceled")
 	})
 }
 

--- a/internal/api/transport/token_refresh_test.go
+++ b/internal/api/transport/token_refresh_test.go
@@ -33,11 +33,9 @@ func TestTokenKeepalive(t *testing.T) {
 		defer close(c)
 
 		// tick asserts that the caller tried to set the timer for the right duration,
-		// then returns a channel that can be read from immediately.
+		// then returns a channel we can feed time.Time on to drive the goroutine.
 		tick := func(d time.Duration) <-chan time.Time {
 			assert.Equal(t, time.Duration(92)*time.Second, d, "must try to sleep for %ds", 92)
-
-			// time.After(0) and the underlying time.NewTicker(0) panic on 0 input.
 			return c
 		}
 

--- a/internal/api/transport/transport.go
+++ b/internal/api/transport/transport.go
@@ -287,6 +287,12 @@ func expireEarly(src oauth2.TokenSource) (oauth2.TokenSource, error) {
 // about when the old one expires. A failed attempt to fetch the token
 // is not retried and the function exits early. It is safe to call with
 // a nil src.
+//
+// The ticker is intentionally a function and not a [time.Ticker]
+// or even the chan time.Time itself. The expiration may vary from
+// between tokens, so using a ticker with constant interval would
+// be incorrect. This does create more garbage, as [time.After] creates
+// a fresh [time.Ticker] on every iteration.
 func tokenKeepalive(ctx context.Context, src oauth2.TokenSource, tickFunc func(time.Duration) <-chan time.Time) {
 	if src == nil {
 		return


### PR DESCRIPTION
Addresses this flaky unit test: https://github.com/weaviate/weaviate-go-client/actions/runs/28953283792/job/85905446083?pr=429#step:4:712

Previously our fake ticker fired after some number of ms, leaving the outcome of the test to the subtle timings. Instead, we return a channel that can be received on immediately.

This may not fix the flake entirely (we'll see), but should be an improvement.