### PR TITLE
v6: Update example/basic

### DIFF
--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/weaviate/weaviate-go-client/v6"
 	"github.com/weaviate/weaviate-go-client/v6/aggregate"
 	"github.com/weaviate/weaviate-go-client/v6/collections"
+	"github.com/weaviate/weaviate-go-client/v6/data"
 	"github.com/weaviate/weaviate-go-client/v6/example"
+	vv8 "github.com/weaviate/weaviate-go-client/v6/modules/weaviate"
 	"github.com/weaviate/weaviate-go-client/v6/query"
 )
 
@@ -21,72 +24,90 @@ func main() {
 	example.Catch(err)
 	defer c.Close()
 
-	CollectionName := "GoThings"
+	CollectionName := "Songs"
 
-	// If GoThings collection does not exist, create it.
-	canSearch := true
-	ok, err := c.Collections.Exists(ctx, CollectionName)
-	example.Catch(err)
-	if !ok {
-		_, err := c.Collections.Create(ctx, collections.Collection{
-			Name: CollectionName,
-			Properties: []collections.Property{
-				{Name: "name", DataType: collections.DataTypeText},
-				{Name: "description", DataType: collections.DataTypeText},
-				{Name: "url", DataType: collections.DataTypeText},
+	c.Collections.Delete(ctx, CollectionName)
+	songs, err := c.Collections.Create(ctx, collections.Collection{
+		Name: CollectionName,
+		Properties: []collections.Property{
+			{Name: "title", DataType: collections.DataTypeText},
+			{Name: "album", DataType: collections.DataTypeText},
+			{Name: "duration_sec", DataType: collections.DataTypeInt},
+		},
+		Vectors: map[string]collections.VectorConfig{
+			"title_vec": {
+				Vectorizer: vv8.Text2Vec{
+					Properties: []string{"title"},
+					Model:      vv8.SnowflakeArcticEmbedMv1_5,
+					Dimensions: 256,
+				},
 			},
-		})
-		example.Catch(err)
-
-		// Current client version does not support defining vector indices.
-		// Without one, similarity search is not possible.
-		canSearch = false
-	}
-
-	// Cleanup after the test is done.
-	defer c.Collections.Delete(ctx, CollectionName)
-
-	// Get a handle for GoThings collection.
-	products := c.Collections.Use(CollectionName)
+		},
+	})
+	example.Catch(err)
 
 	// Insert some objects, logging the "before" and "after" counts.
-	count, err := products.Count(ctx)
+	count, err := songs.Count(ctx)
 	example.Catch(err)
 
-	log.Printf("collection GoThings has %d objects", count)
+	log.Printf("collection %s has %d objects", CollectionName, count)
 
-	for i := range 5 {
-		res, err := products.Data.Insert(ctx, nil)
+	type Song struct {
+		Title    string `json:"title"`
+		Album    string `json:"album"`
+		Duration int    `json:"duration_sec"`
+	}
+
+	for _, s := range []Song{
+		{
+			Title:    "Schism",
+			Album:    "Lateralus",
+			Duration: 406,
+		},
+		{
+			Title:    "Parabola",
+			Album:    "Lateralus",
+			Duration: 363,
+		},
+		{
+			Title:    "The Pot",
+			Album:    "10,000 Days",
+			Duration: 382,
+		},
+		{
+			Title:    "Forty Six & 2",
+			Album:    "Ænima",
+			Duration: 376,
+		},
+	} {
+		res, err := songs.Data.Insert(ctx, &data.Object{
+			Properties: data.MustEncode(&s),
+		})
 		if err != nil {
 			log.Fatal(err)
 		}
 		for id, msg := range res.Errors {
-			fmt.Printf("\tobject #%d (%s) failed with error %q\n", i, id, msg)
+			fmt.Printf("\tinsert song %q (id=%s) failed with error %q\n", s.Title, id, msg)
 		}
 	}
 
-	count, err = products.Count(ctx)
+	count, err = songs.Count(ctx)
 	example.Catch(err)
 
-	log.Printf("collection GoThings has %d objects", count)
-
-	if !canSearch {
-		log.Print("collection GoThings has no vector indices")
-		return
-	}
+	log.Printf("collection %s has %d objects", CollectionName, count)
 
 	// Query some objects using NearText search.
-	nt, err := products.Query.NearText(ctx, query.NearText{
-		Concepts:      []string{"sneakers", "flipflops"},
-		MoveAway:      &query.Move{Concepts: []string{"sandals"}, Force: .34},
+	nt, err := songs.Query.NearText(ctx, query.NearText{
+		Concepts:      []string{"forty", "six"},
+		MoveAway:      &query.Move{Concepts: []string{"pot"}, Force: .34},
 		Limit:         3,
-		ReturnVectors: []string{"text2vec_weaviate"}, // the default vector name
+		ReturnVectors: []string{"title_vec"},
 	})
 	example.Catch(err)
 
-	log.Printf("NearText[sneakers, flipflops] returned %d objects:", len(nt.Objects))
+	log.Printf("NearText[forty, six] returned %d objects:", len(nt.Objects))
 	for _, obj := range nt.Objects {
-		fmt.Println("\t- ", obj.Properties["description"])
+		fmt.Println("\t- ", obj.Properties["title"])
 	}
 
 	if len(nt.Objects) == 0 {
@@ -95,43 +116,35 @@ func main() {
 
 	// Fetch 3 most similar objects to the first result hit
 	target := nt.Objects[0]
-	nv, err := products.Query.NearVector(ctx, query.NearVector{
-		Target:           target.Vectors["text2vec_weaviate"], // the default vector name
+	nv, err := songs.Query.NearVector(ctx, query.NearVector{
+		Target:           target.Vectors["title_vec"],
 		Similarity:       query.Distance(0.56),
 		AutoLimit:        2,
 		Limit:            3,
-		ReturnProperties: []string{"name", "url"},
+		ReturnProperties: []string{"title", "album"},
 		ReturnMetadata:   query.ReturnMetadata{Distance: true},
 	})
 	example.Catch(err)
 
-	// Scan results into our custom Go struct
-	type Product struct {
-		Name string `json:"name"`
-		URL  string `json:"url"`
-	}
-
-	decoded := make([]query.Object[Product], len(nv.Objects))
+	decoded := make([]query.Object[Song], len(nv.Objects))
 	example.Catch(query.Decode(nv, &decoded))
 
-	log.Print("NearVector[max_distance=.56] returned these 3 entries:")
+	log.Printf("NearVector[max_distance=.56] returned these %d entries:", len(nv.Objects))
 	for _, obj := range decoded {
-		fmt.Printf("\t- [%s](%s) distance=%f\n", obj.Properties.Name, obj.Properties.URL, *obj.Metadata.Distance)
+		fmt.Printf("\t- %q distance=%f\n", obj.Properties.Title, *obj.Metadata.Distance)
 	}
 
-	grouped, err := products.Aggregate.OverAll.GroupBy(ctx, aggregate.OverAll{
-		Text: []aggregate.Text{
-			{Property: "name", TopOccurrences: true, TopOccurencesCutoff: 10},
+	grouped, err := songs.Aggregate.OverAll.GroupBy(ctx, aggregate.OverAll{
+		Integer: []aggregate.Integer{
+			{Property: "duration_sec", Min: true, Median: true, Max: true},
 		},
-	}, aggregate.GroupBy{Property: "name", Limit: 5})
+	}, aggregate.GroupBy{Property: "album", Limit: 5})
 	example.Catch(err)
 
 	for _, group := range grouped.Groups {
-		log.Printf("Group %q has %d objects (value=%q)", group.Property, len(group.Aggregations.Text), group.Value)
-		for _, txt := range group.Aggregations.Text {
-			for _, top := range txt.TopOccurrences {
-				fmt.Printf("\t- %q occurs %d times\n", top.Value, top.OccursTimes)
-			}
+		log.Printf("Group %q has %d objects (group_by=%q)", group.Value, len(group.Aggregations.Integer), group.Property)
+		for name, duration := range group.Aggregations.Integer {
+			fmt.Printf("\t- songs in %q have median duration of %v\n", name, time.Duration(*duration.Median)*time.Second)
 		}
 	}
 }

--- a/modules/register_test.go
+++ b/modules/register_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/modules"
 	"github.com/weaviate/weaviate-go-client/v6/modules/model2vec"
 	"github.com/weaviate/weaviate-go-client/v6/modules/selfprovided"
+	"github.com/weaviate/weaviate-go-client/v6/modules/weaviate"
 )
 
 // TestModules ensures that all modules are registerred with [modules.Registry]
@@ -32,6 +33,21 @@ func TestModules(t *testing.T) {
 			conf: map[string]any{
 				"inferenceURL": "example.com",
 				"properties":   []string{"title", "lyrics"},
+			},
+		},
+		{
+			name: "text2vec-weaviate",
+			module: weaviate.Text2Vec{
+				URL:        "example.com",
+				Properties: []string{"title", "lyrics"},
+				Model:      weaviate.SnowflakeArcticEmbedMv1_5,
+				Dimensions: 92,
+			},
+			conf: map[string]any{
+				"baseURL":    "example.com",
+				"properties": []string{"title", "lyrics"},
+				"model":      "Snowflake/snowflake-arctic-embed-m-v1.5",
+				"dimensions": 92,
 			},
 		},
 	} {

--- a/modules/weaviate/module.go
+++ b/modules/weaviate/module.go
@@ -1,0 +1,23 @@
+package weaviate
+
+import "github.com/weaviate/weaviate-go-client/v6/modules"
+
+func init() {
+	modules.Register(*new(Text2Vec))
+}
+
+// Text2Vec is a vectorizer for text properties
+// based on the text2vec-weaviate module.
+type Text2Vec struct {
+	URL        string   `json:"baseURL"`
+	Properties []string `json:"properties"`
+	Model      string   `json:"model"`
+	Dimensions int      `json:"dimensions"`
+}
+
+func (Text2Vec) Name() string { return "text2vec-weaviate" }
+
+const (
+	SnowflakeArcticEmbedMv1_5 = "Snowflake/snowflake-arctic-embed-m-v1.5"
+	SnowflakeArcticEmbedLv2_0 = "Snowflake/snowflake-arctic-embed-l-v2.0"
+)


### PR DESCRIPTION
Since #431 and co. added vector config and vectorizer modules, we can now define our custom vector in `example/basic` and run the example to completion (vector search + aggregations).