### PR TITLE
v6: Keepalive configuration

### DIFF
--- a/client.go
+++ b/client.go
@@ -276,6 +276,18 @@ func WithTokenSource(src oauth2.TokenSource) Option {
 	}
 }
 
+type KeepAlive transport.KeepAlive
+
+// Set custom keepalive parameters.
+//
+// The REST transport inherits the settings from [http.DefaultTransport].
+// By default, keepalive is disabled for the gRPC transport.
+func WithKeepAlive(keepalive KeepAlive) Option {
+	return func(c *config) {
+		c.KeepAlive = (*transport.KeepAlive)(&keepalive)
+	}
+}
+
 // IsLive reports instance / cluster liveness.
 func (c *Client) IsLive(ctx context.Context) (bool, error) {
 	if err := c.transport.Do(ctx, api.IsLiveRequest, nil); err != nil {
@@ -358,15 +370,16 @@ func (ht *hybridTransport) Close() error {
 // newTransport returns an [internal.Transport] for REST and gRPC requests.
 func newTransport(ctx context.Context, c config) (*hybridTransport, error) {
 	t, err := transport.New(ctx, transport.Config{
-		Scheme:   c.Scheme,
-		RESTHost: c.RESTHost,
-		RESTPort: c.RESTPort,
-		GRPCHost: c.GRPCHost,
-		GRPCPort: c.GRPCPort,
-		Header:   c.Header,
-		Auth:     c.Auth,
-		Timeout:  c.Timeout,
-		Version:  api.Version,
+		Scheme:    c.Scheme,
+		RESTHost:  c.RESTHost,
+		RESTPort:  c.RESTPort,
+		GRPCHost:  c.GRPCHost,
+		GRPCPort:  c.GRPCPort,
+		Header:    c.Header,
+		Auth:      c.Auth,
+		Timeout:   c.Timeout,
+		KeepAlive: c.KeepAlive,
+		Version:   api.Version,
 	})
 	if err != nil {
 		return nil, err

--- a/client_test.go
+++ b/client_test.go
@@ -85,6 +85,11 @@ func TestNewLocal(t *testing.T) {
 			weaviate.WithReadTimeout(20*time.Second),
 			weaviate.WithBatchTimeout(100*time.Millisecond),
 			weaviate.WithTokenSource(tokenSource),
+			weaviate.WithKeepAlive(weaviate.KeepAlive{
+				Idle:     5 * time.Minute,
+				Interval: 20 * time.Second,
+				Retry:    5,
+			}),
 		)
 		assert.NoError(t, err)
 		assert.NotNil(t, c, "nil client")
@@ -107,6 +112,11 @@ func TestNewLocal(t *testing.T) {
 				Read:  20 * time.Second,
 				Write: 90 * time.Second,
 				Batch: 100 * time.Millisecond,
+			},
+			KeepAlive: &transport.KeepAlive{
+				Idle:     5 * time.Minute,
+				Interval: 20 * time.Second,
+				Retry:    5,
 			},
 			Version: api.Version,
 		}, got)

--- a/internal/api/transport/transport.go
+++ b/internal/api/transport/transport.go
@@ -383,6 +383,9 @@ type KeepAlive struct {
 	Retry int
 }
 
+// If k is not nil, dialOptions returns non-nil configuration for
+// [transports.RESTConfig.KeepAlive] and [transports.GRPCConfig.KeepAlive] respectively.
+// If k is nil, both values are nil too.
 func (k *KeepAlive) dialOptions() (*net.KeepAliveConfig, *keepalive.ClientParameters) {
 	if k == nil {
 		return nil, nil

--- a/internal/api/transport/transport.go
+++ b/internal/api/transport/transport.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -14,19 +15,21 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 )
 
 type Config struct {
-	Scheme   string      // Scheme for request URLs, "http" or "https".
-	RESTHost string      // Hostname of the REST host.
-	RESTPort int         // Port number of the REST host
-	GRPCHost string      // Hostname of the gRPC host.
-	GRPCPort int         // Port number of the gRPC host.
-	Header   http.Header // Request headers.
-	Auth     any         // Authentication provider.
-	Timeout  Timeout     // Request timeout options.
-	Version  string      // API version, e.g. "v1"
+	Scheme    string      // Scheme for request URLs, "http" or "https".
+	RESTHost  string      // Hostname of the REST host.
+	RESTPort  int         // Port number of the REST host
+	GRPCHost  string      // Hostname of the gRPC host.
+	GRPCPort  int         // Port number of the gRPC host.
+	Header    http.Header // Request headers.
+	Auth      any         // Authentication provider.
+	Timeout   Timeout     // Request timeout options.
+	KeepAlive *KeepAlive  // Keepalive configuration.
+	Version   string      // API version, e.g. "v1"
 }
 
 // Timeout sets client-side timeouts.
@@ -91,6 +94,8 @@ func newTransport(ctx context.Context, cfg Config) (StreamingTransport, error) {
 	}
 	restConf.TokenSource = src
 	gRPCConf.TokenSource = src
+
+	restConf.KeepAlive, gRPCConf.KeepAlive = cfg.KeepAlive.dialOptions()
 
 	rest := transports.NewREST(restConf)
 
@@ -345,3 +350,54 @@ func (t *transport) NewStream(ctx context.Context) (BatchStream, error) {
 }
 
 func (t *transport) MaxSize() int { return t.MaxMessageSize }
+
+const (
+	minIdle     = time.Minute      // gRPC recommends clients do not go below 1 minute to avoid DDoS.
+	minInterval = 20 * time.Second // Somewhere between the minimum 15s and the default 30s for http.Client.
+	minRetry    = 3                // minRetry*minInterval result in 1 minute timeout for gRPC connections.
+)
+
+type KeepAlive struct {
+	// Idle is the time that the connection must be idle before
+	// the first keep-alive probe is sent. If set below 1 minute,
+	// a minimum value of 1 minute will be used.
+	Idle time.Duration
+
+	// Interval is the time between keep-alive probes.
+	// If zero, a default value of 20 seconds is used.
+	//
+	// When applied to [gRPC connections], [keepalive.ClientParameters.Timeout]
+	// is calculated as Interval * Retry.
+	//
+	// [gRPC connections]: https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md#basic-keepalive
+	Interval time.Duration
+
+	// Retry is the maximum number of keep-alive probes that
+	// can go unanswered before dropping a connection.
+	// If zero, a default value of 6 is used.
+	//
+	// When applied to [gRPC connections], [keepalive.ClientParameters.Timeout]
+	// is calculated as Interval * Retry.
+	//
+	// [gRPC connections]: https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md#basic-keepalive
+	Retry int
+}
+
+func (k *KeepAlive) dialOptions() (*net.KeepAliveConfig, *keepalive.ClientParameters) {
+	if k == nil {
+		return nil, nil
+	}
+	idle := max(minIdle, k.Idle)
+	interval := max(minInterval, k.Interval)
+	retry := max(minRetry, k.Retry)
+	return &net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     idle,
+			Interval: interval,
+			Count:    retry,
+		}, &keepalive.ClientParameters{
+			PermitWithoutStream: true,
+			Time:                idle,
+			Timeout:             interval * time.Duration(retry),
+		}
+}

--- a/internal/api/transport/transport_test.go
+++ b/internal/api/transport/transport_test.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -16,6 +17,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/internal/transports"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 // Test that transport fetches instance's /meta information when created.
@@ -446,4 +448,59 @@ func (e *exchanger) Exchange(ctx context.Context, got oauth2.Config) (oauth2.Tok
 	assert.Equal(e.t, e.wantClientID, got.ClientID, "bad client id")
 	assert.Equal(e.t, e.wantScopes, got.Scopes, "bad scopes")
 	return oauth2.StaticTokenSource(&e.tok), nil
+}
+
+func TestKeepAlive(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		keepalive *KeepAlive
+		rest      *net.KeepAliveConfig        // Expected REST configuration.
+		gRPC      *keepalive.ClientParameters // Expected gRPC configuration.
+	}{
+		{name: "nil keepalive"},
+		{
+			name: "below minimum",
+			keepalive: &KeepAlive{
+				Idle:     time.Second,
+				Interval: time.Second,
+				Retry:    1,
+			},
+			rest: &net.KeepAliveConfig{
+				Enable:   true,
+				Idle:     minIdle,
+				Interval: minInterval,
+				Count:    minRetry,
+			},
+			gRPC: &keepalive.ClientParameters{
+				PermitWithoutStream: true,
+				Time:                minIdle,
+				Timeout:             minInterval * time.Duration(minRetry),
+			},
+		},
+		{
+			name: "adequate values",
+			keepalive: &KeepAlive{
+				Idle:     5 * time.Minute,
+				Interval: 30 * time.Second,
+				Retry:    5,
+			},
+			rest: &net.KeepAliveConfig{
+				Enable:   true,
+				Idle:     5 * time.Minute,
+				Interval: 30 * time.Second,
+				Count:    5,
+			},
+			gRPC: &keepalive.ClientParameters{
+				PermitWithoutStream: true,
+				Time:                5 * time.Minute,
+				Timeout:             5 * 30 * time.Second,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rest, gRPC := tt.keepalive.dialOptions()
+			assert.Equal(t, tt.rest, rest, "rest configuration")
+			assert.Equal(t, tt.gRPC, gRPC, "gRPC configuration")
+		})
+	}
 }

--- a/internal/transports/grpc.go
+++ b/internal/transports/grpc.go
@@ -11,17 +11,19 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/oauth"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 )
 
 // Config for [GRPC] transport.
 type GRPCConfig[Client any] struct {
-	Host           string             // Hostname of the gRPC host.
-	Port           int                // Port number of the gRPC host.
-	Header         *metadata.MD       // Headers added with each request.
-	MaxMessageSize int                // Maximum gRPC message size in bytes.
-	TokenSource    oauth2.TokenSource // OAuth2 token provider.
-	TLS            bool               // If true, channel will use TLS protocol.
+	Host           string                      // Hostname of the gRPC host.
+	Port           int                         // Port number of the gRPC host.
+	Header         *metadata.MD                // Headers added with each request.
+	MaxMessageSize int                         // Maximum gRPC message size in bytes.
+	TokenSource    oauth2.TokenSource          // OAuth2 token provider.
+	TLS            bool                        // If true, channel will use TLS protocol.
+	KeepAlive      *keepalive.ClientParameters // Keepalive configuration.
 
 	NewGRPCClient NewGRPCClientFunc[Client]
 }
@@ -82,6 +84,10 @@ func NewGRPC[Client any](cfg GRPCConfig[Client]) (*GRPC[Client], error) {
 		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(
 			&oauth.TokenSource{TokenSource: cfg.TokenSource},
 		))
+	}
+
+	if cfg.KeepAlive != nil {
+		dialOpts = append(dialOpts, grpc.WithKeepaliveParams(*cfg.KeepAlive))
 	}
 
 	target := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)

