### PR TITLE
v6: Fix keepalive configuration for REST transport

### DIFF
--- a/internal/transports/rest.go
+++ b/internal/transports/rest.go
@@ -154,6 +154,7 @@ func NewREST(cfg RESTConfig) *REST {
 			Timeout:         30 * time.Second,
 			KeepAliveConfig: *cfg.KeepAlive,
 		}).DialContext
+		hc.Transport = tr
 	}
 
 	r := &REST{

--- a/internal/transports/rest.go
+++ b/internal/transports/rest.go
@@ -147,7 +147,7 @@ func NewREST(cfg RESTConfig) *REST {
 		cfg.Scheme, cfg.Host, cfg.Port, cfg.Version,
 	)
 
-	var hc http.Client
+	hc := &http.Client{}
 	if cfg.KeepAlive != nil {
 		tr := http.DefaultTransport.(*http.Transport).Clone()
 		tr.DialContext = (&net.Dialer{
@@ -157,23 +157,23 @@ func NewREST(cfg RESTConfig) *REST {
 		hc.Transport = tr
 	}
 
-	r := &REST{
-		hc:      &hc,
-		baseURL: baseURL,
-		header:  cfg.Header,
-	}
-
+	// Handle TokenSource config last. [oauth2.NewClient] will wrap around
+	// the current hc.Transport, which must be fully configured at that point.
 	if cfg.TokenSource != nil {
 		// Here [oauth2.NewClient] uses context exclusively as a value store,
 		// where it looks for the HTTPClient key before falling back to
 		// [http.DefaultClient]. We could get away with passing a nil context,
 		// which we won't do in case our http.Client has some configurations
 		// we want to propagate to the oauth2 client.
-		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, r.hc)
-		r.hc = oauth2.NewClient(ctx, cfg.TokenSource)
+		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, hc)
+		hc = oauth2.NewClient(ctx, cfg.TokenSource)
 	}
 
-	return r
+	return &REST{
+		hc:      hc,
+		baseURL: baseURL,
+		header:  cfg.Header,
+	}
 }
 
 // HTTPError is returned if the response has an error HTTP status code.

--- a/internal/transports/rest_test.go
+++ b/internal/transports/rest_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -28,9 +29,10 @@ func TestREST_Do(t *testing.T) {
 	for _, tt := range testkit.WithOnly(t, []struct {
 		testkit.Only
 
-		name string
-		req  transports.Endpoint
-		src  oauth2.TokenSource
+		name      string
+		req       transports.Endpoint
+		src       oauth2.TokenSource
+		keepalive *net.KeepAliveConfig
 
 		respBody string // Set response body to return.
 		respCode int    // Override returned status code (default: HTTP 200).
@@ -105,6 +107,19 @@ func TestREST_Do(t *testing.T) {
 			src: oauth2.StaticTokenSource(&oauth2.Token{
 				AccessToken: "my-token",
 			}),
+		},
+		{
+			// Make sure additional parameters like keepalive
+			// do not overwrite TokenSource configuration.
+			name: "bearer token authorization with keepalive",
+			req: &endpoint{
+				method: http.MethodGet,
+				path:   "/test",
+			},
+			src: oauth2.StaticTokenSource(&oauth2.Token{
+				AccessToken: "my-token",
+			}),
+			keepalive: &net.KeepAliveConfig{Enable: true},
 		},
 		{
 			name: "basic token authorization",


### PR DESCRIPTION
#446 creates a custom `http.Transport` with keepalive configuration but never actually passes it to `http.Client`. 

f1ee3e27d9f296d9cbc88f20e48593b5d3a51dc8 is 1-line fix for that. I couldn't think of a good way to test that keepalive configuration actually makes it to the `http.Client`, because the later will only hold a _reference to a method on a net.Dialer with KeepAliveConfig_. Inspecting the Client object doesn't let us access the dialer, and we cannot see keepalive pings via the `httptest.Server`. 

Since there're now 2 configuration parameters which modify `http.Client` I added a unit test case to check that they will not override each other if both are set.