### PR TITLE
v6: Compression

### DIFF
--- a/collections/client_test.go
+++ b/collections/client_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate-go-client/v6/collections"
+	"github.com/weaviate/weaviate-go-client/v6/collections/compression"
 	"github.com/weaviate/weaviate-go-client/v6/collections/vectorindex"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
 	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
@@ -130,14 +131,20 @@ func TestClient_Create(t *testing.T) {
 				Vectors: map[string]collections.VectorConfig{
 					"lyrics_vec": {},
 					"title_vec": {
-						Vectorizer: testkit.Module{
-							"url": "example.com",
-						},
 						Index: vectorindex.HFresh{
 							Distance:         vectorindex.DistanceCosine,
 							MaxPostingSizeKB: 1024,
 							ReplicaCount:     8,
 							SearchProbe:      64,
+						},
+						Compression: compression.RQ{
+							Enabled:      true,
+							Cache:        true,
+							Bits:         1,
+							RescoreLimit: 16,
+						},
+						Vectorizer: testkit.Module{
+							"url": "example.com",
 						},
 					},
 				},
@@ -226,12 +233,6 @@ func TestClient_Create(t *testing.T) {
 							Vectors: map[string]api.VectorConfig{
 								"lyrics_vec": {},
 								"title_vec": {
-									Vectorizer: &api.Module{
-										Name: testkit.ModuleName,
-										Conf: map[string]any{
-											"url": "example.com",
-										},
-									},
 									Index: &api.Module{
 										Name: "hfresh",
 										Conf: map[string]any{
@@ -239,6 +240,21 @@ func TestClient_Create(t *testing.T) {
 											"maxPostingSizeKB": 1024,
 											"replicas":         8,
 											"searchProbe":      64,
+										},
+									},
+									Compression: &api.Module{
+										Name: "rq",
+										Conf: map[string]any{
+											"enabled":       true,
+											"cache":         true,
+											"bits":          1,
+											"rescore_limit": 16,
+										},
+									},
+									Vectorizer: &api.Module{
+										Name: testkit.ModuleName,
+										Conf: map[string]any{
+											"url": "example.com",
 										},
 									},
 								},
@@ -393,12 +409,6 @@ func TestClient_GetConfig(t *testing.T) {
 						Vectors: map[string]api.VectorConfig{
 							"lyrics_vec": {},
 							"title_vec": {
-								Vectorizer: &api.Module{
-									Name: testkit.ModuleName,
-									Conf: map[string]any{
-										"url": "example.com",
-									},
-								},
 								Index: &api.Module{
 									Name: "hfresh",
 									Conf: map[string]any{
@@ -406,6 +416,21 @@ func TestClient_GetConfig(t *testing.T) {
 										"maxPostingSizeKB": 1024,
 										"replicas":         8,
 										"searchProbe":      64,
+									},
+								},
+								Compression: &api.Module{
+									Name: "rq",
+									Conf: map[string]any{
+										"enabled":       true,
+										"cache":         true,
+										"bits":          1,
+										"rescore_limit": 16,
+									},
+								},
+								Vectorizer: &api.Module{
+									Name: testkit.ModuleName,
+									Conf: map[string]any{
+										"url": "example.com",
 									},
 								},
 							},
@@ -494,14 +519,20 @@ func TestClient_GetConfig(t *testing.T) {
 				Vectors: map[string]collections.VectorConfig{
 					"lyrics_vec": {},
 					"title_vec": {
-						Vectorizer: testkit.Module{
-							"url": "example.com",
-						},
 						Index: vectorindex.HFresh{
 							Distance:         vectorindex.DistanceCosine,
 							MaxPostingSizeKB: 1024,
 							ReplicaCount:     8,
 							SearchProbe:      64,
+						},
+						Compression: compression.RQ{
+							Enabled:      true,
+							Cache:        true,
+							Bits:         1,
+							RescoreLimit: 16,
+						},
+						Vectorizer: testkit.Module{
+							"url": "example.com",
 						},
 					},
 				},

--- a/collections/client_test.go
+++ b/collections/client_test.go
@@ -138,7 +138,6 @@ func TestClient_Create(t *testing.T) {
 							SearchProbe:      64,
 						},
 						Compression: compression.RQ{
-							Enabled:      true,
 							Cache:        true,
 							Bits:         1,
 							RescoreLimit: 16,
@@ -246,7 +245,6 @@ func TestClient_Create(t *testing.T) {
 									Compression: &api.Module{
 										Name: "rq",
 										Conf: map[string]any{
-											"enabled":       true,
 											"cache":         true,
 											"bits":          1,
 											"rescore_limit": 16,
@@ -423,7 +421,6 @@ func TestClient_GetConfig(t *testing.T) {
 								Compression: &api.Module{
 									Name: "rq",
 									Conf: map[string]any{
-										"enabled":       true,
 										"cache":         true,
 										"bits":          1,
 										"rescore_limit": 16,
@@ -529,7 +526,6 @@ func TestClient_GetConfig(t *testing.T) {
 							SearchProbe:      64,
 						},
 						Compression: compression.RQ{
-							Enabled:      true,
 							Cache:        true,
 							Bits:         1,
 							RescoreLimit: 16,

--- a/collections/client_test.go
+++ b/collections/client_test.go
@@ -147,6 +147,7 @@ func TestClient_Create(t *testing.T) {
 							"url": "example.com",
 						},
 					},
+					"audio_vec": {SkipDefaultCompression: true},
 				},
 				Sharding: &collections.ShardingConfig{
 					DesiredCount:        3,
@@ -258,6 +259,7 @@ func TestClient_Create(t *testing.T) {
 										},
 									},
 								},
+								"audio_vec": {SkipDefaultCompression: true},
 							},
 							Sharding: &api.ShardingConfig{
 								DesiredCount:        3,
@@ -434,6 +436,7 @@ func TestClient_GetConfig(t *testing.T) {
 									},
 								},
 							},
+							"audio_vec": {SkipDefaultCompression: true},
 						},
 						Sharding: &api.ShardingConfig{
 							DesiredCount:        3,
@@ -535,6 +538,7 @@ func TestClient_GetConfig(t *testing.T) {
 							"url": "example.com",
 						},
 					},
+					"audio_vec": {SkipDefaultCompression: true},
 				},
 				Sharding: &collections.ShardingConfig{
 					DesiredCount:        3,

--- a/collections/collection.go
+++ b/collections/collection.go
@@ -69,14 +69,25 @@ type (
 )
 
 type VectorConfig struct {
-	Index       VectorIndex
+	// Vector index configuration.
+	// See [collections/vectorindex] package for available index options.
+	Index VectorIndex
+
+	// Compression algorithm for vector data.
+	// See [collections/compression] package for available algorithms.
 	Compression Compression
+
+	// SkipDefaultCompression prevents the server from selecting the default
+	// compression algorithm when [Compression] does not specify any.
+	// If set to true, vector data will be stored in its original shape until
+	// compression is manually enabled later.
+	SkipDefaultCompression bool
 
 	// Vectorizer module. If no module is selected, the field should be set
 	// to an implementation encoding the "none" option for this module kind.
 	// The value is encoded via [modules.Encode] and does not receive any
 	// special treatment in this package.
-	// See v6/modules package for available vectorizers.
+	// See ./modules package for available vectorizers.
 	Vectorizer modules.Module
 }
 
@@ -165,6 +176,7 @@ func collectionToAPI(c *Collection) (api.Collection, error) {
 			}
 		}
 
+		vc.SkipDefaultCompression = v.SkipDefaultCompression
 		if v.Compression != nil {
 			conf, err := compression.Registry.Encode(v.Compression)
 			if err != nil {
@@ -274,6 +286,7 @@ func collectionFromAPI(c *api.Collection) (Collection, error) {
 			vc.Index = conf
 		}
 
+		vc.SkipDefaultCompression = v.SkipDefaultCompression
 		if v.Compression != nil {
 			conf, err := compression.Registry.Decode(v.Compression.Name, v.Compression.Conf)
 			if err != nil {

--- a/collections/collection.go
+++ b/collections/collection.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"github.com/weaviate/weaviate-go-client/v6/collections/compression"
 	"github.com/weaviate/weaviate-go-client/v6/collections/vectorindex"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
@@ -62,11 +63,14 @@ type (
 	MultiTenancyConfig api.MultiTenancyConfig
 )
 
-type VectorIndex internal.Module[vectorindex.Type]
+type (
+	VectorIndex internal.Module[vectorindex.Type]
+	Compression internal.Module[compression.Type]
+)
 
 type VectorConfig struct {
-	Index VectorIndex
-	// Compression any // TODO(dyma)
+	Index       VectorIndex
+	Compression Compression
 
 	// Vectorizer module. If no module is selected, the field should be set
 	// to an implementation encoding the "none" option for this module kind.
@@ -157,6 +161,17 @@ func collectionToAPI(c *Collection) (api.Collection, error) {
 			}
 			vc.Index = &api.Module{
 				Name: string(v.Index.Name()),
+				Conf: conf,
+			}
+		}
+
+		if v.Compression != nil {
+			conf, err := compression.Registry.Encode(v.Compression)
+			if err != nil {
+				return api.Collection{}, err
+			}
+			vc.Compression = &api.Module{
+				Name: string(v.Compression.Name()),
 				Conf: conf,
 			}
 		}
@@ -257,6 +272,14 @@ func collectionFromAPI(c *api.Collection) (Collection, error) {
 				return Collection{}, err
 			}
 			vc.Index = conf
+		}
+
+		if v.Compression != nil {
+			conf, err := compression.Registry.Decode(v.Compression.Name, v.Compression.Conf)
+			if err != nil {
+				return Collection{}, err
+			}
+			vc.Compression = conf
 		}
 
 		if v.Vectorizer != nil {

--- a/collections/compression/compression.go
+++ b/collections/compression/compression.go
@@ -14,7 +14,6 @@ type Type string
 var _ internal.Module[Type] = (*RQ)(nil)
 
 type RQ struct {
-	Enabled      bool `json:"enabled"`
 	Bits         int  `json:"bits"`
 	RescoreLimit int  `json:"rescore_limit"`
 	Cache        bool `json:"cache"`

--- a/collections/compression/compression.go
+++ b/collections/compression/compression.go
@@ -1,0 +1,23 @@
+package compression
+
+import "github.com/weaviate/weaviate-go-client/v6/internal"
+
+// Registry stores all compression algorithms defined by this package.
+var Registry internal.Modules[Type]
+
+func init() {
+	Registry.Register(*new(RQ))
+}
+
+type Type string
+
+var _ internal.Module[Type] = (*RQ)(nil)
+
+type RQ struct {
+	Enabled      bool `json:"enabled"`
+	Bits         int  `json:"bits"`
+	RescoreLimit int  `json:"rescore_limit"`
+	Cache        bool `json:"cache"`
+}
+
+func (RQ) Name() Type { return "rq" }

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -398,7 +398,7 @@ func (c *Collection) UnmarshalJSON(data []byte) error {
 
 		if conf := v.VectorIndexConfig; conf != nil {
 			// Compression config map is embedded into the vector index configuration.
-			// If we can find any of the registered compresison modules there, we can
+			// If we can find any of the registered compression modules there, we can
 			// extract them into a Module and remove that entry from conf map.
 			if name, ok := compression.Registry.Find(conf); ok {
 				if m, ok := conf[name].(map[string]any); ok {

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -80,7 +80,8 @@ type VectorConfig struct {
 	Index *Module
 
 	// Compression algorithm.
-	Compression *Module
+	Compression            *Module
+	SkipDefaultCompression bool
 
 	// Vectorizer module.
 	Vectorizer *Module
@@ -205,6 +206,8 @@ var (
 	_ json.Unmarshaler = (*Collection)(nil)
 )
 
+const skipDefaultCompressionKey = "skipDefaultQuantization"
+
 // MarshalJSON marshals Collection via [rest.Class].
 func (c *Collection) MarshalJSON() ([]byte, error) {
 	properties := make([]rest.Property, len(c.Properties)+len(c.References))
@@ -235,9 +238,16 @@ func (c *Collection) MarshalJSON() ([]byte, error) {
 			vc.VectorIndexType = v.Index.Name
 			vc.VectorIndexConfig = v.Index.Conf
 
-			if v.Compression != nil {
+			if !v.SkipDefaultCompression && v.Compression != nil {
 				vc.VectorIndexConfig[v.Compression.Name] = v.Compression.Conf
 			}
+		}
+
+		if v.SkipDefaultCompression {
+			if vc.VectorIndexConfig == nil {
+				vc.VectorIndexConfig = make(map[string]any, 1)
+			}
+			vc.VectorIndexConfig[skipDefaultCompressionKey] = true
 		}
 
 		vectorizer := noneVectorizer
@@ -395,6 +405,13 @@ func (c *Collection) UnmarshalJSON(data []byte) error {
 					}
 				}
 				delete(conf, name)
+			}
+
+			if v, ok := conf[skipDefaultCompressionKey]; ok {
+				delete(conf, skipDefaultCompressionKey)
+				if skip, ok := v.(bool); ok {
+					vc.SkipDefaultCompression = skip
+				}
 			}
 
 			vc.Index = &Module{

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -239,6 +239,9 @@ func (c *Collection) MarshalJSON() ([]byte, error) {
 			vc.VectorIndexConfig = v.Index.Conf
 
 			if !v.SkipDefaultCompression && v.Compression != nil {
+				// "enabled" flag is hidden from the user,
+				// and we only set it at the API threshold.
+				v.Compression.Conf["enabled"] = true
 				vc.VectorIndexConfig[v.Compression.Name] = v.Compression.Conf
 			}
 		}

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/weaviate/weaviate-go-client/v6/collections/compression"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api/internal/gen/rest"
 	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
@@ -75,10 +76,11 @@ type (
 )
 
 type VectorConfig struct {
-	// Compression any // TODO(dyma)
-
 	// Vector index configuration.
 	Index *Module
+
+	// Compression algorithm.
+	Compression *Module
 
 	// Vectorizer module.
 	Vectorizer *Module
@@ -232,6 +234,10 @@ func (c *Collection) MarshalJSON() ([]byte, error) {
 		if v.Index != nil {
 			vc.VectorIndexType = v.Index.Name
 			vc.VectorIndexConfig = v.Index.Conf
+
+			if v.Compression != nil {
+				vc.VectorIndexConfig[v.Compression.Name] = v.Compression.Conf
+			}
 		}
 
 		vectorizer := noneVectorizer
@@ -377,11 +383,25 @@ func (c *Collection) UnmarshalJSON(data []byte) error {
 			break
 		}
 
-		if v.VectorIndexConfig != nil {
+		if conf := v.VectorIndexConfig; conf != nil {
+			// Compression config map is embedded into the vector index configuration.
+			// If we can find any of the registered compresison modules there, we can
+			// extract them into a Module and remove that entry from conf map.
+			if name, ok := compression.Registry.Find(conf); ok {
+				if m, ok := conf[name].(map[string]any); ok {
+					vc.Compression = &Module{
+						Name: name,
+						Conf: m,
+					}
+				}
+				delete(conf, name)
+			}
+
 			vc.Index = &Module{
 				Name: v.VectorIndexType,
-				Conf: v.VectorIndexConfig,
+				Conf: conf,
 			}
+
 		}
 
 		vectors[k] = vc

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -202,6 +202,15 @@ func TestRESTRequests(t *testing.T) {
 									"distance": "cosine",
 								},
 							},
+							Compression: &api.Module{
+								Name: "rq",
+								Conf: map[string]any{
+									"enabled":       true,
+									"cache":         true,
+									"bits":          1,
+									"rescore_limit": 16,
+								},
+							},
 							Vectorizer: &api.Module{
 								Name: testkit.ModuleName,
 								Conf: map[string]any{
@@ -296,6 +305,12 @@ func TestRESTRequests(t *testing.T) {
 						VectorIndexType: "hfresh",
 						VectorIndexConfig: map[string]any{
 							"distance": "cosine",
+							"rq": map[string]any{
+								"enabled":       true,
+								"cache":         true,
+								"bits":          1,
+								"rescore_limit": 16,
+							},
 						},
 						Vectorizer: map[string]any{
 							testkit.ModuleName: map[string]any{
@@ -1366,6 +1381,12 @@ func TestRESTResponses(t *testing.T) {
 						VectorIndexType: "hfresh",
 						VectorIndexConfig: map[string]any{
 							"distance": "cosine",
+							"rq": map[string]any{
+								"enabled":       true,
+								"cache":         true,
+								"bits":          1,
+								"rescore_limit": 16,
+							},
 						},
 						Vectorizer: map[string]any{
 							testkit.ModuleName: map[string]any{
@@ -1465,6 +1486,15 @@ func TestRESTResponses(t *testing.T) {
 							Name: "hfresh",
 							Conf: map[string]any{
 								"distance": "cosine",
+							},
+						},
+						Compression: &api.Module{
+							Name: "rq",
+							Conf: map[string]any{
+								"enabled":       true,
+								"cache":         true,
+								"bits":          float64(1),
+								"rescore_limit": float64(16),
 							},
 						},
 						Vectorizer: &api.Module{

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -219,6 +219,7 @@ func TestRESTRequests(t *testing.T) {
 							},
 						},
 						"title_vec": {},
+						"audio_vec": {SkipDefaultCompression: true},
 					},
 					Sharding: &api.ShardingConfig{
 						DesiredCount:        3,
@@ -319,6 +320,14 @@ func TestRESTRequests(t *testing.T) {
 						},
 					},
 					"title_vec": {
+						Vectorizer: map[string]any{
+							"none": map[string]any{},
+						},
+					},
+					"audio_vec": {
+						VectorIndexConfig: map[string]any{
+							"skipDefaultQuantization": true,
+						},
 						Vectorizer: map[string]any{
 							"none": map[string]any{},
 						},
@@ -1399,6 +1408,13 @@ func TestRESTResponses(t *testing.T) {
 							"none": map[string]any{},
 						},
 					},
+					"audio_vec": {
+						VectorIndexType: "hfresh",
+						VectorIndexConfig: map[string]any{
+							"distance":                "manhattan",
+							"skipDefaultQuantization": true,
+						},
+					},
 				},
 				ShardingConfig: map[string]any{
 					"desiredCount":        3,
@@ -1505,6 +1521,15 @@ func TestRESTResponses(t *testing.T) {
 						},
 					},
 					"title_vec": {},
+					"audio_vec": {
+						Index: &api.Module{
+							Name: "hfresh",
+							Conf: map[string]any{
+								"distance": "manhattan",
+							},
+						},
+						SkipDefaultCompression: true,
+					},
 				},
 				Sharding: &api.ShardingConfig{
 					DesiredCount:        3,

--- a/internal/modules.go
+++ b/internal/modules.go
@@ -83,6 +83,25 @@ func (*Modules[T]) Encode(m Module[T]) (map[string]any, error) {
 	return v, nil
 }
 
+// Find returns the first key from map m for which a module
+// exists in the registry; found indicates if such key exists.
+// The registry is iterated in a random order and the method
+// returns after the first match.
+func (ms *Modules[T]) Find(m map[string]any) (key string, found bool) {
+	ms.registry.Range(func(k any, _ any) bool {
+		name, ok := k.(string)
+		if ok {
+			if _, ok = m[name]; ok {
+				key = name
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return
+}
+
 // customModule implements a simple [CustomModule].
 type customModule[T ~string] struct {
 	name string

--- a/internal/modules_test.go
+++ b/internal/modules_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 )
 
-func TestModules(t *testing.T) {
+func TestModules_EncodeDecode(t *testing.T) {
 	var ms internal.Modules[string]
 	ms.Register(*new(module))
 
@@ -66,6 +66,45 @@ func TestModules(t *testing.T) {
 		assert.NoError(t, err, "decode")
 		assert.Equal(t, five, decoded, "decoded value")
 	})
+}
+
+func TestModules_Find(t *testing.T) {
+	var ms internal.Modules[string]
+	ms.Register(*new(module))
+
+	for _, tt := range []struct {
+		name  string
+		m     map[string]any
+		found assert.BoolAssertionFunc
+		want  string
+	}{
+		{
+			name: "key present",
+			m: map[string]any{
+				"foo":         "bar",
+				"hello":       "world",
+				"test-module": 5,
+			},
+			found: assert.True,
+			want:  "test-module",
+		},
+		{
+			name: "key not present",
+			m: map[string]any{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			found: assert.False,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			key, ok := ms.Find(tt.m)
+
+			if tt.found(t, ok, "found a match") {
+				assert.Equal(t, tt.want, key, "module name")
+			}
+		})
+	}
 }
 
 // module implements [internal.Module] for a simple struct.


### PR DESCRIPTION
In this PR we complete the vector configuration with a compression algorithm. Compression modules are organized exactly like vectorizer and vector index modules from the previous PRs, i.e. under a dedicated `collections/compression` package. 

```go
collections.Collection{
    Vectors: map[string]collections.VectorConfig{
        "lyrics_vec": {
            Compression: compression.RQ{
                Enabled: true,
                Bits: 8,
                RescoreLimit: 64,
                Cache: true,
            },
        },
    },
}
```

We start with only providing RQ quantization; a follow-up PR will extend the package with the remaining option (PQ/SQ/BQ).