### PR TITLE
v6: BM25 search and AND_CROSS search operator

### DIFF
--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -954,6 +954,32 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 			},
 		},
 		{
+			name: "bm25 with keyword similarity",
+			req: &api.SearchRequest{
+				BM25: &api.BM25{
+					Query:           "she sells seashells",
+					QueryProperties: []string{"sentence"},
+					KeywordSimilarity: api.KeywordSimilarity{
+						AllTokensMatch: true,
+						CrossProperty:  true,
+					},
+				},
+			},
+			want: &proto.SearchRequest{
+				Bm25Search: &proto.BM25{
+					Query:      "she sells seashells",
+					Properties: []string{"sentence"},
+					SearchOperator: &proto.SearchOperatorOptions{
+						Operator: proto.SearchOperatorOptions_OPERATOR_AND_CROSS,
+					},
+				},
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+			},
+		},
+		{
 			name: "hybrid with near vector",
 			req: &api.SearchRequest{
 				Hybrid: &api.Hybrid{

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -31,6 +31,7 @@ type SearchRequest struct {
 
 	NearVector *NearVector
 	NearText   *NearText
+	BM25       *BM25
 	Hybrid     *Hybrid
 }
 
@@ -99,6 +100,11 @@ type (
 
 		Selection Selection
 	}
+	BM25 struct {
+		Query             string
+		QueryProperties   []string
+		KeywordSimilarity KeywordSimilarity
+	}
 	Hybrid struct {
 		Query             string
 		QueryProperties   []string
@@ -127,6 +133,7 @@ type (
 	}
 	KeywordSimilarity struct {
 		AllTokensMatch     bool
+		CrossProperty      bool
 		MinimumTokensMatch *int32
 	}
 )
@@ -184,6 +191,8 @@ func (r *SearchRequest) MarshalMessage() (*proto.SearchRequest, error) {
 		req.NearVector, err = marshalNearVector(r.NearVector)
 	case r.NearText != nil:
 		req.NearText, err = marshalNearText(r.NearText)
+	case r.BM25 != nil:
+		req.Bm25Search, err = marshalBM25(r.BM25)
 	case r.Hybrid != nil:
 		req.HybridSearch, err = marshalHybrid(r.Hybrid)
 	}
@@ -649,27 +658,46 @@ func marshalNearText(req *NearText) (*proto.NearTextSearch, error) {
 	return nt, nil
 }
 
+func marshalBM25(req *BM25) (*proto.BM25, error) {
+	dev.AssertNotNil(req, "req")
+	return &proto.BM25{
+		Query:          req.Query,
+		Properties:     req.QueryProperties,
+		SearchOperator: marshalKeywordSimilarity(req.KeywordSimilarity),
+	}, nil
+}
+
+func marshalKeywordSimilarity(kw KeywordSimilarity) *proto.SearchOperatorOptions {
+	switch {
+	case kw.AllTokensMatch:
+		if kw.CrossProperty {
+			return &proto.SearchOperatorOptions{
+				Operator: proto.SearchOperatorOptions_OPERATOR_AND_CROSS,
+			}
+		} else {
+			return &proto.SearchOperatorOptions{
+				Operator: proto.SearchOperatorOptions_OPERATOR_AND,
+			}
+		}
+	case kw.MinimumTokensMatch != nil:
+		return &proto.SearchOperatorOptions{
+			Operator:             proto.SearchOperatorOptions_OPERATOR_OR,
+			MinimumOrTokensMatch: kw.MinimumTokensMatch,
+		}
+	}
+	return nil
+}
+
 func marshalHybrid(req *Hybrid) (*proto.Hybrid, error) {
 	dev.AssertNotNil(req, "req")
 
 	h := &proto.Hybrid{
-		Query:         req.Query,
-		Properties:    req.QueryProperties,
-		AlphaParam:    req.Alpha,
-		UseAlphaParam: true,
-		FusionType:    proto.Hybrid_FusionType(req.Fusion),
-	}
-
-	switch {
-	case req.KeywordSimilarity.AllTokensMatch:
-		h.Bm25SearchOperator = &proto.SearchOperatorOptions{
-			Operator: proto.SearchOperatorOptions_OPERATOR_AND,
-		}
-	case req.KeywordSimilarity.MinimumTokensMatch != nil:
-		h.Bm25SearchOperator = &proto.SearchOperatorOptions{
-			Operator:             proto.SearchOperatorOptions_OPERATOR_OR,
-			MinimumOrTokensMatch: req.KeywordSimilarity.MinimumTokensMatch,
-		}
+		Query:              req.Query,
+		Properties:         req.QueryProperties,
+		AlphaParam:         req.Alpha,
+		UseAlphaParam:      true,
+		FusionType:         proto.Hybrid_FusionType(req.Fusion),
+		Bm25SearchOperator: marshalKeywordSimilarity(req.KeywordSimilarity),
 	}
 
 	var err error

--- a/query/bm25.go
+++ b/query/bm25.go
@@ -1,11 +1,54 @@
 package query
 
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/query/filter"
+)
+
+type BM25 struct {
+	Limit                  int              // Limit the number of results returned for the query.
+	Offset                 int              // Skip the first N objects in the collection.
+	AutoLimit              int              // Return objects in the first N similarity clusters.
+	After                  uuid.UUID        // Skip all objects before the one with this ID.
+	Filter                 filter.Expr      // Filter results based on their properties.
+	ReturnMetadata         ReturnMetadata   // Select query and object metadata to return for each object.
+	ReturnVectors          []string         // List vectors to return for each object in the result set.
+	ReturnReferences       []Reference      // Select reference properties to return.
+	ReturnNestedProperties []NestedProperty // Return object properties and a subset of their nested properties.
+
+	// Select a subset of properties to return. By default, all properties are returned.
+	// To not return any properties, initialize this value to an empty slice explicitly.
+	ReturnProperties []string
+
+	// Query is tokenized and the resulting keywords are searched across [QueryProeprties].
+	// Required parameter.
+	Query string
+
+	// Select a subset of properties to search for keywords. By default, all searchable
+	// text/text[] properties are considered.
+	QueryProperties []string
+
+	// Similarity threshold.
+	KeywordSimilarity KeywordSimilarity
+
+	// groupBy can only be set by [BM25Func.GroupBy], as it changes the shape of the response.
+	groupBy *GroupBy
+}
+
 type (
 	// KeywordSimilarity conrols the similarity threshold for BM25 (keyword) search.
 	KeywordSimilarity struct {
 		// allTokensMatch requires each token in the search query to be present
 		// in a candidate object for it to be considered a match.
 		allTokensMatch bool
+
+		// crossProperty counts token matches from all query properties towards
+		// the similarity target.
+		crossProperty bool
 
 		// minimumTokensMatch is the lower threshold for the number of times
 		// _each_ token needs be present in a candidate object for it to be considered a match.
@@ -14,12 +57,56 @@ type (
 )
 
 func (kws *KeywordSimilarity) AllTokensMatch() bool       { return kws.allTokensMatch }
+func (kws *KeywordSimilarity) CrossProperty() bool        { return kws.crossProperty }
 func (kws *KeywordSimilarity) MinimumTokensMatch() *int32 { return kws.mininumTokensMatch }
 
-// AllTokensMatch is a [KeywordSimilarity] parameter with AllTokensMatch=true.
+// AllTokensMatch is a [KeywordSimilarity] parameter with allTokensMatch=true.
 var AllTokensMatch = KeywordSimilarity{allTokensMatch: true}
+
+// AllTokensMatchCross is a [KeywordSimilarity] parameter like [AllTokensMatch],
+// but counting matches from all query properties towards the similarity target.
+var AllTokensMatchCross = KeywordSimilarity{allTokensMatch: true, crossProperty: true}
 
 // MinimumTokensMatch returns [KeywordSimilarity] with MinimumTokensMatch=n.
 func MinimumTokensMatch(n int32) KeywordSimilarity {
 	return KeywordSimilarity{mininumTokensMatch: &n}
+}
+
+// BM25Func runs plain near text search.
+type BM25Func func(context.Context, BM25) (*Result, error)
+
+// bm25Func makes internal.Transport available to [query] via a closure.
+func bm25Func(t internal.Transport, rd api.RequestDefaults) BM25Func {
+	return func(ctx context.Context, bm25 BM25) (*Result, error) {
+		return query(ctx, t, request{
+			RequestDefaults:        rd,
+			Limit:                  int32(bm25.Limit),
+			AutoLimit:              int32(bm25.AutoLimit),
+			Offset:                 int32(bm25.Offset),
+			After:                  bm25.After,
+			Filter:                 bm25.Filter,
+			ReturnVectors:          bm25.ReturnVectors,
+			ReturnMetadata:         bm25.ReturnMetadata,
+			ReturnProperties:       bm25.ReturnProperties,
+			ReturnNestedProperties: bm25.ReturnNestedProperties,
+			ReturnReferences:       bm25.ReturnReferences,
+			GroupBy:                bm25.groupBy,
+		}, func(req *api.SearchRequest) {
+			req.BM25 = &api.BM25{
+				Query:           bm25.Query,
+				QueryProperties: bm25.QueryProperties,
+				KeywordSimilarity: api.KeywordSimilarity{
+					AllTokensMatch:     bm25.KeywordSimilarity.AllTokensMatch(),
+					CrossProperty:      bm25.KeywordSimilarity.CrossProperty(),
+					MinimumTokensMatch: bm25.KeywordSimilarity.MinimumTokensMatch(),
+				},
+			}
+		})
+	}
+}
+
+// GroupBy runs near text search with a GroupBy clause.
+func (bf BM25Func) GroupBy(ctx context.Context, bm25 BM25, groupBy GroupBy) (*GroupByResult, error) {
+	bm25.groupBy = &groupBy
+	return queryGroupBy(ctx, bf, bm25)
 }

--- a/query/bm25_test.go
+++ b/query/bm25_test.go
@@ -2,9 +2,14 @@ package query_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/internal/testkit"
 	"github.com/weaviate/weaviate-go-client/v6/query"
+	"github.com/weaviate/weaviate-go-client/v6/types"
 )
 
 func TestKeywordSimilarity(t *testing.T) {
@@ -12,9 +17,103 @@ func TestKeywordSimilarity(t *testing.T) {
 		assert.True(t, query.AllTokensMatch.AllTokensMatch(), "all tokens match")
 		assert.Nil(t, query.AllTokensMatch.MinimumTokensMatch(), "minimum tokens match")
 	})
+	t.Run("all tokens match cross property", func(t *testing.T) {
+		assert.True(t, query.AllTokensMatchCross.AllTokensMatch(), "all tokens match")
+		assert.True(t, query.AllTokensMatchCross.CrossProperty(), "cross property")
+		assert.Nil(t, query.AllTokensMatchCross.MinimumTokensMatch(), "minimum tokens match")
+	})
 	t.Run("minimum tokens match", func(t *testing.T) {
 		similarity := query.MinimumTokensMatch(5)
 		assert.False(t, similarity.AllTokensMatch(), "all tokens match")
 		assert.NotNil(t, similarity.MinimumTokensMatch(), "minimum tokens match")
 	})
+}
+
+func TestBM25(t *testing.T) {
+	rd := api.RequestDefaults{
+		CollectionName:   "Songs",
+		Tenant:           "john_doe",
+		ConsistencyLevel: api.ConsistencyLevelQuorum,
+	}
+
+	for _, tt := range testkit.WithOnly(t, []struct {
+		testkit.Only
+
+		name  string
+		nt    query.BM25
+		stubs []testkit.Stub[api.SearchRequest, api.SearchResponse]
+		want  *query.Result // Expected return value.
+		err   testkit.Error
+	}{
+		{
+			name: "ok",
+			nt: query.BM25{
+				Query:             "yellow submarine",
+				QueryProperties:   []string{"title", "lyrics"},
+				KeywordSimilarity: query.MinimumTokensMatch(3),
+			},
+			stubs: []testkit.Stub[api.SearchRequest, api.SearchResponse]{
+				{
+					Request: &api.SearchRequest{
+						RequestDefaults: rd,
+						BM25: &api.BM25{
+							Query:           "yellow submarine",
+							QueryProperties: []string{"title", "lyrics"},
+							KeywordSimilarity: api.KeywordSimilarity{
+								MinimumTokensMatch: testkit.Ptr[int32](3),
+							},
+						},
+					},
+					Response: api.SearchResponse{
+						Took: 92 * time.Second,
+						Results: []api.Object{
+							{
+								Collection: "Songs",
+								Metadata: api.ObjectMetadata{
+									UUID: testkit.UUID,
+								},
+								Properties: map[string]any{
+									"title":        "Yellow Submarine",
+									"duration_sec": 160,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &query.Result{
+				Took: 92 * time.Second,
+				Objects: []query.Object[map[string]any]{
+					{
+						Object: types.Object[map[string]any]{
+							Collection: "Songs",
+							UUID:       testkit.UUID,
+							Properties: map[string]any{
+								"title":        "Yellow Submarine",
+								"duration_sec": 160,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "request error",
+			stubs: []testkit.Stub[api.SearchRequest, api.SearchResponse]{
+				{Err: testkit.ErrWhaam},
+			},
+			err: testkit.ExpectError,
+		},
+	}) {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := testkit.NewTransport(t, tt.stubs)
+
+			c := query.NewClient(transport, rd)
+			require.NotNil(t, c, "client")
+
+			got, err := c.BM25(t.Context(), tt.nt)
+			tt.err.Require(t, err, "bm25 query")
+			require.EqualExportedValues(t, tt.want, got, "query result")
+		})
+	}
 }

--- a/query/client.go
+++ b/query/client.go
@@ -24,6 +24,7 @@ func NewClient(t internal.Transport, rd api.RequestDefaults) *Client {
 		NearVector: nearVectorFunc(t, rd),
 		NearText:   nearTextFunc(t, rd),
 		Hybrid:     hybridFunc(t, rd),
+		BM25:       bm25Func(t, rd),
 	}
 }
 
@@ -35,6 +36,7 @@ type Client struct {
 	NearVector NearVectorFunc
 	NearText   NearTextFunc
 	Hybrid     HybridFunc
+	BM25       BM25Func
 }
 
 type (

--- a/query/hybrid.go
+++ b/query/hybrid.go
@@ -89,6 +89,7 @@ func hybridFunc(t internal.Transport, rd api.RequestDefaults) HybridFunc {
 				Fusion:          h.Fusion,
 				KeywordSimilarity: api.KeywordSimilarity{
 					AllTokensMatch:     h.KeywordSimilarity.AllTokensMatch(),
+					CrossProperty:      h.KeywordSimilarity.CrossProperty(),
 					MinimumTokensMatch: h.KeywordSimilarity.MinimumTokensMatch(),
 				},
 				NearVector: nearVector(h.NearVector),

--- a/query/hybrid_test.go
+++ b/query/hybrid_test.go
@@ -174,7 +174,7 @@ func TestHybrid(t *testing.T) {
 			require.NotNil(t, c, "client")
 
 			got, err := c.Hybrid(t.Context(), tt.nt)
-			tt.err.Require(t, err, "near vector query")
+			tt.err.Require(t, err, "hybrid query")
 			require.EqualExportedValues(t, tt.want, got, "query result")
 		})
 	}


### PR DESCRIPTION
This PR adds BM25 to `Query` namespace and extends `KeywordSimilarity` so it supports `AND_CROSS` parameter as well.

The new search operator can be used thusly:

```go
songs.Query.BM25(ctx, query.BM25{
    Query: "la-la-land",
    KeywordSimilarity: AllTokensMatchCross,
})
```