### PR TITLE
v6: Fuzz SSB Client

### DIFF
--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -166,8 +166,8 @@ type OOM struct {
 }
 
 type Results struct {
-	OK     []string          // IDs of tasks that completed successfully.
-	Failed map[string]string // Batch insertion errors keyed by task ID.
+	OK     []string         // IDs of tasks that completed successfully.
+	Failed map[string]error // Batch insertion errors keyed by task ID.
 }
 
 type permissionFlags uint8
@@ -438,7 +438,7 @@ func (c *Client) recv(s Stream, cancelSend context.CancelFunc) error {
 			retry := make([]*Task, 0, len(failed))
 			if len(failed) > 0 {
 				c.wip.walk(maps.Keys(failed), func(t *Task) (remove bool) {
-					err := errors.New(failed[t.ID()])
+					err := failed[t.ID()]
 					if c.canRetry.check(t, err) {
 						t.retry(err)
 						retry = append(retry, t)

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -294,6 +294,7 @@ func (c *Client) init() {
 		defer func() {
 			c.finish(err)
 			close(tick)
+			close(c.retry)
 		}()
 
 		// Start a stream, unblock the 'send' goroutine, and continue reconnecting
@@ -495,8 +496,6 @@ func (c *Client) recv(s Stream, cancelSend context.CancelFunc) error {
 // all accepted tasks have been processed. If the context expires, Close
 // fails all pending tasks and returns the cause of the context's expiry.
 func (c *Client) Close() error {
-	defer close(c.retry)
-
 	close(c.queue)
 	<-c.ctx.Done()
 	err := context.Cause(c.ctx)

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"log"
 	"maps"
 	"slices"
 	"sync"
@@ -472,17 +473,21 @@ func (c *Client) recv(s Stream, cancelSend context.CancelFunc) error {
 			c.batch.resize(*event.Backoff)
 
 		case event.OOM != nil:
+			log.Println("{{{{{OOM}}}}}}}")
 			oomTimer = time.AfterFunc(event.OOM.ExitAfter, func() {
+				log.Println("{{{{{OOM -- Server unresponsive}}}}}}}")
 				c.finish(errors.New("server OOM"))
 			})
 			c.state.clear()
 
 		case event.ShuttingDown:
+			log.Println("SHUTTING DOWN =-=======-=0-0-0-00-0-00-00-0-0-0-0")
 			cancelSend()
 			if oomTimer != nil {
 				// The only reason that we got here is because the message
 				// had arrived before oomTimer fired. Server is responsive
 				// and we can try to reconnect.
+				log.Println("|} SHUTTING DOWN AFTER OOM {|")
 				oomTimer.Stop()
 				oomTimer = nil
 			}

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -218,8 +218,8 @@ func (s *state) set(permissions permissionFlags) {
 	s.changed = make(chan struct{})
 }
 
-// await blocks until flag is set or ctx expires
-// and returns [Context.Err] in the latter case.
+// await blocks until permission is set and atomically consumes it.
+// If ctx expires await exits early with [Context.Err].
 func (s *state) await(ctx context.Context, permissions permissionFlags) error {
 	// TODO(dyma): test+fuzz
 
@@ -241,6 +241,7 @@ func (s *state) await(ctx context.Context, permissions permissionFlags) error {
 			return ctx.Err()
 		}
 	}
+	s.permissions &^= permissions
 	s.mu.Unlock()
 	return nil
 }
@@ -353,7 +354,6 @@ func (c *Client) send(ctx context.Context, s Stream) {
 			if err = s.Send(req); err != nil {
 				return
 			}
-			c.state.clear() // Do not send / prepare until this one is Ack'ed.
 		}
 		return
 	}

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -545,6 +545,7 @@ func (b *batch) add(tasks ...*Task) {
 // addLocked adds v to request and updates [batch.len].
 func (b *batch) addLocked(v any) {
 	added, reqFull := b.req.Add(v)
+
 	if added {
 		b.len++
 	}
@@ -599,14 +600,13 @@ func (b *batch) disableGrowth() {
 func (b *batch) refillLocked() {
 	b.req = b.newRequest()
 	b.len = 0
-	b.flags ^= full
+	b.flags &^= full
 	for _, v := range b.buf {
 		b.addLocked(v)
 		if b.flags&full == full {
 			break
 		}
 	}
-	b.buf = b.buf[b.len:]
 }
 
 // clear empties the batch, preserving the capacity and noGrow flag, if set.
@@ -615,9 +615,9 @@ func (b *batch) clear() {
 	defer b.mu.Unlock()
 
 	b.req = b.newRequest()
-	b.buf = b.buf[:0]
 	b.len = 0
-	b.flags ^= full
+	b.buf = b.buf[:0]
+	b.flags &^= full
 }
 
 func newCache(size int) cache {

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -281,9 +281,11 @@ func (c *Client) init() {
 	}
 
 	tick := make(chan span)
+	tock := make(chan struct{})
 	go func() {
 		for s := range tick {
 			c.send(s.ctx, s.stream)
+			tock <- struct{}{}
 		}
 	}()
 
@@ -308,7 +310,8 @@ func (c *Client) init() {
 					// canceled c.ctx will prevent us from reconnecting.
 					return
 				}
-				<-ctx.Done()
+				<-ctx.Done() // Ensure recv canceled the context on exit.
+				<-tock       // Wait until current 'send' routine returns.
 			}
 
 			c.state.clear()

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -110,7 +110,7 @@ var ErrTooLarge = errors.New("batch item exceeds maximum request size")
 type Stream interface {
 	// Send marshaled batch request. The batch is guaranteed to be
 	// of the same type as returned by [Transport.NewRequest].
-	Send(BatchRequest) error
+	Send(any) error
 
 	// Recv receives the next server-side event.
 	// An [io.EOF] indicates the stream has terminated successfully.

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -3,10 +3,8 @@ package ssb
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"iter"
-	"log"
 	"maps"
 	"slices"
 	"sync"
@@ -193,15 +191,6 @@ type state struct {
 	changed     chan struct{}
 }
 
-func (s *state) String() string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return fmt.Sprintf(
-		"[state: changed=%p canPrepare=%t, canSend=%t]",
-		s.changed, s.permissions&canPrepare == canPrepare, s.permissions&canSend == canSend,
-	)
-}
-
 // clear all flags set previously.
 func (s *state) clear() {
 	s.mu.Lock()
@@ -222,8 +211,6 @@ func (s *state) set(permissions permissionFlags) {
 // await blocks until permission is set and atomically consumes it.
 // If ctx expires await exits early with [Context.Err].
 func (s *state) await(ctx context.Context, permissions permissionFlags) error {
-	// TODO(dyma): test+fuzz
-
 	// await works like a context-aware [sync.Cond.Wait].
 	// We check if [s.permissions] contain the permissions we need
 	// while holding the lock. If the check fails, we release the lock
@@ -332,11 +319,7 @@ func (c *Client) init() {
 			// If connection drops, we assume that any in-progress tasks
 			// have failed on the server and we have to redo them all.
 			c.batch.clear()
-			log.Println("BATCH CLEAR")
-			c.wip.all(func(t *Task) {
-				log.Printf("batch.add %s after clear", t.value())
-				c.batch.add(t)
-			})
+			c.wip.all(func(t *Task) { c.batch.add(t) })
 			c.retry = make(chan []*Task, retryBuffer)
 
 			select {
@@ -348,21 +331,9 @@ func (c *Client) init() {
 	}()
 }
 
-func (c *Client) String() string {
-	return fmt.Sprintf(
-		"\t%s\n\t%s\n\t%s\n\tlen(queue)=%d\n\tlen(retry)=%d",
-		&c.state, &c.wip, &c.batch, len(c.queue), len(c.retry),
-	)
-}
-
 // send consumes queue and retry channels, prepares and sends the batch.
 func (c *Client) send(ctx context.Context, s Stream) {
 	defer s.Close() //nolint:errcheck
-
-	log.Printf("{send(%p)}: === begin ===", ctx)
-	defer func() {
-		log.Printf("{send(%p)}: === end ===", ctx)
-	}()
 
 	// The caller should exit if maybeSend returns a non-nil error.
 	maybeSend := func() (err error) {
@@ -397,13 +368,9 @@ func (c *Client) send(ctx context.Context, s Stream) {
 
 			t.setValue(v)
 			c.wip.put(t)
-			log.Printf("batch.add %s after <-c.queue", t.value())
 			c.batch.add(t)
 
 		case tasks := <-c.retry:
-			for _, t := range tasks {
-				log.Printf("batch.add %s after <-c.retry", t.value())
-			}
 			c.batch.add(tasks...)
 
 		case <-ctx.Done():
@@ -416,7 +383,6 @@ func (c *Client) send(ctx context.Context, s Stream) {
 	}
 
 Drain:
-	log.Printf("{send:DRAIN(%p)}: begin \n%s", ctx, c)
 	// Every time we receive Results, the wip shrinks and the batch's capacity
 	// is reduced to the wip's size. This guarantees the batch will eventually
 	// fill up. Disable growth to prevent Backoff from increasing the capacity.
@@ -426,16 +392,12 @@ Drain:
 		if wipCount == 0 {
 			return
 		}
-		log.Println("{send:DRAIN}: resize batch to wip=", wipCount)
 		c.batch.resize(wipCount)
 		if err := maybeSend(); err != nil {
 			return
 		}
 		select {
 		case tasks := <-c.retry:
-			for _, t := range tasks {
-				log.Printf("batch.add %s after <-c.retry (DRAIN)", t.value())
-			}
 			c.batch.add(tasks...)
 		case <-ctx.Done():
 			return
@@ -473,11 +435,9 @@ func (c *Client) recv(s Stream, cancelSend context.CancelFunc) error {
 			c.state.set(canPrepare | canSend)
 
 		case event.Ack:
-			log.Printf("ACK [V]\n%s", c)
 			c.state.set(canPrepare | canSend)
 
 		case event.Results != nil:
-			log.Print("RESULTS")
 			c.wip.walk(slices.Values(event.Results.OK), func(t *Task) bool {
 				t.complete(nil)
 				return true
@@ -501,12 +461,6 @@ func (c *Client) recv(s Stream, cancelSend context.CancelFunc) error {
 				})
 			}
 
-			for _, t := range retry {
-				log.Println("retry " + t.value().(string))
-				if v := t.value(); c.batch.contains(v) {
-					panic("retry " + v.(string) + " still in batch!")
-				}
-			}
 			select {
 			case c.retry <- retry:
 			case <-c.ctx.Done():
@@ -586,15 +540,6 @@ type batch struct {
 	newRequest func() BatchRequest
 }
 
-func (b *batch) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return fmt.Sprintf(
-		"[batch: req=%p b.len=%d b.cap=%d len(b.buf)=%d full=%t noGrow=%t]",
-		b.req, b.len, b.cap, len(b.buf), b.flags&full == full, b.flags&noGrow == noGrow,
-	)
-}
-
 // add all [Task.value] to the batch.
 func (b *batch) add(tasks ...*Task) {
 	b.mu.Lock()
@@ -602,22 +547,11 @@ func (b *batch) add(tasks ...*Task) {
 
 	for _, t := range tasks {
 		v := t.value()
-		if slices.Contains(b.buf, v) {
-			panic("batch.add=" + v.(string))
-		}
 		b.buf = append(b.buf, v)
 		if b.flags&full != full {
 			b.addLocked(v)
 		}
 	}
-}
-
-// Debug
-func (b *batch) contains(v any) bool {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	return slices.Contains(b.buf, v)
 }
 
 // addLocked adds v to request and updates [batch.len].
@@ -706,10 +640,6 @@ func newCache(size int) cache {
 type cache struct {
 	mu sync.Mutex
 	m  map[string]*Task
-}
-
-func (c *cache) String() string {
-	return fmt.Sprintf("[wip: size=%d]", c.size())
 }
 
 // put a task in the cache.

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -206,7 +206,6 @@ func (s *state) String() string {
 func (s *state) clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	log.Printf("{state:clear} changed=%p", s.changed)
 	s.permissions = 0
 }
 
@@ -216,7 +215,6 @@ func (s *state) set(permissions permissionFlags) {
 	defer s.mu.Unlock()
 
 	s.permissions = permissions
-	log.Printf("{state:set}: canSend=%t, NOTIFY close(%p)", s.permissions&canSend == canSend, s.changed)
 	close(s.changed)
 	s.changed = make(chan struct{})
 }
@@ -235,12 +233,10 @@ func (s *state) await(ctx context.Context, permissions permissionFlags) error {
 		// s.changed is closed and re-created on set, so we must copy
 		// the current channel to avoid accessing s.changed concurrently.
 		changed := s.changed
-		log.Printf("{state:await}: canSend=%t, listen for changed=%p ", s.permissions&canSend == canSend, changed)
 		s.mu.Unlock()
 
 		select {
 		case <-changed:
-			log.Printf("<-changed unblocked by=%p", changed)
 			s.mu.Lock()
 		case <-ctx.Done():
 			return ctx.Err()
@@ -367,25 +363,19 @@ func (c *Client) send(ctx context.Context, s Stream) {
 	maybeSend := func() (err error) {
 		req := c.batch.prepare()
 		if req != nil {
-			log.Printf("{send(%p)}: await canSend req=%p\n%s", ctx, req, c)
 			if err = c.state.await(ctx, canSend); err != nil {
-				log.Printf("{send(%p)}: failed to await", ctx)
 				return
 			}
 			if err = s.Send(req); err != nil {
-				log.Printf("{send(%p)}: failed to send req=%p", ctx, req)
 				return
 			}
-			log.Printf("{send(%p)}: SEND req=%p", ctx, req)
 		}
 		return
 	}
 
-	log.Printf("{send(%p)}: await canPrepare", ctx)
 	if err := c.state.await(ctx, canPrepare); err != nil {
 		return
 	}
-	log.Printf("{send(%p)}: Started!\n%s", ctx, c)
 
 	for {
 		select {
@@ -405,7 +395,6 @@ func (c *Client) send(ctx context.Context, s Stream) {
 			c.batch.add(t)
 
 		case tasks := <-c.retry:
-			// log.Printf("{send(%p)}: (%d items) <-c.retry \n%s", ctx, len(tasks), c)
 			c.batch.add(tasks...)
 
 		case <-ctx.Done():
@@ -469,7 +458,6 @@ func (c *Client) recv(s Stream, cancelSend context.CancelFunc) error {
 
 		switch {
 		case event.Started:
-			log.Print("STARTED")
 			c.reconnCount = 0
 			c.state.set(canPrepare | canSend)
 
@@ -507,27 +495,22 @@ func (c *Client) recv(s Stream, cancelSend context.CancelFunc) error {
 			case <-c.ctx.Done():
 				continue
 			}
-			log.Println("c.retry<-retry done => ", len(retry))
 
 		case event.Backoff != nil:
 			c.batch.resize(*event.Backoff)
 
 		case event.OOM != nil:
-			log.Println("{{{{{OOM}}}}}}}")
 			oomTimer = time.AfterFunc(event.OOM.ExitAfter, func() {
-				log.Println("{{{{{OOM -- Server unresponsive}}}}}}}")
 				c.finish(errors.New("server OOM"))
 			})
 			c.state.clear()
 
 		case event.ShuttingDown:
-			log.Println("SHUTTING DOWN =-=======-=0-0-0-00-0-00-00-0-0-0-0")
 			cancelSend()
 			if oomTimer != nil {
 				// The only reason that we got here is because the message
 				// had arrived before oomTimer fired. Server is responsive
 				// and we can try to reconnect.
-				log.Println("|} SHUTTING DOWN AFTER OOM {|")
 				oomTimer.Stop()
 				oomTimer = nil
 			}
@@ -602,6 +585,9 @@ func (b *batch) add(tasks ...*Task) {
 
 	for _, t := range tasks {
 		v := t.value()
+		if slices.Contains(b.buf, v) {
+			panic("batch.add=" + v.(string))
+		}
 		b.buf = append(b.buf, v)
 		if b.flags&full != full {
 			b.addLocked(v)

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -197,8 +197,8 @@ func (s *state) String() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return fmt.Sprintf(
-		"[state: canPrepare=%t, canSend=%t",
-		s.permissions&canPrepare == canPrepare, s.permissions&canSend == canSend,
+		"[state: changed=%p canPrepare=%t, canSend=%t]",
+		s.changed, s.permissions&canPrepare == canPrepare, s.permissions&canSend == canSend,
 	)
 }
 
@@ -206,6 +206,7 @@ func (s *state) String() string {
 func (s *state) clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	log.Printf("{state:clear} changed=%p", s.changed)
 	s.permissions = 0
 }
 
@@ -215,6 +216,7 @@ func (s *state) set(permissions permissionFlags) {
 	defer s.mu.Unlock()
 
 	s.permissions = permissions
+	log.Printf("{state:set}: canSend=%t, NOTIFY close(%p)", s.permissions&canSend == canSend, s.changed)
 	close(s.changed)
 	s.changed = make(chan struct{})
 }
@@ -233,10 +235,12 @@ func (s *state) await(ctx context.Context, permissions permissionFlags) error {
 		// s.changed is closed and re-created on set, so we must copy
 		// the current channel to avoid accessing s.changed concurrently.
 		changed := s.changed
+		log.Printf("{state:await}: canSend=%t, listen for changed=%p ", s.permissions&canSend == canSend, changed)
 		s.mu.Unlock()
 
 		select {
 		case <-changed:
+			log.Printf("<-changed unblocked by=%p", changed)
 			s.mu.Lock()
 		case <-ctx.Done():
 			return ctx.Err()
@@ -341,27 +345,45 @@ func (c *Client) init() {
 	}()
 }
 
+func (c *Client) String() string {
+	return fmt.Sprintf(
+		"\t%s\n\t%s\n\t%s\n\tlen(queue)=%d\n\tlen(retry)=%d",
+		&c.state, &c.wip, &c.batch, len(c.queue), len(c.retry),
+	)
+}
+
 // send consumes queue and retry channels, prepares and sends the batch.
 func (c *Client) send(ctx context.Context, s Stream) {
 	defer s.Close() //nolint:errcheck
+
+	log.Printf("{send(%p)}: === begin ===", ctx)
+	defer func() {
+		log.Printf("{send(%p)}: === end ===", ctx)
+	}()
 
 	// The caller should exit if maybeSend returns a non-nil error.
 	maybeSend := func() (err error) {
 		req := c.batch.prepare()
 		if req != nil {
+			log.Printf("{send(%p)}: await canSend req=%p\n%s", ctx, req, c)
 			if err = c.state.await(ctx, canSend); err != nil {
+				log.Printf("{send(%p)}: failed to await", ctx)
 				return
 			}
 			if err = s.Send(req); err != nil {
+				log.Printf("{send(%p)}: failed to send req=%p", ctx, req)
 				return
 			}
+			log.Printf("{send(%p)}: SEND req=%p", ctx, req)
 		}
 		return
 	}
 
+	log.Printf("{send(%p)}: await canPrepare", ctx)
 	if err := c.state.await(ctx, canPrepare); err != nil {
 		return
 	}
+	log.Printf("{send(%p)}: Started!\n%s", ctx, c)
 
 	for {
 		select {
@@ -381,6 +403,7 @@ func (c *Client) send(ctx context.Context, s Stream) {
 			c.batch.add(t)
 
 		case tasks := <-c.retry:
+			// log.Printf("{send(%p)}: (%d items) <-c.retry \n%s", ctx, len(tasks), c)
 			c.batch.add(tasks...)
 
 		case <-ctx.Done():
@@ -393,6 +416,7 @@ func (c *Client) send(ctx context.Context, s Stream) {
 	}
 
 Drain:
+	log.Printf("{send:DRAIN(%p)}: begin \n%s", ctx, c)
 	// Every time we receive Results, the wip shrinks and the batch's capacity
 	// is reduced to the wip's size. This guarantees the batch will eventually
 	// fill up. Disable growth to prevent Backoff from increasing the capacity.
@@ -402,12 +426,14 @@ Drain:
 		if wipCount == 0 {
 			return
 		}
+		log.Println("{send:DRAIN}: resize batch to wip=", wipCount)
 		c.batch.resize(wipCount)
 		if err := maybeSend(); err != nil {
 			return
 		}
 		select {
 		case tasks := <-c.retry:
+			log.Printf("{send:DRAIN}: got %d retry items, wip=%d", len(tasks), c.wip.size())
 			c.batch.add(tasks...)
 		case <-ctx.Done():
 			return
@@ -433,13 +459,16 @@ func (c *Client) recv(s Stream, cancelSend context.CancelFunc) error {
 
 		switch {
 		case event.Started:
+			log.Print("STARTED")
 			c.reconnCount = 0
 			c.state.set(canPrepare | canSend)
 
 		case event.Ack:
+			log.Printf("ACK [V]\n%s", c)
 			c.state.set(canPrepare | canSend)
 
 		case event.Results != nil:
+			log.Print("RESULTS")
 			c.wip.walk(slices.Values(event.Results.OK), func(t *Task) bool {
 				t.complete(nil)
 				return true
@@ -468,6 +497,7 @@ func (c *Client) recv(s Stream, cancelSend context.CancelFunc) error {
 			case <-c.ctx.Done():
 				continue
 			}
+			log.Println("c.retry<-retry done => ", len(retry))
 
 		case event.Backoff != nil:
 			c.batch.resize(*event.Backoff)
@@ -550,8 +580,8 @@ func (b *batch) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return fmt.Sprintf(
-		"[batch: b.len=%d b.cap=%d len(b.buf)=%d full=%t noGrow=%t",
-		b.len, b.cap, len(b.buf), b.flags&full == full, b.flags&noGrow == noGrow,
+		"[batch: req=%p b.len=%d b.cap=%d len(b.buf)=%d full=%t noGrow=%t]",
+		b.req, b.len, b.cap, len(b.buf), b.flags&full == full, b.flags&noGrow == noGrow,
 	)
 }
 

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -320,15 +320,16 @@ func (c *Client) init() {
 			if s, err = c.transport.NewStream(c.ctx); err == nil {
 				ctx, cancel := context.WithCancel(c.ctx)
 				tick <- span{ctx: ctx, stream: s}
-				if err = c.recv(s, cancel); err == io.EOF {
+				err = c.recv(s, cancel)
+				<-tock       // Wait until current 'send' span completes.
+				<-ctx.Done() // Make sure recv canceled the context on exit
+				if err == io.EOF {
 					// io.EOF means the stream ended successfully,
 					// and everything else means "try to reconnect".
 					// IF the server OOMs and stops responding, the
 					// canceled c.ctx will prevent us from reconnecting.
 					return
 				}
-				<-ctx.Done() // Ensure recv canceled the context on exit.
-				<-tock       // Wait until current 'send' routine returns.
 			}
 
 			c.state.clear()

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -296,8 +296,7 @@ func (c *Client) init() {
 
 		// Start a stream, unblock the 'send' goroutine, and continue reconnecting
 		// until batch completes, the server is deemed unresponsive, or context expires.
-		for ; c.reconnCount < c.reconnLimit; c.reconnCount++ {
-
+		for err = io.EOF; c.reconnCount < c.reconnLimit; c.reconnCount++ {
 			var s Stream
 			if s, err = c.transport.NewStream(c.ctx); err == nil {
 				ctx, cancel := context.WithCancel(c.ctx)

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -557,7 +557,6 @@ func (b *batch) add(tasks ...*Task) {
 // addLocked adds v to request and updates [batch.len].
 func (b *batch) addLocked(v any) {
 	added, reqFull := b.req.Add(v)
-
 	if added {
 		b.len++
 	}

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -329,13 +329,18 @@ func (c *Client) init() {
 			}
 
 			c.state.clear()
+			// If connection drops, we assume that any in-progress tasks
+			// have failed on the server and we have to redo them all.
+			c.batch.clear()
+			log.Println("BATCH CLEAR")
+			c.wip.all(func(t *Task) {
+				log.Printf("batch.add %s after clear", t.value())
+				c.batch.add(t)
+			})
+			c.retry = make(chan []*Task, retryBuffer)
 
 			select {
 			case <-time.After(c.delayFunc(c.reconnCount)):
-				// If connection drops, we assume that any in-progress tasks
-				// have failed on the server and we have to redo them all.
-				c.batch.clear()
-				c.wip.all(func(t *Task) { c.batch.add(t) })
 			case <-c.ctx.Done():
 				return
 			}
@@ -392,9 +397,13 @@ func (c *Client) send(ctx context.Context, s Stream) {
 
 			t.setValue(v)
 			c.wip.put(t)
+			log.Printf("batch.add %s after <-c.queue", t.value())
 			c.batch.add(t)
 
 		case tasks := <-c.retry:
+			for _, t := range tasks {
+				log.Printf("batch.add %s after <-c.retry", t.value())
+			}
 			c.batch.add(tasks...)
 
 		case <-ctx.Done():
@@ -424,7 +433,9 @@ Drain:
 		}
 		select {
 		case tasks := <-c.retry:
-			log.Printf("{send:DRAIN}: got %d retry items, wip=%d", len(tasks), c.wip.size())
+			for _, t := range tasks {
+				log.Printf("batch.add %s after <-c.retry (DRAIN)", t.value())
+			}
 			c.batch.add(tasks...)
 		case <-ctx.Done():
 			return
@@ -490,6 +501,12 @@ func (c *Client) recv(s Stream, cancelSend context.CancelFunc) error {
 				})
 			}
 
+			for _, t := range retry {
+				log.Println("retry " + t.value().(string))
+				if v := t.value(); c.batch.contains(v) {
+					panic("retry " + v.(string) + " still in batch!")
+				}
+			}
 			select {
 			case c.retry <- retry:
 			case <-c.ctx.Done():
@@ -593,6 +610,14 @@ func (b *batch) add(tasks ...*Task) {
 			b.addLocked(v)
 		}
 	}
+}
+
+// Debug
+func (b *batch) contains(v any) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return slices.Contains(b.buf, v)
 }
 
 // addLocked adds v to request and updates [batch.len].

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -3,6 +3,7 @@ package ssb
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"iter"
 	"maps"
@@ -189,6 +190,15 @@ type state struct {
 	mu          sync.Mutex
 	permissions permissionFlags
 	changed     chan struct{}
+}
+
+func (s *state) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return fmt.Sprintf(
+		"[state: canPrepare=%t, canSend=%t",
+		s.permissions&canPrepare == canPrepare, s.permissions&canSend == canSend,
+	)
 }
 
 // clear all flags set previously.
@@ -531,6 +541,15 @@ type batch struct {
 	newRequest func() BatchRequest
 }
 
+func (b *batch) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return fmt.Sprintf(
+		"[batch: b.len=%d b.cap=%d len(b.buf)=%d full=%t noGrow=%t",
+		b.len, b.cap, len(b.buf), b.flags&full == full, b.flags&noGrow == noGrow,
+	)
+}
+
 // add all [Task.value] to the batch.
 func (b *batch) add(tasks ...*Task) {
 	b.mu.Lock()
@@ -631,6 +650,10 @@ func newCache(size int) cache {
 type cache struct {
 	mu sync.Mutex
 	m  map[string]*Task
+}
+
+func (c *cache) String() string {
+	return fmt.Sprintf("[wip: size=%d]", c.size())
 }
 
 // put a task in the cache.

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -108,8 +108,8 @@ type Transport interface {
 var ErrTooLarge = errors.New("batch item exceeds maximum request size")
 
 type Stream interface {
-	// Send marshaled batch request. The batch is guaranteed to be
-	// of the same type as returned by [Transport.NewRequest].
+	// Send marshaled batch request. The batch must be
+	// the value returned by [Transport.NewRequest].
 	Send(any) error
 
 	// Recv receives the next server-side event.

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -299,6 +299,7 @@ func (c *Client) init() {
 	tick := make(chan span)
 	tock := make(chan struct{})
 	go func() {
+		defer close(tock)
 		for s := range tick {
 			c.send(s.ctx, s.stream)
 			tock <- struct{}{}

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -449,6 +449,14 @@ func (c *Client) recv(s Stream, cancelSend context.CancelFunc) error {
 	var oomTimer *time.Timer // Waiting for OOM to resolve.
 	var shutdown bool        // Server is shutting down.
 
+	defer func() {
+		// Stop the timer unconditionally, even if the stream hangs up
+		// while waiting for ShuttingDown after seeing an OOM.
+		if oomTimer != nil {
+			oomTimer.Stop()
+		}
+	}()
+
 	for {
 		event, err := s.Recv()
 		if err != nil {

--- a/internal/api/ssb/protocol_test.go
+++ b/internal/api/ssb/protocol_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -72,6 +71,8 @@ func TestClient(t *testing.T) {
 		work:       make(chan *Batch, 8),
 		seen:       make(map[string]taskStat, sim.TaskCount),
 		done:       make(chan struct{}),
+
+		wip: make(map[string]struct{}),
 	}
 	go srv.run()
 
@@ -158,6 +159,8 @@ type Server struct {
 	work chan *Batch
 	seen map[string]taskStat
 	done chan struct{}
+
+	wip map[string]struct{}
 }
 
 type taskStat struct {
@@ -197,13 +200,30 @@ func (srv *Server) run() {
 			case batch, ok := <-stream.srvRecv():
 				if !ok {
 					for len(srv.work) > 0 {
-						results := srv.processBatch(<-srv.work)
+						batch := <-srv.work
+						results := srv.processBatch(batch)
 						if err := stream.srvSend(Event{Results: results}); err != nil {
 							break Conn
+						}
+						for _, id := range batch.values {
+							t := srv.seen[id]
+							t.Retries++
+							srv.seen[id] = t
 						}
 					}
 					break Conn
 				}
+
+				// Debug: record all data that can be sent in the results
+				for _, v := range batch.values {
+					srv.Logf("received %s, add to wip", v)
+					if _, ok := srv.wip[v]; ok {
+						panic("sent duplicate value " + v)
+					}
+
+					srv.wip[v] = struct{}{}
+				}
+
 				assert.NotNil(srv.T, batch)
 				assert.NotEmpty(srv.T, batch.values)
 				srv.Logf("[server]: Received batch (%d) %p", len(batch.values), batch)
@@ -240,10 +260,9 @@ func (srv *Server) run() {
 			}
 		}
 
-		srv.Logf("[server]: Discard any remaining work (%d)", len(srv.work))
-		for len(srv.work) > 0 {
-			<-srv.work
-		}
+		srv.Logf("[server]: Discard any remaining work=%d, wip=%d", len(srv.work), len(srv.wip))
+		clear(srv.wip)
+		srv.work = make(chan *Batch, 8)
 		srv.Logf("[server]: Close stream")
 		stream.srvClose()
 	}
@@ -260,9 +279,10 @@ func (srv *Server) processBatch(b *Batch) *ssb.Results {
 		if !ok {
 			t = taskStat{Retries: -1}
 		}
-		t.Retries++
 
 		// On it's last retry the task fails with a 1/4 chance.
+		var succ bool
+		srv.Logf("[processbatch: %s.retries=%d", id, t.Retries)
 		if srv.prng.Chance(1, srv.RetryLimit-t.Retries+4) {
 			results.Failed[id] = testkit.ErrWhaam
 			t.Err = testkit.ErrWhaam
@@ -270,9 +290,13 @@ func (srv *Server) processBatch(b *Batch) *ssb.Results {
 		} else {
 			results.OK = append(results.OK, id)
 			t.Err = nil
+			succ = true
 			OK++
 		}
 		srv.seen[id] = t
+
+		srv.Logf("processed %s, delete from wip, ok=%t", id, succ)
+		delete(srv.wip, id)
 	}
 	srv.Logf("[server]: Send results: ok=%d, failed=%d", OK, failed)
 	return results
@@ -381,11 +405,10 @@ func (b *Batch) Add(v any) (added, full bool) {
 	defer require.LessOrEqual(b.T, len(b.values), cap(b.values))
 
 	assert.IsType(b.T, *new(string), v, "bad value in Add")
+	require.NotContains(b.T, b.values, v, "duplicate value in batch %s", v)
+
 	if len(b.values) == cap(b.values) {
 		return false, true
-	}
-	if slices.Contains(b.values, v.(string)) {
-		panic(v)
 	}
 	b.values = append(b.values, v.(string))
 	return true, len(b.values) == cap(b.values)

--- a/internal/api/ssb/protocol_test.go
+++ b/internal/api/ssb/protocol_test.go
@@ -3,9 +3,7 @@ package ssb_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
-	"log"
 	"sync"
 	"testing"
 	"time"
@@ -56,10 +54,8 @@ func (sim *Simulation) newServer(conn chan *Stream) *Server {
 		Simulation: sim,
 		conn:       conn,
 		work:       make(chan *Batch, 8),
-		seen:       make(map[string]taskStat, sim.TaskCount),
+		seen:       make(map[string]int, sim.TaskCount),
 		done:       make(chan struct{}),
-
-		wip: make(map[string]struct{}),
 	}
 }
 
@@ -81,35 +77,12 @@ func (sim *Simulation) TooLarge(id string) bool {
 	return ok
 }
 
-// What I want to test:
-//
-//  1. Client never crashes.
-//  2. If context is not canceled, all data added to the batch makes it to the server.
-//     This includes reconnects, which can happen up to N times in a row.
-//  3. OOM terminates the stream at any given time (+ timeout).
-//  4. Tricky?: No new data is sent before an ACK.
-//  5. Canceling the context fails all in-progress tasks.
-//
-// Of those, 1 and 2 seem to be something that's easy to model in a test.
-// I think what I will try and do is first write tests where I come up with
-// the scenario and then progressively add randomness into it.
-//
-// If I can build a server model with a good size-to-weight ratio, then I can
-// just let it rip FRNG style and check that it doesn't produce invalid outcomes.
-//
-// Luckily (!!) the client can only do Add, so that is a trivial part really.
-// I can fuzz the smaller components (like batch or cache) and PBT the client.
-// protocol_fuzz_test.go (package ssb) + protocol_test.go (package ssb_test)
-//
-// Assertion guideline: During the simulation, use `require` only for testing logic,
-// as it may interrupt the test and cause a panic. Use `require` for final checks.
-
 const retryLimit = 3
 
 func TestClient(t *testing.T) {
+	prng := testkit.NewPRNG(t)
 	for range 10 {
 		t.Run("ssb client fuzz", func(t *testing.T) {
-			prng := testkit.NewPRNG(t)
 			sim := Simulation{
 				T:    t,
 				prng: prng,
@@ -133,6 +106,7 @@ func TestClient(t *testing.T) {
 			for i := 0; i < sim.TaskCount; i++ {
 				id := uuid.New()
 				sim.CheckSize(id.String())
+
 				task, err := c.Add(
 					t.Context(),
 					ssb.Data{Object: &api.BatchObject{UUID: id}},
@@ -140,7 +114,7 @@ func TestClient(t *testing.T) {
 
 				// If the test server can OOM, then we won't try and guess
 				// whether the error was expected, as OOM happens randomly.
-				if !sim.CanOOM {
+				if !sim.CanOOM && err != context.Canceled {
 					assert.NoError(t, err, "add error")
 				}
 
@@ -151,15 +125,8 @@ func TestClient(t *testing.T) {
 				}
 			}
 
-			log.Println("added all data -> close client")
-
 			// Close the client.
-			err := c.Close()
-			if sim.CanOOM && err != nil {
-				assert.ErrorContains(t, err, "OOM", "close error, CanOOM=%t", sim.CanOOM)
-			} else {
-				assert.NoError(t, err, "close error")
-			}
+			c.Close() // nolint:errcheck
 
 			// Shutdown the server.
 			close(conn)
@@ -174,162 +141,13 @@ func TestClient(t *testing.T) {
 	}
 }
 
-type Batch struct {
-	*Simulation
-	values []string
-}
-type Event ssb.Event
-
-type Server struct {
-	*Simulation
-	conn <-chan *Stream
-	work chan *Batch
-	seen map[string]taskStat
-	done chan struct{}
-
-	wip map[string]struct{}
-}
-
-type taskStat struct {
-	Retries int
-	Err     error
-}
-
-func (srv *Server) run() {
-	srv.Helper()
-
-	defer close(srv.work)
-	defer close(srv.done)
-
-	for stream := range srv.conn {
-		if err := stream.srvSend(Event{Started: true}); err != nil {
-			continue
-		}
-
-		var oom bool
-	Conn:
-		for {
-			if srv.ShuttingDown() || oom {
-				srv.Logf("[server]: Shutting down (OOM=%t)", oom)
-				stream.srvSend(Event{ShuttingDown: true})
-				break Conn
-			}
-
-			if srv.Backoff() {
-				backoff := srv.prng.RangeInclusive(srv.BatchSize/2, srv.BatchSize*2)
-				if err := stream.srvSend(Event{Backoff: &backoff}); err != nil {
-					break Conn
-				}
-			}
-
-			select {
-			case batch, ok := <-stream.srvRecv():
-				if !ok {
-					for len(srv.work) > 0 {
-						batch := <-srv.work
-						results := srv.processBatch(batch)
-						if err := stream.srvSend(Event{Results: results}); err != nil {
-							break Conn
-						}
-						for _, id := range batch.values {
-							t := srv.seen[id]
-							t.Retries++
-							if err, ok := results.Failed[id]; ok {
-								t.Err = err
-							}
-							srv.seen[id] = t
-						}
-					}
-					break Conn
-				}
-
-				// Debug: record all data that can be sent in the results
-				for _, v := range batch.values {
-					srv.Logf("received %s, add to wip", v)
-					if _, ok := srv.wip[v]; ok {
-						panic("sent duplicate value " + v)
-					}
-
-					srv.wip[v] = struct{}{}
-				}
-
-				assert.NotNil(srv.T, batch)
-				assert.NotEmpty(srv.T, batch.values)
-				srv.Logf("[server]: Received batch (%d) %p", len(batch.values), batch)
-
-				if oom = srv.OOM(); oom {
-					var exitAfter time.Duration
-					if srv.prng.Bool() {
-						exitAfter = 5 * time.Second
-					}
-					if err := stream.srvSend(Event{OOM: &ssb.OOM{ExitAfter: exitAfter}}); err != nil {
-						break Conn
-					}
-					continue
-				}
-				srv.work <- batch
-				srv.Log("[server]: Ack batch")
-				if err := stream.srvSend(Event{Ack: true}); err != nil {
-					srv.Log("[server]: Failed to ack batch")
-					break Conn
-				}
-				srv.Log("[server]: Ack-ed batch")
-
-			case batch := <-srv.work:
-				results := srv.processBatch(batch)
-				if err := stream.srvSend(Event{Results: results}); err != nil {
-					break Conn
-				}
-				for _, id := range batch.values {
-					t := srv.seen[id]
-					t.Retries++
-					if err, ok := results.Failed[id]; ok {
-						t.Err = err
-					}
-					srv.seen[id] = t
-				}
-			}
-		}
-
-		srv.Logf("[server]: Discard any remaining work=%d, wip=%d", len(srv.work), len(srv.wip))
-		clear(srv.wip)
-		srv.work = make(chan *Batch, 8)
-		srv.Logf("[server]: Close stream")
-		stream.srvClose()
+type (
+	Batch struct {
+		*Simulation
+		values []string
 	}
-}
-
-func (srv *Server) processBatch(b *Batch) *ssb.Results {
-	results := &ssb.Results{
-		OK:     make([]string, 0),
-		Failed: make(map[string]error),
-	}
-	var OK, failed int
-	for _, id := range b.values {
-		t, ok := srv.seen[id]
-		if !ok {
-			t = taskStat{Retries: -1}
-		}
-		srv.seen[id] = t
-
-		// On it's last retry the task fails with a 1/4 chance.
-		var succ bool
-		srv.Logf("[processbatch: %s.retries=%d", id, t.Retries)
-		if srv.prng.Chance(1, srv.RetryLimit-t.Retries+4) {
-			results.Failed[id] = testkit.ErrWhaam
-			failed++
-		} else {
-			results.OK = append(results.OK, id)
-			succ = true
-			OK++
-		}
-
-		srv.Logf("processed %s, delete from wip, ok=%t", id, succ)
-		delete(srv.wip, id)
-	}
-	srv.Logf("[server]: Send results: ok=%d, failed=%d", OK, failed)
-	return results
-}
+	Event ssb.Event
+)
 
 type Transport struct {
 	*Simulation
@@ -355,6 +173,41 @@ func (t *Transport) NewStream(ctx context.Context) (ssb.Stream, error) {
 	return s, nil
 }
 
+func (t *Transport) NewRequest() ssb.BatchRequest {
+	t.Helper()
+	require.Greater(t.T, t.MessageCap, 0, "max message size")
+
+	return &Batch{
+		Simulation: t.Simulation,
+		values:     make([]string, 0, t.MessageCap),
+	}
+}
+
+func (t *Transport) Prepare(data ssb.Data) (any, error) {
+	t.Helper()
+	assert.NotNil(t.T, data.Object, "nil batch object")
+
+	id := data.Object.UUID.String()
+	if t.TooLarge(id) {
+		return nil, ssb.ErrTooLarge
+	}
+	return id, nil
+}
+
+func (b *Batch) Add(v any) (added, full bool) {
+	b.Helper()
+	defer require.LessOrEqual(b.T, cap(b.values), b.MessageCap, "batch grew beyond MessageCap")
+
+	assert.IsType(b.T, *new(string), v, "bad value in Add")
+	assert.NotContains(b.T, b.values, v, "duplicate value in batch %s", v)
+
+	if len(b.values) == cap(b.values) {
+		return false, true
+	}
+	b.values = append(b.values, v.(string))
+	return true, len(b.values) == cap(b.values)
+}
+
 type Stream struct {
 	*Simulation
 	ctx    context.Context
@@ -375,7 +228,6 @@ func (s *Stream) Send(req any) error {
 	select {
 	case s.batchc <- req.(*Batch):
 	case <-s.ctx.Done():
-		s.Log("[stream.Send]: context canceled")
 		return io.EOF
 	}
 	return nil
@@ -395,7 +247,6 @@ func (s *Stream) Recv() (ssb.Event, error) {
 }
 
 func (s *Stream) Close() error {
-	s.Log("[stream.Close]: Client closed it's half of the stream")
 	close(s.batchc)
 	return nil
 }
@@ -411,36 +262,108 @@ func (s *Stream) srvSend(ev Event) error {
 func (s *Stream) srvRecv() <-chan *Batch { return s.batchc }
 func (s *Stream) srvClose()              { s.cancel(io.EOF) }
 
-func (t *Transport) NewRequest() ssb.BatchRequest {
-	return &Batch{
-		Simulation: t.Simulation,
-		values:     make([]string, 0, t.MessageCap),
+type Server struct {
+	*Simulation
+	conn <-chan *Stream
+	work chan *Batch
+	seen map[string]int
+	done chan struct{}
+}
+
+func (srv *Server) run() {
+	srv.Helper()
+
+	defer close(srv.done)
+
+	for stream := range srv.conn {
+		if err := stream.srvSend(Event{Started: true}); err != nil {
+			continue
+		}
+
+		var oom bool
+		work := make(chan *Batch, 8)
+
+	Conn:
+		for {
+			if srv.ShuttingDown() || oom {
+				stream.srvSend(Event{ShuttingDown: true}) // nolint:errcheck
+				break Conn
+			}
+
+			if srv.Backoff() {
+				backoff := srv.prng.RangeInclusive(srv.BatchSize/2, srv.BatchSize*2)
+				if err := stream.srvSend(Event{Backoff: &backoff}); err != nil {
+					break Conn
+				}
+			}
+
+			select {
+			case batch, ok := <-stream.srvRecv():
+				if !ok { // Client closed it's side of the stream.
+					var err error
+					for len(work) > 0 && err == nil {
+						err = srv.processBatch(<-work, stream)
+					}
+					break Conn
+				}
+
+				assert.NotNil(srv.T, batch)
+				assert.NotEmpty(srv.T, batch.values)
+
+				if oom = srv.OOM(); oom {
+					var exitAfter time.Duration // Let the client think server is unresponsive.
+					if /*srv.prng.Bool()*/ true {
+						exitAfter = 5 * time.Second // Give the server enought time to respond.
+					}
+					if err := stream.srvSend(Event{OOM: &ssb.OOM{ExitAfter: exitAfter}}); err != nil {
+						break Conn
+					}
+					continue
+				}
+
+				work <- batch
+				if err := stream.srvSend(Event{Ack: true}); err != nil {
+					break Conn
+				}
+
+			case batch := <-work:
+				if err := srv.processBatch(batch, stream); err != nil {
+					break Conn
+				}
+			}
+		}
+
+		stream.srvClose()
 	}
 }
 
-func (t *Transport) Prepare(data ssb.Data) (any, error) {
-	t.Helper()
-	assert.NotNil(t.T, data.Object, "nil batch object")
-
-	id := data.Object.UUID.String()
-	if t.TooLarge(id) {
-		return nil, ssb.ErrTooLarge
+func (srv *Server) processBatch(b *Batch, s *Stream) error {
+	results := &ssb.Results{
+		OK:     make([]string, 0),
+		Failed: make(map[string]error),
 	}
-	return id, nil
-}
+	for _, id := range b.values {
+		retries, ok := srv.seen[id]
+		if !ok {
+			retries = -1
+		}
+		srv.seen[id] = retries
 
-func (b *Batch) Add(v any) (added, full bool) {
-	b.Helper()
-	defer require.LessOrEqual(b.T, len(b.values), cap(b.values))
-
-	assert.IsType(b.T, *new(string), v, "bad value in Add")
-	require.NotContains(b.T, b.values, v, "duplicate value in batch %s", v)
-
-	if len(b.values) == cap(b.values) {
-		return false, true
+		// On it's last retry the task fails with a 1/4 chance.
+		if srv.prng.Chance(1, srv.RetryLimit-retries+4) {
+			results.Failed[id] = testkit.ErrWhaam
+		} else {
+			results.OK = append(results.OK, id)
+		}
 	}
-	b.values = append(b.values, v.(string))
-	return true, len(b.values) == cap(b.values)
-}
+	if err := s.srvSend(Event{Results: results}); err != nil {
+		return err
+	}
 
-func (b *Batch) String() string { return fmt.Sprint(b.values) }
+	// Update retry stats after the client's received Results,
+	// otherwise we might get out of sync.
+	for _, id := range b.values {
+		srv.seen[id] = srv.seen[id] + 1
+	}
+	return nil
+}

--- a/internal/api/ssb/protocol_test.go
+++ b/internal/api/ssb/protocol_test.go
@@ -126,22 +126,19 @@ func (srv *Server) run() {
 	srv.Helper()
 	defer close(srv.work)
 
-	// srv.Log("[server]: Run")
-
 	for stream := range srv.conn {
 		if err := stream.srvSend(Event{Started: true}); err != nil {
 			continue
 		}
-		// srv.Log("[server]: Stream started")
 
-		// var oom bool
+		var oom bool
 	Conn:
 		for {
-			// if srv.prng.Chance(1, 30) || oom {
-			// 	srv.Logf("[server]: Shutting down (OOM=%t)", oom)
-			// 	stream.srvSend() <- Event{ShuttingDown: true}
-			// 	break Conn
-			// }
+			if srv.prng.Chance(1, 30) || oom {
+				srv.Logf("[server]: Shutting down (OOM=%t)", oom)
+				stream.srvSend(Event{ShuttingDown: true})
+				break Conn
+			}
 			select {
 			case batch, ok := <-stream.srvRecv():
 				if !ok {

--- a/internal/api/ssb/protocol_test.go
+++ b/internal/api/ssb/protocol_test.go
@@ -81,9 +81,9 @@ func TestClient(t *testing.T) {
 	prng := testkit.NewPRNG(t)
 
 	const (
-		N            = 10
+		N            = 50
 		retryLimit   = 3
-		maxTaskCount = 1000
+		maxTaskCount = 500
 	)
 
 	var (

--- a/internal/api/ssb/protocol_test.go
+++ b/internal/api/ssb/protocol_test.go
@@ -3,10 +3,11 @@ package ssb_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log"
+	"slices"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -57,8 +58,8 @@ func TestClient(t *testing.T) {
 	sim := Simulation{
 		T:           t,
 		prng:        testkit.NewPRNG(t),
-		TaskCount:   32,
-		BatchSize:   16,
+		TaskCount:   124512,
+		BatchSize:   53,
 		RetryLimit:  3,
 		ReconnLimit: 5,
 		CanOOM:      true,
@@ -69,7 +70,7 @@ func TestClient(t *testing.T) {
 		Simulation: &sim,
 		conn:       conn,
 		work:       make(chan *Batch, 8),
-		seen:       make(map[uuid.UUID]taskStat, sim.TaskCount),
+		seen:       make(map[string]taskStat, sim.TaskCount),
 		done:       make(chan struct{}),
 	}
 	go srv.run()
@@ -86,11 +87,12 @@ func TestClient(t *testing.T) {
 			Limit:     sim.ReconnLimit,
 			DelayFunc: func(int) time.Duration { return 0 },
 		},
-		CanRetry: func(_ string, retries int, _ error) bool {
+		CanRetry: func(id string, retries int, _ error) bool {
 			return retries < sim.RetryLimit
 		},
 	})
 
+	// Add all data to the client.
 	tasks := make([]*ssb.Task, 0, sim.TaskCount)
 	for i := 0; i < sim.TaskCount; i++ {
 		id := uuid.New()
@@ -115,6 +117,8 @@ func TestClient(t *testing.T) {
 	}
 
 	log.Println("added all data -> close client")
+
+	// Close the client.
 	err := c.Close()
 	if sim.CanOOM && err != nil {
 		assert.ErrorContains(t, err, "OOM", "close error, CanOOM=%t", sim.CanOOM)
@@ -122,14 +126,29 @@ func TestClient(t *testing.T) {
 		assert.NoError(t, err, "close error")
 	}
 
+	// Shutdown the server.
 	close(conn)
 	<-srv.done
+
+	for _, task := range tasks {
+		<-task.Done()
+		id, err := task.ID(), task.Err()
+		if _, tooLarge := sim.TooLarge.Load(id); tooLarge {
+			require.ErrorIs(t, err, ssb.ErrTooLarge, "%s is too large", id)
+			continue
+		}
+		stat, ok := srv.seen[task.ID()]
+		if ok {
+			require.Equal(t, stat.Err, err, "task %s error", id)
+			require.Equal(t, stat.Retries, task.TimesRetried(), "task %s error", id)
+		}
+	}
 	t.Log("FINISH TEST")
 }
 
 type Batch struct {
 	*Simulation
-	values []uuid.UUID
+	values []string
 }
 type Event ssb.Event
 
@@ -137,15 +156,13 @@ type Server struct {
 	*Simulation
 	conn <-chan *Stream
 	work chan *Batch
-	seen map[uuid.UUID]taskStat
+	seen map[string]taskStat
 	done chan struct{}
-
-	oom atomic.Bool
 }
 
 type taskStat struct {
 	Retries int
-	Err     int
+	Err     error
 }
 
 func (srv *Server) run() {
@@ -159,11 +176,11 @@ func (srv *Server) run() {
 			continue
 		}
 
-		srv.oom.Store(false)
+		var oom bool
 	Conn:
 		for {
-			if srv.prng.Chance(1, 30) || srv.oom.Load() {
-				srv.Logf("[server]: Shutting down (OOM=%t)", srv.oom.Load())
+			if srv.prng.Chance(1, 30) || oom {
+				srv.Logf("[server]: Shutting down (OOM=%t)", oom)
 				stream.srvSend(Event{ShuttingDown: true})
 				break Conn
 			}
@@ -191,8 +208,8 @@ func (srv *Server) run() {
 				assert.NotEmpty(srv.T, batch.values)
 				srv.Logf("[server]: Received batch (%d) %p", len(batch.values), batch)
 
-				if srv.prng.Chance(1, 20) {
-					srv.oom.Store(true)
+				if srv.CanOOM && srv.prng.Chance(1, 20) {
+					oom = true
 					var exitAfter time.Duration
 					// if srv.prng.Bool() {
 					exitAfter = 5 * time.Second
@@ -202,7 +219,6 @@ func (srv *Server) run() {
 					}
 					continue
 				}
-				//
 				srv.work <- batch
 				srv.Log("[server]: Ack batch")
 				if err := stream.srvSend(Event{Ack: true}); err != nil {
@@ -212,11 +228,11 @@ func (srv *Server) run() {
 				srv.Log("[server]: Ack-ed batch")
 
 			case batch := <-srv.work:
-				if srv.prng.Chance(1, 10) {
-					srv.Log("[server]: Busy, return batch to queue")
-					srv.work <- batch
-					continue
-				}
+				// if srv.prng.Chance(1, 10) {
+				// 	srv.Log("[server]: Busy, return batch to queue")
+				// 	srv.work <- batch
+				// 	continue
+				// }
 				results := srv.processBatch(batch)
 				if err := stream.srvSend(Event{Results: results}); err != nil {
 					break Conn
@@ -247,11 +263,13 @@ func (srv *Server) processBatch(b *Batch) *ssb.Results {
 		t.Retries++
 
 		// On it's last retry the task fails with a 1/4 chance.
-		if id := id.String(); srv.prng.Chance(1, srv.RetryLimit-t.Retries+4) {
+		if srv.prng.Chance(1, srv.RetryLimit-t.Retries+4) {
 			results.Failed[id] = testkit.ErrWhaam
+			t.Err = testkit.ErrWhaam
 			failed++
 		} else {
 			results.OK = append(results.OK, id)
+			t.Err = nil
 			OK++
 		}
 		srv.seen[id] = t
@@ -341,18 +359,17 @@ func (s *Stream) srvRecv() <-chan *Batch { return s.batchc }
 func (s *Stream) srvClose()              { s.cancel(io.EOF) }
 
 func (t *Transport) NewRequest() ssb.BatchRequest {
-	b := &Batch{
+	return &Batch{
 		Simulation: t.Simulation,
-		values:     make([]uuid.UUID, 0, 92), // FIXME: random cap, not 92
+		values:     make([]string, 0, 92), // FIXME: random cap, not 92
 	}
-	return b
 }
 
 func (t *Transport) Prepare(data ssb.Data) (any, error) {
 	t.Helper()
 	assert.NotNil(t.T, data.Object, "nil batch object")
 
-	id := data.Object.UUID
+	id := data.Object.UUID.String()
 	if _, ok := t.TooLarge.Load(id); ok {
 		return nil, ssb.ErrTooLarge
 	}
@@ -363,10 +380,15 @@ func (b *Batch) Add(v any) (added, full bool) {
 	b.Helper()
 	defer require.LessOrEqual(b.T, len(b.values), cap(b.values))
 
-	assert.IsType(b.T, *new(uuid.UUID), v, "bad value in Add")
+	assert.IsType(b.T, *new(string), v, "bad value in Add")
 	if len(b.values) == cap(b.values) {
 		return false, true
 	}
-	b.values = append(b.values, v.(uuid.UUID))
+	if slices.Contains(b.values, v.(string)) {
+		panic(v)
+	}
+	b.values = append(b.values, v.(string))
 	return true, len(b.values) == cap(b.values)
 }
+
+func (b *Batch) String() string { return fmt.Sprint(b.values) }

--- a/internal/api/ssb/protocol_test.go
+++ b/internal/api/ssb/protocol_test.go
@@ -47,7 +47,8 @@ type Simulation struct {
 // I can fuzz the smaller components (like batch or cache) and PBT the client.
 // protocol_fuzz_test.go (package ssb) + protocol_test.go (package ssb_test)
 //
-// Assertion guideline: `assert` for Client-stuff, `require` for test logic.
+// Assertion guideline: During the simulation, use `require` only for testing logic,
+// as it may interrupt the test and cause a panic. Use `require` for final checks.
 func TestClient(t *testing.T) {
 	sim := Simulation{
 		T:           t,
@@ -58,13 +59,12 @@ func TestClient(t *testing.T) {
 	}
 
 	conn := make(chan *Stream)
-	t.Cleanup(func() { close(conn) })
-
 	srv := Server{
 		Simulation: &sim,
 		conn:       conn,
 		work:       make(chan *Batch, 8),
 		seen:       make(map[uuid.UUID]taskStat, sim.TaskCount),
+		done:       make(chan struct{}),
 	}
 	go srv.run()
 
@@ -95,13 +95,16 @@ func TestClient(t *testing.T) {
 			t.Context(),
 			ssb.Data{Object: &api.BatchObject{UUID: id}},
 		)
+		// TODO(dyma): expect error after OOM
 		assert.NoError(t, err, "add error")
-		require.NotNil(t, task, "nil task")
+		assert.NotNil(t, task, "nil task")
 		tasks[i] = task
 	}
 
 	t.Log("added all data -> close client")
 	assert.NoError(t, c.Close(), "close client")
+	close(conn)
+	srv.close()
 }
 
 type Batch struct {
@@ -115,6 +118,7 @@ type Server struct {
 	conn <-chan *Stream
 	work chan *Batch
 	seen map[uuid.UUID]taskStat
+	done chan struct{}
 }
 
 type taskStat struct {
@@ -124,7 +128,9 @@ type taskStat struct {
 
 func (srv *Server) run() {
 	srv.Helper()
+
 	defer close(srv.work)
+	defer close(srv.done)
 
 	for stream := range srv.conn {
 		if err := stream.srvSend(Event{Started: true}); err != nil {
@@ -151,7 +157,7 @@ func (srv *Server) run() {
 					break Conn
 				}
 				require.NotNil(srv.T, batch)
-				srv.Logf("[server]: Received batch (%d)", len(batch.values))
+				srv.Logf("[server]: Received batch (%d) %p", len(batch.values), batch)
 				require.NotEmpty(srv.T, batch.values)
 
 				if srv.prng.Chance(1, 20) {
@@ -167,6 +173,7 @@ func (srv *Server) run() {
 							break Conn
 						}
 					}
+					srv.Logf("[server]: OOM'ed")
 					continue
 				}
 
@@ -191,10 +198,11 @@ func (srv *Server) run() {
 			}
 		}
 
-		srv.Log("[server]: Close stream + discard any remaining work")
+		srv.Logf("[server]: Discard any remaining work (%d)", len(srv.work))
 		for len(srv.work) > 0 {
 			<-srv.work
 		}
+		srv.Logf("[server]: Close stream")
 		stream.srvClose()
 	}
 }
@@ -224,6 +232,12 @@ func (srv *Server) processBatch(b *Batch) *ssb.Results {
 	}
 	srv.Logf("[server]: Send results: ok=%d, failed=%d", OK, failed)
 	return results
+}
+
+func (srv *Server) close() {
+	srv.Log("[server:close] wait <-srv.done")
+	<-srv.done
+	srv.Log("[server:close] closed!")
 }
 
 type Transport struct {
@@ -279,11 +293,14 @@ func (s *Stream) Send(req any) error {
 }
 
 func (s *Stream) Recv() (ssb.Event, error) {
+	if s.prng.Chance(1, 25) {
+		s.cancel(errors.New("bad network"))
+	}
+
 	select {
 	case ev := <-s.eventc:
 		return ssb.Event(ev), nil
 	case <-s.ctx.Done():
-		// s.Logf("[stream.Recv]:  context canceled: %v", context.Cause(s.ctx))
 		return ssb.Event{}, context.Cause(s.ctx)
 	}
 }
@@ -295,8 +312,6 @@ func (s *Stream) Close() error {
 }
 
 func (s *Stream) srvSend(ev Event) error {
-	// s.Log("[server::srvSend] start")
-	// defer s.Log("[server::srvSend] done")
 	select {
 	case s.eventc <- ev:
 		return nil

--- a/internal/api/ssb/protocol_test.go
+++ b/internal/api/ssb/protocol_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,10 +23,12 @@ type Simulation struct {
 	prng *testkit.PRNG
 
 	TaskCount   int
+	BatchSize   int
 	RetryLimit  int
 	ReconnCount int
 	ReconnLimit int
 	TooLarge    sync.Map
+	CanOOM      bool
 }
 
 // What I want to test:
@@ -54,8 +58,10 @@ func TestClient(t *testing.T) {
 		T:           t,
 		prng:        testkit.NewPRNG(t),
 		TaskCount:   32,
+		BatchSize:   16,
 		RetryLimit:  3,
 		ReconnLimit: 5,
+		CanOOM:      true,
 	}
 
 	conn := make(chan *Stream)
@@ -75,7 +81,7 @@ func TestClient(t *testing.T) {
 			conn:       conn,
 		},
 		QueueSize: 32,
-		BatchSize: 16,
+		BatchSize: sim.BatchSize,
 		Reconnect: ssb.ReconnectPolicy{
 			Limit:     sim.ReconnLimit,
 			DelayFunc: func(int) time.Duration { return 0 },
@@ -85,7 +91,7 @@ func TestClient(t *testing.T) {
 		},
 	})
 
-	tasks := make([]*ssb.Task, sim.TaskCount)
+	tasks := make([]*ssb.Task, 0, sim.TaskCount)
 	for i := 0; i < sim.TaskCount; i++ {
 		id := uuid.New()
 		if sim.prng.Chance(1, 50) {
@@ -95,16 +101,30 @@ func TestClient(t *testing.T) {
 			t.Context(),
 			ssb.Data{Object: &api.BatchObject{UUID: id}},
 		)
-		// TODO(dyma): expect error after OOM
-		assert.NoError(t, err, "add error")
-		assert.NotNil(t, task, "nil task")
-		tasks[i] = task
+
+		// If the test server can OOM, then we won't try and guess
+		// whether the error was expected, as OOM happens randomly.
+		if !sim.CanOOM {
+			assert.NoError(t, err, "add error")
+		}
+		if err != nil {
+			if assert.NotNil(t, task, "nil task") {
+				tasks = append(tasks, task)
+			}
+		}
 	}
 
-	t.Log("added all data -> close client")
-	assert.NoError(t, c.Close(), "close client")
+	log.Println("added all data -> close client")
+	err := c.Close()
+	if sim.CanOOM && err != nil {
+		assert.ErrorContains(t, err, "OOM", "close error, CanOOM=%t", sim.CanOOM)
+	} else {
+		assert.NoError(t, err, "close error")
+	}
+
 	close(conn)
-	srv.close()
+	<-srv.done
+	t.Log("FINISH TEST")
 }
 
 type Batch struct {
@@ -119,6 +139,8 @@ type Server struct {
 	work chan *Batch
 	seen map[uuid.UUID]taskStat
 	done chan struct{}
+
+	oom atomic.Bool
 }
 
 type taskStat struct {
@@ -137,14 +159,23 @@ func (srv *Server) run() {
 			continue
 		}
 
-		var oom bool
+		srv.oom.Store(false)
 	Conn:
 		for {
-			if srv.prng.Chance(1, 30) || oom {
-				srv.Logf("[server]: Shutting down (OOM=%t)", oom)
+			if srv.prng.Chance(1, 30) || srv.oom.Load() {
+				srv.Logf("[server]: Shutting down (OOM=%t)", srv.oom.Load())
 				stream.srvSend(Event{ShuttingDown: true})
 				break Conn
 			}
+
+			if srv.prng.Chance(1, 3) {
+				srv.Logf("[server]: Backoff")
+				backoff := srv.prng.RangeInclusive(srv.BatchSize/2, srv.BatchSize*2)
+				if err := stream.srvSend(Event{Backoff: &backoff}); err != nil {
+					break Conn
+				}
+			}
+
 			select {
 			case batch, ok := <-stream.srvRecv():
 				if !ok {
@@ -156,27 +187,22 @@ func (srv *Server) run() {
 					}
 					break Conn
 				}
-				require.NotNil(srv.T, batch)
+				assert.NotNil(srv.T, batch)
+				assert.NotEmpty(srv.T, batch.values)
 				srv.Logf("[server]: Received batch (%d) %p", len(batch.values), batch)
-				require.NotEmpty(srv.T, batch.values)
 
 				if srv.prng.Chance(1, 20) {
-					oom = true
-					if srv.prng.Bool() {
-						srv.Logf("[server]: Out Of Memory -> shutdown right away")
-						if err := stream.srvSend(Event{OOM: new(ssb.OOM)}); err != nil {
-							break Conn
-						}
-					} else {
-						srv.Logf("[server]: Out Of Memory -> starve the client")
-						if err := stream.srvSend(Event{OOM: &ssb.OOM{ExitAfter: 5 * time.Second}}); err != nil {
-							break Conn
-						}
+					srv.oom.Store(true)
+					var exitAfter time.Duration
+					// if srv.prng.Bool() {
+					exitAfter = 5 * time.Second
+					// }
+					if err := stream.srvSend(Event{OOM: &ssb.OOM{ExitAfter: exitAfter}}); err != nil {
+						break Conn
 					}
-					srv.Logf("[server]: OOM'ed")
 					continue
 				}
-
+				//
 				srv.work <- batch
 				srv.Log("[server]: Ack batch")
 				if err := stream.srvSend(Event{Ack: true}); err != nil {
@@ -234,12 +260,6 @@ func (srv *Server) processBatch(b *Batch) *ssb.Results {
 	return results
 }
 
-func (srv *Server) close() {
-	srv.Log("[server:close] wait <-srv.done")
-	<-srv.done
-	srv.Log("[server:close] closed!")
-}
-
 type Transport struct {
 	*Simulation
 	conn chan<- *Stream
@@ -251,8 +271,6 @@ func (t *Transport) NewStream(ctx context.Context) (ssb.Stream, error) {
 	t.Helper()
 	assert.NotNil(t.T, ctx, "nil stream context")
 
-	t.Log("[transport]: New stream")
-
 	ctx, cancel := context.WithCancelCause(ctx)
 	s := &Stream{
 		Simulation: t.Simulation,
@@ -263,7 +281,7 @@ func (t *Transport) NewStream(ctx context.Context) (ssb.Stream, error) {
 	}
 
 	t.conn <- s
-	return s, nil // TODO(dyma): sometimes error for reconnects?
+	return s, nil
 }
 
 type Stream struct {
@@ -276,8 +294,8 @@ type Stream struct {
 
 func (s *Stream) Send(req any) error {
 	s.Helper()
-	require.NotNil(s.T, req, "nil request")
-	require.IsType(s.T, (*Batch)(nil), req, "bad request")
+	assert.NotNil(s.T, req, "nil request")
+	assert.IsType(s.T, (*Batch)(nil), req, "bad request")
 
 	if s.prng.Chance(1, 25) {
 		s.cancel(errors.New("bad network"))
@@ -332,11 +350,10 @@ func (t *Transport) NewRequest() ssb.BatchRequest {
 
 func (t *Transport) Prepare(data ssb.Data) (any, error) {
 	t.Helper()
-	require.NotNil(t.T, data.Object, "nil batch object")
+	assert.NotNil(t.T, data.Object, "nil batch object")
 
 	id := data.Object.UUID
 	if _, ok := t.TooLarge.Load(id); ok {
-		t.Log("TOO LARGE ", id)
 		return nil, ssb.ErrTooLarge
 	}
 	return id, nil
@@ -346,7 +363,7 @@ func (b *Batch) Add(v any) (added, full bool) {
 	b.Helper()
 	defer require.LessOrEqual(b.T, len(b.values), cap(b.values))
 
-	require.IsType(b.T, *new(uuid.UUID), v, "bad value in Add")
+	assert.IsType(b.T, *new(uuid.UUID), v, "bad value in Add")
 	if len(b.values) == cap(b.values) {
 		return false, true
 	}

--- a/internal/api/ssb/protocol_test.go
+++ b/internal/api/ssb/protocol_test.go
@@ -142,7 +142,6 @@ func (srv *Server) run() {
 			select {
 			case batch, ok := <-stream.srvRecv():
 				if !ok {
-					// srv.Logf("client closed the stream, process remaining %d batches", len(srv.work))
 					for len(srv.work) > 0 {
 						results := srv.processBatch(<-srv.work)
 						if err := stream.srvSend(Event{Results: results}); err != nil {
@@ -155,16 +154,21 @@ func (srv *Server) run() {
 				srv.Logf("[server]: Received batch (%d)", len(batch.values))
 				require.NotEmpty(srv.T, batch.values)
 
-				// if srv.prng.Chance(1, 20) {
-				// 	srv.Logf("[server]: Out Of Memory")
-				// 	oom = true
-				// 	if srv.prng.Bool() {
-				// 		stream.srvSend() <- Event{OOM: new(ssb.OOM)}
-				// 	} else {
-				// 		stream.srvSend() <- Event{OOM: &ssb.OOM{ExitAfter: 5 * time.Second}}
-				// 	}
-				// 	continue
-				// }
+				if srv.prng.Chance(1, 20) {
+					oom = true
+					if srv.prng.Bool() {
+						srv.Logf("[server]: Out Of Memory -> shutdown right away")
+						if err := stream.srvSend(Event{OOM: new(ssb.OOM)}); err != nil {
+							break Conn
+						}
+					} else {
+						srv.Logf("[server]: Out Of Memory -> starve the client")
+						if err := stream.srvSend(Event{OOM: &ssb.OOM{ExitAfter: 5 * time.Second}}); err != nil {
+							break Conn
+						}
+					}
+					continue
+				}
 
 				srv.work <- batch
 				srv.Log("[server]: Ack batch")

--- a/internal/api/ssb/protocol_test.go
+++ b/internal/api/ssb/protocol_test.go
@@ -20,15 +20,65 @@ import (
 
 type Simulation struct {
 	*testing.T
-	prng *testkit.PRNG
+	prng     *testkit.PRNG
+	tooLarge sync.Map
 
 	TaskCount   int
 	BatchSize   int
+	MessageCap  int
 	RetryLimit  int
 	ReconnCount int
 	ReconnLimit int
-	TooLarge    sync.Map
 	CanOOM      bool
+}
+
+func (sim *Simulation) newClient(conn chan *Stream) *ssb.Client {
+	return ssb.NewClient(ssb.ClientConfig{
+		Context: sim.Context(),
+		Transport: &Transport{
+			Simulation: sim,
+			conn:       conn,
+		},
+		QueueSize: sim.prng.RangeInclusive(sim.BatchSize/2, sim.BatchSize*2),
+		BatchSize: sim.BatchSize,
+		Reconnect: ssb.ReconnectPolicy{
+			Limit:     sim.ReconnLimit,
+			DelayFunc: func(int) time.Duration { return 0 },
+		},
+		CanRetry: func(id string, retries int, _ error) bool {
+			return retries < sim.RetryLimit
+		},
+	})
+}
+
+func (sim *Simulation) newServer(conn chan *Stream) *Server {
+	return &Server{
+		Simulation: sim,
+		conn:       conn,
+		work:       make(chan *Batch, 8),
+		seen:       make(map[string]taskStat, sim.TaskCount),
+		done:       make(chan struct{}),
+
+		wip: make(map[string]struct{}),
+	}
+}
+
+func (sim *Simulation) Backoff() bool      { return sim.prng.Chance(1, 3) }
+func (sim *Simulation) OOM() bool          { return sim.CanOOM && sim.prng.Chance(1, 20) }
+func (sim *Simulation) ShuttingDown() bool { return sim.prng.Chance(1, 30) }
+func (sim *Simulation) BadNetwork() bool   { return sim.prng.Chance(1, 25) }
+
+// CheckSize stores the ID of this task if it is "too large".
+func (sim *Simulation) CheckSize(id string) {
+	if sim.prng.Chance(1, 50) {
+		sim.tooLarge.Store(id, true)
+	}
+}
+
+// TooLarge returns true if the task is "too large".
+func (sim *Simulation) TooLarge(id string) bool {
+	_, ok := sim.tooLarge.Load(id)
+	return ok
 }
 
 // What I want to test:
@@ -53,98 +103,75 @@ type Simulation struct {
 //
 // Assertion guideline: During the simulation, use `require` only for testing logic,
 // as it may interrupt the test and cause a panic. Use `require` for final checks.
+
+const retryLimit = 3
+
 func TestClient(t *testing.T) {
-	sim := Simulation{
-		T:           t,
-		prng:        testkit.NewPRNG(t),
-		TaskCount:   124512,
-		BatchSize:   53,
-		RetryLimit:  3,
-		ReconnLimit: 5,
-		CanOOM:      true,
-	}
+	for range 10 {
+		t.Run("ssb client fuzz", func(t *testing.T) {
+			prng := testkit.NewPRNG(t)
+			sim := Simulation{
+				T:    t,
+				prng: prng,
 
-	conn := make(chan *Stream)
-	srv := Server{
-		Simulation: &sim,
-		conn:       conn,
-		work:       make(chan *Batch, 8),
-		seen:       make(map[string]taskStat, sim.TaskCount),
-		done:       make(chan struct{}),
-
-		wip: make(map[string]struct{}),
-	}
-	go srv.run()
-
-	c := ssb.NewClient(ssb.ClientConfig{
-		Context: t.Context(),
-		Transport: &Transport{
-			Simulation: &sim,
-			conn:       conn,
-		},
-		QueueSize: 32,
-		BatchSize: sim.BatchSize,
-		Reconnect: ssb.ReconnectPolicy{
-			Limit:     sim.ReconnLimit,
-			DelayFunc: func(int) time.Duration { return 0 },
-		},
-		CanRetry: func(id string, retries int, _ error) bool {
-			return retries < sim.RetryLimit
-		},
-	})
-
-	// Add all data to the client.
-	tasks := make([]*ssb.Task, 0, sim.TaskCount)
-	for i := 0; i < sim.TaskCount; i++ {
-		id := uuid.New()
-		if sim.prng.Chance(1, 50) {
-			sim.TooLarge.Store(id, true)
-		}
-		task, err := c.Add(
-			t.Context(),
-			ssb.Data{Object: &api.BatchObject{UUID: id}},
-		)
-
-		// If the test server can OOM, then we won't try and guess
-		// whether the error was expected, as OOM happens randomly.
-		if !sim.CanOOM {
-			assert.NoError(t, err, "add error")
-		}
-		if err != nil {
-			if assert.NotNil(t, task, "nil task") {
-				tasks = append(tasks, task)
+				TaskCount:   prng.IntInclusive(500),
+				BatchSize:   prng.RangeInclusive(16, 64),
+				MessageCap:  prng.RangeInclusive(32, 128),
+				RetryLimit:  retryLimit,
+				ReconnLimit: prng.RangeInclusive(3, 5),
+				CanOOM:      prng.Bool(),
 			}
-		}
+
+			conn := make(chan *Stream)
+			c := sim.newClient(conn)
+			srv := sim.newServer(conn)
+
+			go srv.run()
+
+			// Add all data to the client.
+			tasks := make([]*ssb.Task, 0, sim.TaskCount)
+			for i := 0; i < sim.TaskCount; i++ {
+				id := uuid.New()
+				sim.CheckSize(id.String())
+				task, err := c.Add(
+					t.Context(),
+					ssb.Data{Object: &api.BatchObject{UUID: id}},
+				)
+
+				// If the test server can OOM, then we won't try and guess
+				// whether the error was expected, as OOM happens randomly.
+				if !sim.CanOOM {
+					assert.NoError(t, err, "add error")
+				}
+
+				if err == nil {
+					if assert.NotNil(t, task, "nil task") {
+						tasks = append(tasks, task)
+					}
+				}
+			}
+
+			log.Println("added all data -> close client")
+
+			// Close the client.
+			err := c.Close()
+			if sim.CanOOM && err != nil {
+				assert.ErrorContains(t, err, "OOM", "close error, CanOOM=%t", sim.CanOOM)
+			} else {
+				assert.NoError(t, err, "close error")
+			}
+
+			// Shutdown the server.
+			close(conn)
+			<-srv.done
+
+			// Wait for all tasks to complete.
+			for _, task := range tasks {
+				<-task.Done()
+				require.LessOrEqual(t, task.TimesRetried(), retryLimit, "task %s retries", task.ID())
+			}
+		})
 	}
-
-	log.Println("added all data -> close client")
-
-	// Close the client.
-	err := c.Close()
-	if sim.CanOOM && err != nil {
-		assert.ErrorContains(t, err, "OOM", "close error, CanOOM=%t", sim.CanOOM)
-	} else {
-		assert.NoError(t, err, "close error")
-	}
-
-	// Shutdown the server.
-	close(conn)
-	<-srv.done
-
-	for _, task := range tasks {
-		<-task.Done()
-		id, err := task.ID(), task.Err()
-		if _, tooLarge := sim.TooLarge.Load(id); tooLarge {
-			require.ErrorIs(t, err, ssb.ErrTooLarge, "%s is too large", id)
-			continue
-		}
-		stat, ok := srv.seen[task.ID()]
-		if ok {
-			require.Equal(t, stat.Err, err, "task %s error", id)
-			require.Equal(t, stat.Retries, task.TimesRetried(), "task %s error", id)
-		}
-	}
-	t.Log("FINISH TEST")
 }
 
 type Batch struct {
@@ -182,14 +209,13 @@ func (srv *Server) run() {
 		var oom bool
 	Conn:
 		for {
-			if srv.prng.Chance(1, 30) || oom {
+			if srv.ShuttingDown() || oom {
 				srv.Logf("[server]: Shutting down (OOM=%t)", oom)
 				stream.srvSend(Event{ShuttingDown: true})
 				break Conn
 			}
 
-			if srv.prng.Chance(1, 3) {
-				srv.Logf("[server]: Backoff")
+			if srv.Backoff() {
 				backoff := srv.prng.RangeInclusive(srv.BatchSize/2, srv.BatchSize*2)
 				if err := stream.srvSend(Event{Backoff: &backoff}); err != nil {
 					break Conn
@@ -208,6 +234,9 @@ func (srv *Server) run() {
 						for _, id := range batch.values {
 							t := srv.seen[id]
 							t.Retries++
+							if err, ok := results.Failed[id]; ok {
+								t.Err = err
+							}
 							srv.seen[id] = t
 						}
 					}
@@ -228,12 +257,11 @@ func (srv *Server) run() {
 				assert.NotEmpty(srv.T, batch.values)
 				srv.Logf("[server]: Received batch (%d) %p", len(batch.values), batch)
 
-				if srv.CanOOM && srv.prng.Chance(1, 20) {
-					oom = true
+				if oom = srv.OOM(); oom {
 					var exitAfter time.Duration
-					// if srv.prng.Bool() {
-					exitAfter = 5 * time.Second
-					// }
+					if srv.prng.Bool() {
+						exitAfter = 5 * time.Second
+					}
 					if err := stream.srvSend(Event{OOM: &ssb.OOM{ExitAfter: exitAfter}}); err != nil {
 						break Conn
 					}
@@ -248,14 +276,17 @@ func (srv *Server) run() {
 				srv.Log("[server]: Ack-ed batch")
 
 			case batch := <-srv.work:
-				// if srv.prng.Chance(1, 10) {
-				// 	srv.Log("[server]: Busy, return batch to queue")
-				// 	srv.work <- batch
-				// 	continue
-				// }
 				results := srv.processBatch(batch)
 				if err := stream.srvSend(Event{Results: results}); err != nil {
 					break Conn
+				}
+				for _, id := range batch.values {
+					t := srv.seen[id]
+					t.Retries++
+					if err, ok := results.Failed[id]; ok {
+						t.Err = err
+					}
+					srv.seen[id] = t
 				}
 			}
 		}
@@ -279,21 +310,19 @@ func (srv *Server) processBatch(b *Batch) *ssb.Results {
 		if !ok {
 			t = taskStat{Retries: -1}
 		}
+		srv.seen[id] = t
 
 		// On it's last retry the task fails with a 1/4 chance.
 		var succ bool
 		srv.Logf("[processbatch: %s.retries=%d", id, t.Retries)
 		if srv.prng.Chance(1, srv.RetryLimit-t.Retries+4) {
 			results.Failed[id] = testkit.ErrWhaam
-			t.Err = testkit.ErrWhaam
 			failed++
 		} else {
 			results.OK = append(results.OK, id)
-			t.Err = nil
 			succ = true
 			OK++
 		}
-		srv.seen[id] = t
 
 		srv.Logf("processed %s, delete from wip, ok=%t", id, succ)
 		delete(srv.wip, id)
@@ -339,7 +368,7 @@ func (s *Stream) Send(req any) error {
 	assert.NotNil(s.T, req, "nil request")
 	assert.IsType(s.T, (*Batch)(nil), req, "bad request")
 
-	if s.prng.Chance(1, 25) {
+	if s.BadNetwork() {
 		s.cancel(errors.New("bad network"))
 	}
 
@@ -353,7 +382,7 @@ func (s *Stream) Send(req any) error {
 }
 
 func (s *Stream) Recv() (ssb.Event, error) {
-	if s.prng.Chance(1, 25) {
+	if s.BadNetwork() {
 		s.cancel(errors.New("bad network"))
 	}
 
@@ -385,7 +414,7 @@ func (s *Stream) srvClose()              { s.cancel(io.EOF) }
 func (t *Transport) NewRequest() ssb.BatchRequest {
 	return &Batch{
 		Simulation: t.Simulation,
-		values:     make([]string, 0, 92), // FIXME: random cap, not 92
+		values:     make([]string, 0, t.MessageCap),
 	}
 }
 
@@ -394,7 +423,7 @@ func (t *Transport) Prepare(data ssb.Data) (any, error) {
 	assert.NotNil(t.T, data.Object, "nil batch object")
 
 	id := data.Object.UUID.String()
-	if _, ok := t.TooLarge.Load(id); ok {
+	if t.TooLarge(id) {
 		return nil, ssb.ErrTooLarge
 	}
 	return id, nil

--- a/internal/api/ssb/protocol_test.go
+++ b/internal/api/ssb/protocol_test.go
@@ -60,9 +60,9 @@ func (sim *Simulation) newServer(conn chan *Stream) *Server {
 }
 
 func (sim *Simulation) Backoff() bool      { return sim.prng.Chance(1, 3) }
-func (sim *Simulation) OOM() bool          { return sim.CanOOM && sim.prng.Chance(1, 20) }
-func (sim *Simulation) ShuttingDown() bool { return sim.prng.Chance(1, 30) }
-func (sim *Simulation) BadNetwork() bool   { return sim.prng.Chance(1, 25) }
+func (sim *Simulation) BadNetwork() bool   { return sim.prng.Chance(1, 30) }
+func (sim *Simulation) ShuttingDown() bool { return sim.prng.Chance(1, 50) }
+func (sim *Simulation) OOM() bool          { return sim.CanOOM && sim.prng.Chance(1, 50) }
 
 // CheckSize stores the ID of this task if it is "too large".
 func (sim *Simulation) CheckSize(id string) {
@@ -77,20 +77,32 @@ func (sim *Simulation) TooLarge(id string) bool {
 	return ok
 }
 
-const retryLimit = 3
-
 func TestClient(t *testing.T) {
 	prng := testkit.NewPRNG(t)
-	for range 10 {
+
+	const (
+		N            = 10
+		retryLimit   = 3
+		maxTaskCount = 1000
+	)
+
+	var (
+		added int // Added to batch stream.
+		seen  int // Arrived to the server.
+		ok    int // Succeeded.
+		fail  int // Failed.
+	)
+
+	for range N {
 		t.Run("ssb client fuzz", func(t *testing.T) {
 			sim := Simulation{
 				T:    t,
 				prng: prng,
 
-				TaskCount:   prng.IntInclusive(500),
+				TaskCount:   prng.IntInclusive(maxTaskCount),
+				RetryLimit:  retryLimit,
 				BatchSize:   prng.RangeInclusive(16, 64),
 				MessageCap:  prng.RangeInclusive(32, 128),
-				RetryLimit:  retryLimit,
 				ReconnLimit: prng.RangeInclusive(3, 5),
 				CanOOM:      prng.Bool(),
 			}
@@ -136,9 +148,23 @@ func TestClient(t *testing.T) {
 			for _, task := range tasks {
 				<-task.Done()
 				require.LessOrEqual(t, task.TimesRetried(), retryLimit, "task %s retries", task.ID())
+
+				switch task.Err() {
+				case nil:
+					ok++
+				default:
+					fail++
+				}
 			}
+
+			added += sim.TaskCount
+			seen += len(srv.seen)
 		})
 	}
+
+	require.GreaterOrEqual(t, seen, int(float64(added)*.9), "over 90% of all data arrive at the server")
+	require.GreaterOrEqual(t, ok, int(float64(seen)*.75), "over 75% of submitted tasks succeed")
+	require.LessOrEqual(t, fail, int(float64(seen)*.25), "under 25% of submitted tasks fail")
 }
 
 type (

--- a/internal/api/ssb/protocol_test.go
+++ b/internal/api/ssb/protocol_test.go
@@ -210,7 +210,9 @@ func (srv *Server) processBatch(b *Batch) *ssb.Results {
 			t = taskStat{Retries: -1}
 		}
 		t.Retries++
-		if id := id.String(); srv.prng.Chance(0, srv.RetryLimit-t.Retries+4) {
+
+		// On it's last retry the task fails with a 1/4 chance.
+		if id := id.String(); srv.prng.Chance(1, srv.RetryLimit-t.Retries+4) {
 			results.Failed[id] = testkit.ErrWhaam
 			failed++
 		} else {

--- a/internal/api/ssb/protocol_test.go
+++ b/internal/api/ssb/protocol_test.go
@@ -1,0 +1,337 @@
+package ssb_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api/ssb"
+	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
+)
+
+type Simulation struct {
+	*testing.T
+	prng *testkit.PRNG
+
+	TaskCount   int
+	RetryLimit  int
+	ReconnCount int
+	ReconnLimit int
+	TooLarge    sync.Map
+}
+
+// What I want to test:
+//
+//  1. Client never crashes.
+//  2. If context is not canceled, all data added to the batch makes it to the server.
+//     This includes reconnects, which can happen up to N times in a row.
+//  3. OOM terminates the stream at any given time (+ timeout).
+//  4. Tricky?: No new data is sent before an ACK.
+//  5. Canceling the context fails all in-progress tasks.
+//
+// Of those, 1 and 2 seem to be something that's easy to model in a test.
+// I think what I will try and do is first write tests where I come up with
+// the scenario and then progressively add randomness into it.
+//
+// If I can build a server model with a good size-to-weight ratio, then I can
+// just let it rip FRNG style and check that it doesn't produce invalid outcomes.
+//
+// Luckily (!!) the client can only do Add, so that is a trivial part really.
+// I can fuzz the smaller components (like batch or cache) and PBT the client.
+// protocol_fuzz_test.go (package ssb) + protocol_test.go (package ssb_test)
+//
+// Assertion guideline: `assert` for Client-stuff, `require` for test logic.
+func TestClient(t *testing.T) {
+	sim := Simulation{
+		T:           t,
+		prng:        testkit.NewPRNG(t),
+		TaskCount:   32,
+		RetryLimit:  3,
+		ReconnLimit: 5,
+	}
+
+	conn := make(chan *Stream)
+	t.Cleanup(func() { close(conn) })
+
+	srv := Server{
+		Simulation: &sim,
+		conn:       conn,
+		work:       make(chan *Batch, 8),
+		seen:       make(map[uuid.UUID]taskStat, sim.TaskCount),
+	}
+	go srv.run()
+
+	c := ssb.NewClient(ssb.ClientConfig{
+		Context: t.Context(),
+		Transport: &Transport{
+			Simulation: &sim,
+			conn:       conn,
+		},
+		QueueSize: 32,
+		BatchSize: 16,
+		Reconnect: ssb.ReconnectPolicy{
+			Limit:     sim.ReconnLimit,
+			DelayFunc: func(int) time.Duration { return 0 },
+		},
+		CanRetry: func(_ string, retries int, _ error) bool {
+			return retries < sim.RetryLimit
+		},
+	})
+
+	tasks := make([]*ssb.Task, sim.TaskCount)
+	for i := 0; i < sim.TaskCount; i++ {
+		id := uuid.New()
+		if sim.prng.Chance(1, 50) {
+			sim.TooLarge.Store(id, true)
+		}
+		task, err := c.Add(
+			t.Context(),
+			ssb.Data{Object: &api.BatchObject{UUID: id}},
+		)
+		assert.NoError(t, err, "add error")
+		require.NotNil(t, task, "nil task")
+		tasks[i] = task
+	}
+
+	t.Log("added all data -> close client")
+	assert.NoError(t, c.Close(), "close client")
+}
+
+type Batch struct {
+	*Simulation
+	values []uuid.UUID
+}
+type Event ssb.Event
+
+type Server struct {
+	*Simulation
+	conn <-chan *Stream
+	work chan *Batch
+	seen map[uuid.UUID]taskStat
+}
+
+type taskStat struct {
+	Retries int
+	Err     int
+}
+
+func (srv *Server) run() {
+	srv.Helper()
+	defer close(srv.work)
+
+	// srv.Log("[server]: Run")
+
+	for stream := range srv.conn {
+		if err := stream.srvSend(Event{Started: true}); err != nil {
+			continue
+		}
+		// srv.Log("[server]: Stream started")
+
+		// var oom bool
+	Conn:
+		for {
+			// if srv.prng.Chance(1, 30) || oom {
+			// 	srv.Logf("[server]: Shutting down (OOM=%t)", oom)
+			// 	stream.srvSend() <- Event{ShuttingDown: true}
+			// 	break Conn
+			// }
+			select {
+			case batch, ok := <-stream.srvRecv():
+				if !ok {
+					// srv.Logf("client closed the stream, process remaining %d batches", len(srv.work))
+					for len(srv.work) > 0 {
+						results := srv.processBatch(<-srv.work)
+						if err := stream.srvSend(Event{Results: results}); err != nil {
+							break Conn
+						}
+					}
+					break Conn
+				}
+				require.NotNil(srv.T, batch)
+				srv.Logf("[server]: Received batch (%d)", len(batch.values))
+				require.NotEmpty(srv.T, batch.values)
+
+				// if srv.prng.Chance(1, 20) {
+				// 	srv.Logf("[server]: Out Of Memory")
+				// 	oom = true
+				// 	if srv.prng.Bool() {
+				// 		stream.srvSend() <- Event{OOM: new(ssb.OOM)}
+				// 	} else {
+				// 		stream.srvSend() <- Event{OOM: &ssb.OOM{ExitAfter: 5 * time.Second}}
+				// 	}
+				// 	continue
+				// }
+
+				srv.work <- batch
+				srv.Log("[server]: Ack batch")
+				if err := stream.srvSend(Event{Ack: true}); err != nil {
+					srv.Log("[server]: Failed to ack batch")
+					break Conn
+				}
+				srv.Log("[server]: Ack-ed batch")
+
+			case batch := <-srv.work:
+				if srv.prng.Chance(1, 10) {
+					srv.Log("[server]: Busy, return batch to queue")
+					srv.work <- batch
+					continue
+				}
+				results := srv.processBatch(batch)
+				if err := stream.srvSend(Event{Results: results}); err != nil {
+					break Conn
+				}
+			}
+		}
+
+		srv.Log("[server]: Close stream + discard any remaining work")
+		for len(srv.work) > 0 {
+			<-srv.work
+		}
+		stream.srvClose()
+	}
+}
+
+func (srv *Server) processBatch(b *Batch) *ssb.Results {
+	results := &ssb.Results{
+		OK:     make([]string, 0),
+		Failed: make(map[string]error),
+	}
+	var OK, failed int
+	for _, id := range b.values {
+		t, ok := srv.seen[id]
+		if !ok {
+			t = taskStat{Retries: -1}
+		}
+		t.Retries++
+		if id := id.String(); srv.prng.Chance(0, srv.RetryLimit-t.Retries+4) {
+			results.Failed[id] = testkit.ErrWhaam
+			failed++
+		} else {
+			results.OK = append(results.OK, id)
+			OK++
+		}
+		srv.seen[id] = t
+	}
+	srv.Logf("[server]: Send results: ok=%d, failed=%d", OK, failed)
+	return results
+}
+
+type Transport struct {
+	*Simulation
+	conn chan<- *Stream
+}
+
+var _ ssb.Transport = (*Transport)(nil)
+
+func (t *Transport) NewStream(ctx context.Context) (ssb.Stream, error) {
+	t.Helper()
+	assert.NotNil(t.T, ctx, "nil stream context")
+
+	t.Log("[transport]: New stream")
+
+	ctx, cancel := context.WithCancelCause(ctx)
+	s := &Stream{
+		Simulation: t.Simulation,
+		ctx:        ctx,
+		cancel:     cancel,
+		batchc:     make(chan *Batch),
+		eventc:     make(chan Event),
+	}
+
+	t.conn <- s
+	return s, nil // TODO(dyma): sometimes error for reconnects?
+}
+
+type Stream struct {
+	*Simulation
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+	batchc chan *Batch
+	eventc chan Event
+}
+
+func (s *Stream) Send(req any) error {
+	s.Helper()
+	require.NotNil(s.T, req, "nil request")
+	require.IsType(s.T, (*Batch)(nil), req, "bad request")
+
+	if s.prng.Chance(1, 25) {
+		s.cancel(errors.New("bad network"))
+	}
+
+	select {
+	case s.batchc <- req.(*Batch):
+	case <-s.ctx.Done():
+		s.Log("[stream.Send]: context canceled")
+		return io.EOF
+	}
+	return nil
+}
+
+func (s *Stream) Recv() (ssb.Event, error) {
+	select {
+	case ev := <-s.eventc:
+		return ssb.Event(ev), nil
+	case <-s.ctx.Done():
+		// s.Logf("[stream.Recv]:  context canceled: %v", context.Cause(s.ctx))
+		return ssb.Event{}, context.Cause(s.ctx)
+	}
+}
+
+func (s *Stream) Close() error {
+	s.Log("[stream.Close]: Client closed it's half of the stream")
+	close(s.batchc)
+	return nil
+}
+
+func (s *Stream) srvSend(ev Event) error {
+	// s.Log("[server::srvSend] start")
+	// defer s.Log("[server::srvSend] done")
+	select {
+	case s.eventc <- ev:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
+}
+func (s *Stream) srvRecv() <-chan *Batch { return s.batchc }
+func (s *Stream) srvClose()              { s.cancel(io.EOF) }
+
+func (t *Transport) NewRequest() ssb.BatchRequest {
+	b := &Batch{
+		Simulation: t.Simulation,
+		values:     make([]uuid.UUID, 0, 92), // FIXME: random cap, not 92
+	}
+	return b
+}
+
+func (t *Transport) Prepare(data ssb.Data) (any, error) {
+	t.Helper()
+	require.NotNil(t.T, data.Object, "nil batch object")
+
+	id := data.Object.UUID
+	if _, ok := t.TooLarge.Load(id); ok {
+		t.Log("TOO LARGE ", id)
+		return nil, ssb.ErrTooLarge
+	}
+	return id, nil
+}
+
+func (b *Batch) Add(v any) (added, full bool) {
+	b.Helper()
+	defer require.LessOrEqual(b.T, len(b.values), cap(b.values))
+
+	require.IsType(b.T, *new(uuid.UUID), v, "bad value in Add")
+	if len(b.values) == cap(b.values) {
+		return false, true
+	}
+	b.values = append(b.values, v.(uuid.UUID))
+	return true, len(b.values) == cap(b.values)
+}

--- a/internal/api/transport/stream/adapters.go
+++ b/internal/api/transport/stream/adapters.go
@@ -75,7 +75,7 @@ func (tad *TransportAdapter) Prepare(d ssb.Data) (v any, err error) {
 // streamAdapter implements [ssb.Stream] on top of [transport.BatchStream].
 type streamAdapter struct{ stream transport.BatchStream }
 
-func (sad *streamAdapter) Send(req ssb.BatchRequest) error {
+func (sad *streamAdapter) Send(req any) error {
 	dev.AssertType[*api.BatchRequest](req, "batch request")
 	return sad.send(req.(*api.BatchRequest))
 }

--- a/internal/api/transport/stream/adapters.go
+++ b/internal/api/transport/stream/adapters.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/weaviate/weaviate-go-client/v6/internal"
@@ -112,7 +113,7 @@ func (sad *streamAdapter) Recv() (ssb.Event, error) {
 	case *proto.BatchStreamReply_Results_:
 		event.Results = &ssb.Results{
 			OK:     make([]string, len(msg.Results.Successes)),
-			Failed: internal.MakeMap[string, string](len(msg.Results.Errors)),
+			Failed: internal.MakeMap[string, error](len(msg.Results.Errors)),
 		}
 		for i, ok := range msg.Results.Successes {
 			switch d := ok.Detail.(type) {
@@ -126,9 +127,9 @@ func (sad *streamAdapter) Recv() (ssb.Event, error) {
 		for _, e := range msg.Results.Errors {
 			switch d := e.Detail.(type) {
 			case *proto.BatchStreamReply_Results_Error_Uuid:
-				event.Results.Failed[d.Uuid] = e.Error
+				event.Results.Failed[d.Uuid] = errors.New(e.Error)
 			case *proto.BatchStreamReply_Results_Error_Beacon:
-				event.Results.Failed[d.Beacon] = e.Error
+				event.Results.Failed[d.Beacon] = errors.New(e.Error)
 			}
 		}
 	}

--- a/internal/api/transport/stream/adapters_test.go
+++ b/internal/api/transport/stream/adapters_test.go
@@ -173,7 +173,7 @@ func TestStream_Recv(t *testing.T) {
 								Detail: &proto.BatchStreamReply_Results_Error_Beacon{
 									Beacon: "ref-1",
 								},
-								Error: "Whaam!",
+								Error: testkit.ErrWhaam.Error(),
 							},
 						},
 					},
@@ -182,8 +182,8 @@ func TestStream_Recv(t *testing.T) {
 			want: ssb.Event{
 				Results: &ssb.Results{
 					OK: []string{"uuid-0", "ref-0"},
-					Failed: map[string]string{
-						"ref-1": "Whaam!",
+					Failed: map[string]error{
+						"ref-1": testkit.ErrWhaam,
 					},
 				},
 			},

--- a/internal/testkit/prng.go
+++ b/internal/testkit/prng.go
@@ -75,8 +75,4 @@ func (prng *PRNG) Chance(numerator, denominator int) bool {
 	return prng.rand.Intn(denominator+1) < numerator
 }
 
-func (prng *PRNG) Bool() bool {
-	prng.mu.Lock()
-	defer prng.mu.Unlock()
-	return prng.Chance(1, 2)
-}
+func (prng *PRNG) Bool() bool { return prng.Chance(1, 2) }

--- a/internal/testkit/prng.go
+++ b/internal/testkit/prng.go
@@ -1,8 +1,10 @@
 package testkit
 
 import (
+	cryptorand "crypto/rand"
 	"log"
 	"math"
+	"math/big"
 	"math/rand"
 	"os"
 	"strconv"
@@ -31,7 +33,11 @@ func init() {
 		}
 		seed = i
 	} else {
-		seed = Now.UnixNano()
+		i, err := cryptorand.Int(cryptorand.Reader, big.NewInt(math.MaxInt64))
+		if err != nil {
+			log.Fatal("testkit:", err)
+		}
+		seed = i.Int64()
 	}
 }
 
@@ -46,7 +52,7 @@ type PRNG struct {
 }
 
 // NewPRNG returns a new pseudo-random number generator.
-// By default PRNG is seeded to the current unix timestamp.
+// By default PRNG is seeded to the cryptographically random number.
 // The seed is constant during a single test run.
 // Set a custom seed via an envvar before running the tests:
 //

--- a/internal/testkit/prng.go
+++ b/internal/testkit/prng.go
@@ -1,0 +1,76 @@
+package testkit
+
+import (
+	"log"
+	"math"
+	"math/rand"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// EnvSeed can be used to set a seed for this run via an environment variable.
+// This is useful for reproducing failed tests that used [PRNG].
+// The seed is printed to the error log for each failed test:
+//
+//	testkit_seed=1234567
+//
+// To use the failure in the next run simply prepend this line to the go test command:
+//
+//	testkit_seed=1234567 go test ./...
+const EnvSeed = "testkit_seed"
+
+func init() {
+	if v, ok := os.LookupEnv(EnvSeed); ok {
+		i, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			log.Fatalf("invalid %s=%s, must be in64", EnvSeed, v)
+		}
+		seed = i
+	} else {
+		seed = Now.UnixNano()
+	}
+}
+
+// seed for this test run
+var seed int64
+
+type PRNG struct {
+	t *testing.T
+
+	mu   sync.Mutex
+	rand *rand.Rand
+}
+
+// NewPRNG returns a new pseudo-random number generator.
+// By default PRNG is seeded to the current unix timestamp.
+// The seed is constant during a single test run.
+// Set a custom seed via an envvar before running the tests:
+//
+//	testkit_seed=1234567 go test ./...
+func NewPRNG(t *testing.T) *PRNG {
+	t.Logf("%s=%d", EnvSeed, seed)
+	return &PRNG{
+		t:    t,
+		rand: rand.New(rand.NewSource(seed)),
+	}
+}
+
+func (prng *PRNG) Chance(numerator, denominator int) bool {
+	prng.mu.Lock()
+	defer prng.mu.Unlock()
+
+	require.GreaterOrEqual(prng.t, numerator, 0, "numerator")
+	require.Greater(prng.t, denominator, 0, "denominator")
+	require.Less(prng.t, denominator, math.MaxInt, "denominator")
+	return prng.rand.Intn(denominator+1) < numerator
+}
+
+func (prng *PRNG) Bool() bool {
+	prng.mu.Lock()
+	defer prng.mu.Unlock()
+	return prng.Chance(1, 2)
+}

--- a/internal/testkit/prng.go
+++ b/internal/testkit/prng.go
@@ -71,8 +71,24 @@ func (prng *PRNG) Chance(numerator, denominator int) bool {
 
 	require.GreaterOrEqual(prng.t, numerator, 0, "numerator")
 	require.Greater(prng.t, denominator, 0, "denominator")
-	require.Less(prng.t, denominator, math.MaxInt, "denominator")
-	return prng.rand.Intn(denominator+1) < numerator
+	return prng.intInclLocked(denominator) < numerator
 }
 
 func (prng *PRNG) Bool() bool { return prng.Chance(1, 2) }
+
+func (prng *PRNG) IntInclusive(upper int) int {
+	prng.mu.Lock()
+	defer prng.mu.Unlock()
+	return prng.intInclLocked(upper)
+}
+
+func (prng *PRNG) RangeInclusive(lower, upper int) int {
+	prng.mu.Lock()
+	defer prng.mu.Unlock()
+	return lower + prng.intInclLocked(upper-lower)
+}
+
+func (prng *PRNG) intInclLocked(upper int) int {
+	require.Less(prng.t, upper, math.MaxInt, "upper boundary")
+	return prng.rand.Intn(upper + 1)
+}


### PR DESCRIPTION
This PR adds a fuzzer for SSB client. The idea is to create a simulation environment which closely resembles the real world (connection errors, OOM, shutdowns, etc), but is driven by pseudo-random choices and also runs much much faster.

While we cannot perfectly control the entire process, we can verify that some properties hold. For example:
- the Client doesn't crash or hang
- the Client does not exceed it's reconnect limit
- a batch never contains duplicated items
- eventually most of the data makes it to the server

Owning to the fact that server is essentially the same process, this approach helped uncover a number of less-than-trivial bugs, which this PR also fixes. You can read more about each one under the respective `fix(ssb):` commit, but here's a short rundown:

- Clear `full` flag with `&^=` instead of toggling it with `^=`
- Discard all "retry" items before reconnecting to the stream
- Properly await for 'send' routine to exit before reconnecting
- Atomically consume `canSend` permission when sending the next batch
- Stop `oomTimer` if stream disconnects abruptly
- Close `c.retry` at the end of 'recv' loop, not in `Close()` (race detector)