--- a/internal/transports/rest.go
+++ b/internal/transports/rest.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/weaviate/weaviate-go-client/v6/internal/dev"
 	"golang.org/x/oauth2"
@@ -43,12 +45,13 @@ type StatusAccepter interface {
 
 // Config options for [REST].
 type RESTConfig struct {
-	Scheme      string             // Scheme for request URLs, "http" or "https".
-	Host        string             // Hostname of the REST host.
-	Port        int                // Port number of the REST host
-	Header      http.Header        // Headers added with each request.
-	TokenSource oauth2.TokenSource // OAuth2 token source.
-	Version     string             // Version of the REST API.
+	Scheme      string               // Scheme for request URLs, "http" or "https".
+	Host        string               // Hostname of the REST host.
+	Port        int                  // Port number of the REST host
+	Header      http.Header          // Headers added with each request.
+	TokenSource oauth2.TokenSource   // OAuth2 token source.
+	KeepAlive   *net.KeepAliveConfig // Keepalive configuration.
+	Version     string               // Version of the REST API.
 }
 
 func (c *REST) Do(ctx context.Context, req Endpoint, dest any) error {
@@ -144,9 +147,17 @@ func NewREST(cfg RESTConfig) *REST {
 		cfg.Scheme, cfg.Host, cfg.Port, cfg.Version,
 	)
 
+	var hc http.Client
+	if cfg.KeepAlive != nil {
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.DialContext = (&net.Dialer{
+			Timeout:         30 * time.Second,
+			KeepAliveConfig: *cfg.KeepAlive,
+		}).DialContext
+	}
+
 	r := &REST{
-		// TODO(dyma): allow passing custom http.Client
-		hc:      &http.Client{},
+		hc:      &hc,
 		baseURL: baseURL,
 		header:  cfg.Header,
 	}


### PR DESCRIPTION
This PR provides users with a way to configure keepalive for client's underlying transports.

While REST client implicitly uses `http.DefaultTransport`'s 30s keepalive, gRPC has it disabled. In cloud deployments load balancers may therefore drop idle gRPC connections.

We provide a minimal set of parameters to configure the keepalive for both REST and gRPC transports:
- idle time (how soon after the last received byte to ping the server)
- interval (how often to send successive pings if there's no response)
- retry (how many pings can fail before the connection is deemed dead)

In `google.golang.org/grpc` the last two parameters are replaced with [Timeout](https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md#basic-keepalive):

> Interval and retry don't quite apply to PING because the transport is reliable, so they will be replaced with timeout (equivalent to interval * retry), the time between sending a PING and not receiving any bytes to declare the connection dead.

and this is exactly what we do to adapt the configuration to gRPC.

See also: https://github.com/weaviate/weaviate-go-client/pull/367
