### PR TITLE
v6: Fix bugs found in beta.1

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -29,4 +29,4 @@ jobs:
           cache: true
       - name: example/${{ matrix.example }}
         working-directory: ./example
-        run: go run ./${{ matrix.example }}
+        run: go run ./${{ matrix.example }} -test.v

--- a/internal/api/data.go
+++ b/internal/api/data.go
@@ -222,8 +222,7 @@ func (r *ReplaceObjectRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(req)
 }
 
-// ReplaceObjectRequest mirrors InsertObjectRequest but uses PUT method.
-// The collection name is sent as a path parameter.
+// ReplaceObjectRequest replaces an object in a collection.
 type ReplaceObjectRequest struct {
 	RequestDefaults
 	UUID       *uuid.UUID
@@ -246,21 +245,7 @@ func (r *ReplaceObjectRequest) Query() url.Values {
 	return nil
 }
 
-func (r *ReplaceObjectRequest) Body() any {
-	dev.AssertNotNil(r.UUID, "object uuid")
-
-	// InsertObjectRequest already implements json.Marshaler.
-	// For replace, CollectionName and UUID should not part of the payload.
-	return &ReplaceObjectRequest{
-		RequestDefaults: RequestDefaults{
-			Tenant:           r.Tenant,
-			ConsistencyLevel: r.ConsistencyLevel,
-		},
-		Properties: r.Properties,
-		References: r.References,
-		Vectors:    r.Vectors,
-	}
-}
+func (r *ReplaceObjectRequest) Body() any { return r }
 
 // DeleteObjectRequest deletes an object by its UUID.
 type DeleteObjectRequest struct {

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -89,6 +89,8 @@ func TestRESTRequests(t *testing.T) {
 			wantMethod: http.MethodPut,
 			wantPath:   "/objects/Songs/" + testkit.UUID.String(),
 			wantBody: &rest.Object{
+				Id:     &testkit.UUID,
+				Class:  "Songs",
 				Tenant: "john_doe",
 				Properties: map[string]any{
 					"title":  "High Speed Dirt",
@@ -120,7 +122,10 @@ func TestRESTRequests(t *testing.T) {
 			wantMethod: http.MethodPut,
 			wantPath:   "/objects/Songs/" + testkit.UUID.String(),
 			wantQuery:  url.Values{"consistency_level": {string(api.ConsistencyLevelOne)}},
-			wantBody:   &rest.Object{},
+			wantBody: &rest.Object{
+				Id:    &testkit.UUID,
+				Class: "Songs",
+			},
 		},
 		{
 			name: "delete object (no consistency_level)",

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -780,7 +780,7 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 			want: &proto.SearchRequest{
 				NearVector: &proto.NearVector{
 					Targets: &proto.Targets{
-						TargetVectors: []string{"title_vec"},
+						TargetVectors: []string{"title_vec", "title_vec"},
 						Combination:   proto.CombinationMethod_COMBINATION_METHOD_TYPE_RELATIVE_SCORE,
 						WeightsForTargets: []*proto.WeightsForTarget{
 							{

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -979,10 +979,11 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 			},
 			want: &proto.SearchRequest{
 				HybridSearch: &proto.Hybrid{
-					Query:      "yellow submarine",
-					Properties: []string{"title", "lyrics"},
-					AlphaParam: testkit.Ptr[float32](.44),
-					FusionType: proto.Hybrid_FUSION_TYPE_RANKED,
+					Query:         "yellow submarine",
+					Properties:    []string{"title", "lyrics"},
+					AlphaParam:    testkit.Ptr[float32](.44),
+					UseAlphaParam: true,
+					FusionType:    proto.Hybrid_FUSION_TYPE_RANKED,
 					Bm25SearchOperator: &proto.SearchOperatorOptions{
 						Operator: proto.SearchOperatorOptions_OPERATOR_AND,
 					},
@@ -1041,10 +1042,11 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 			},
 			want: &proto.SearchRequest{
 				HybridSearch: &proto.Hybrid{
-					Query:      "yellow submarine",
-					Properties: []string{"title", "lyrics"},
-					AlphaParam: testkit.Ptr[float32](.44),
-					FusionType: proto.Hybrid_FUSION_TYPE_RANKED,
+					Query:         "yellow submarine",
+					Properties:    []string{"title", "lyrics"},
+					AlphaParam:    testkit.Ptr[float32](.44),
+					UseAlphaParam: true,
+					FusionType:    proto.Hybrid_FUSION_TYPE_RANKED,
 					Bm25SearchOperator: &proto.SearchOperatorOptions{
 						Operator:             proto.SearchOperatorOptions_OPERATOR_OR,
 						MinimumOrTokensMatch: testkit.Ptr[int32](1),

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -1004,6 +1004,9 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 							},
 						},
 					},
+					Targets: &proto.Targets{
+						TargetVectors: []string{"lyrics_vec"},
+					},
 				},
 				Metadata: &proto.MetadataRequest{Uuid: true},
 				Properties: &proto.PropertiesRequest{
@@ -1059,6 +1062,9 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 								},
 							},
 						},
+					},
+					Targets: &proto.Targets{
+						TargetVectors: []string{"title_vec"},
 					},
 				},
 				Metadata: &proto.MetadataRequest{Uuid: true},

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -676,11 +676,13 @@ func marshalHybrid(req *Hybrid) (*proto.Hybrid, error) {
 		if h.NearVector, err = marshalNearVector(req.NearVector); err != nil {
 			return nil, err
 		}
+		h.Targets = h.NearVector.Targets
 	}
 	if req.NearText != nil {
 		if h.NearText, err = marshalNearText(req.NearText); err != nil {
 			return nil, err
 		}
+		h.Targets = h.NearText.Targets
 	}
 
 	return h, nil

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -653,10 +653,11 @@ func marshalHybrid(req *Hybrid) (*proto.Hybrid, error) {
 	dev.AssertNotNil(req, "req")
 
 	h := &proto.Hybrid{
-		Query:      req.Query,
-		Properties: req.QueryProperties,
-		AlphaParam: req.Alpha,
-		FusionType: proto.Hybrid_FusionType(req.Fusion),
+		Query:         req.Query,
+		Properties:    req.QueryProperties,
+		AlphaParam:    req.Alpha,
+		UseAlphaParam: true,
+		FusionType:    proto.Hybrid_FusionType(req.Fusion),
 	}
 
 	switch {

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -534,11 +534,11 @@ func marshalNearVector(req *NearVector) (*proto.NearVector, error) {
 		if !ok {
 			vft = &proto.VectorForTarget{Name: tv.Name}
 			vectors = append(vectors, vft)
-			targets = append(targets, tv.Name)
 			seen[tv.Name] = vft
 		}
 
 		vft.Vectors = append(vft.Vectors, v)
+		targets = append(targets, tv.Name)
 		if tv.Weight != nil {
 			weights = append(weights, &proto.WeightsForTarget{
 				Target: tv.Name,

--- a/internal/api/transport/transport.go
+++ b/internal/api/transport/transport.go
@@ -189,7 +189,7 @@ func newRPC[In RequestMessage, Out ReplyMessage](req Message[In, Out], dest any)
 		rpc := req.Method()
 		reply, err := rpc(wc, ctx, in)
 		if err != nil {
-			return fmt.Errorf("%s: %w", req, err)
+			return err
 		}
 
 		if err := unmarshal(reply, out); err != nil {

--- a/internal/api/transport/transport.go
+++ b/internal/api/transport/transport.go
@@ -158,6 +158,9 @@ func (t *transport) Do(ctx context.Context, req any, dest any) error {
 		case Message[proto.BatchReferencesRequest, proto.BatchReferencesReply]:
 			rpc = newRPC(msg, dest)
 			timeout = t.timeout.Write
+		case Message[proto.BatchDeleteRequest, proto.BatchDeleteReply]:
+			rpc = newRPC(msg, dest)
+			timeout = t.timeout.Write
 		default:
 			dev.Assert(false, "%T does not implement MessageMarshaler for any of the supported request types", msg)
 		}

--- a/internal/api/transport/transport.go
+++ b/internal/api/transport/transport.go
@@ -149,6 +149,9 @@ func (t *transport) Do(ctx context.Context, req any, dest any) error {
 		case Message[proto.AggregateRequest, proto.AggregateReply]:
 			rpc = newRPC(msg, dest)
 			timeout = t.timeout.Read
+		case Message[proto.TenantsGetRequest, proto.TenantsGetReply]:
+			rpc = newRPC(msg, dest)
+			timeout = t.timeout.Read
 		case Message[proto.BatchObjectsRequest, proto.BatchObjectsReply]:
 			rpc = newRPC(msg, dest)
 			timeout = t.timeout.Write

--- a/internal/api/transport/transport_test.go
+++ b/internal/api/transport/transport_test.go
@@ -236,6 +236,12 @@ func TestTransport_Do(t *testing.T) {
 					reply:   new(reply[proto.BatchReferencesReply]),
 					timeout: write,
 				},
+				{
+					name:    "batch delete",
+					message: &message[proto.BatchDeleteRequest, proto.BatchDeleteReply]{},
+					reply:   new(reply[proto.BatchDeleteReply]),
+					timeout: write,
+				},
 			}) {
 				t.Run(tt.name, func(t *testing.T) {
 					var got context.Context

--- a/internal/api/transport/transport_test.go
+++ b/internal/api/transport/transport_test.go
@@ -219,6 +219,12 @@ func TestTransport_Do(t *testing.T) {
 					timeout: read,
 				},
 				{
+					name:    "get-tenants",
+					message: &message[proto.TenantsGetRequest, proto.TenantsGetReply]{},
+					reply:   new(reply[proto.TenantsGetReply]),
+					timeout: read,
+				},
+				{
 					name:    "batch objects",
 					message: &message[proto.BatchObjectsRequest, proto.BatchObjectsReply]{},
 					reply:   new(reply[proto.BatchObjectsReply]),

--- a/internal/transports/grpc.go
+++ b/internal/transports/grpc.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/credentials/oauth"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -80,7 +79,10 @@ func NewGRPC[Client any](cfg GRPCConfig[Client]) (*GRPC[Client], error) {
 
 	if cfg.TokenSource != nil {
 		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(
-			&oauth.TokenSource{TokenSource: cfg.TokenSource},
+			&tokenSource{
+				TokenSource: cfg.TokenSource,
+				tls:         cfg.TLS,
+			},
 		))
 	}
 
@@ -124,3 +126,36 @@ func withDefaultHeader(md metadata.MD) grpc.DialOption {
 		return invoker(metadata.AppendToOutgoingContext(ctx, pairs...), method, req, reply, cc, opts...)
 	})
 }
+
+type tokenSource struct {
+	oauth2.TokenSource
+	tls bool // Enable transport level security.
+}
+
+var _ credentials.PerRPCCredentials = (*tokenSource)(nil)
+
+// GetRequestMetadata gets the request metadata as a map from a [tokenSource].
+// This behaves exactly like [oauth.TokenSource.GetRequestMetadata] but omits
+// security level check if TLS is disabled.
+//
+// We disable this precaution knowingly to allow the users to use authenticated
+// connections on an unprotected (possibly private) network.
+//
+// See also: [credentials.CheckSecurityLevel].
+func (ts *tokenSource) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
+	token, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+	if ts.tls {
+		ri, _ := credentials.RequestInfoFromContext(ctx)
+		if err = credentials.CheckSecurityLevel(ri.AuthInfo, credentials.PrivacyAndIntegrity); err != nil {
+			return nil, fmt.Errorf("unable to transfer TokenSource PerRPCCredentials: %v", err)
+		}
+	}
+	return map[string]string{
+		"authorization": token.Type() + " " + token.AccessToken,
+	}, nil
+}
+
+func (ts *tokenSource) RequireTransportSecurity() bool { return ts.tls }

--- a/internal/transports/grpc_test.go
+++ b/internal/transports/grpc_test.go
@@ -3,6 +3,7 @@ package transports_test
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
 	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
+	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -84,11 +86,53 @@ func TestGRPC_Do(t *testing.T) {
 		})
 		require.NoError(t, err, "new grpc transport")
 
-		// Act: our handled above will verify that the request included expected headers.
+		// Act: our handler above will verify that the request included expected headers.
 		gRPC.Do(t.Context(), func(ctx context.Context, client grpc.ClientConnInterface) error {
 			var empty emptypb.Empty
 			return client.Invoke(ctx, ts.MethodName(), nil, &empty)
 		})
+	})
+
+	t.Run("credentials", func(t *testing.T) {
+		for _, tt := range []struct {
+			name string
+			tls  bool
+			ts   oauth2.TokenSource
+		}{
+			{tls: false, ts: nil},
+			{tls: false, ts: oauth2.StaticTokenSource(&oauth2.Token{
+				AccessToken: "api-key",
+			})},
+		} {
+			t.Run(fmt.Sprintf("tls=%t auth=%t", tt.tls, tt.ts != nil), func(t *testing.T) {
+				// Arrange: start a local gRPC server and register a handler with assertions.
+				srv := startTestService(t, func(_ any, ctx context.Context, _ func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
+					// md, ok := metadata.FromIncomingContext(ctx)
+					// assert.True(t, ok, "incoming context should contain metadata")
+					// assert.Subset(t, md, metadata.MD{"x-findme": {"foo"}}, "default headers not present in request metadata")
+
+					return nil, nil
+				})
+
+				gRPC, err := transports.NewGRPC(transports.GRPCConfig[grpc.ClientConnInterface]{
+					Host:          srv.Host(),
+					Port:          srv.Port(),
+					TLS:           tt.tls,
+					TokenSource:   tt.ts,
+					NewGRPCClient: func(channel grpc.ClientConnInterface) grpc.ClientConnInterface { return channel },
+				})
+				require.NoError(t, err, "new grpc transport")
+
+				// Act
+				err = gRPC.Do(t.Context(), func(ctx context.Context, client grpc.ClientConnInterface) error {
+					var empty emptypb.Empty
+					return client.Invoke(ctx, srv.MethodName(), nil, &empty)
+				})
+
+				// Assert
+				assert.NoError(t, err)
+			})
+		}
 	})
 }
 

--- a/internal/transports/grpc_test.go
+++ b/internal/transports/grpc_test.go
@@ -107,9 +107,13 @@ func TestGRPC_Do(t *testing.T) {
 			t.Run(fmt.Sprintf("tls=%t auth=%t", tt.tls, tt.ts != nil), func(t *testing.T) {
 				// Arrange: start a local gRPC server and register a handler with assertions.
 				srv := startTestService(t, func(_ any, ctx context.Context, _ func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
-					// md, ok := metadata.FromIncomingContext(ctx)
-					// assert.True(t, ok, "incoming context should contain metadata")
-					// assert.Subset(t, md, metadata.MD{"x-findme": {"foo"}}, "default headers not present in request metadata")
+					if tt.ts != nil {
+						md, ok := metadata.FromIncomingContext(ctx)
+						assert.True(t, ok, "incoming context should contain metadata")
+						tok, err := tt.ts.Token()
+						assert.NoError(t, err, "get token from %T", tt.ts)
+						assert.Subset(t, md, metadata.MD{"authorization": {"Bearer " + tok.AccessToken}})
+					}
 
 					return nil, nil
 				})


### PR DESCRIPTION
This PR contains several fixes discovered in `beta.1` testing:

1. Internal transport implementation wasn't set up to handle `TenantsGetRequest` and `BatchDeleteRequest` messages.
2. Server cannot find `Targets` nested in the NearVector/NearText part of the Hybrid request, so we need to hoist them.
3. `PUT /objects` requires both collection and UUID to be part of the payload
4. It is necessary to repeat the name of the target vector each time it appears in the target list
5. Do not add gRPC request body to the error message, as it is not easily readable and makes the message cluttered