### PR TITLE
v6: Bugfixes for beta.1

### DIFF
--- a/api/rest/schema.v3.yaml
+++ b/api/rest/schema.v3.yaml
@@ -1255,6 +1255,7 @@ components:
             properties:
                 bm25:
                     $ref: '#/components/schemas/BM25Config'
+                    x-go-type-skip-optional-pointer: false
                 cleanupIntervalSeconds:
                     description: 'Asynchronous index clean up happens every n seconds (default: 60).'
                     format: int32

--- a/cmd/build/contracts.go
+++ b/cmd/build/contracts.go
@@ -369,10 +369,13 @@ func convertToV3(ctx context.Context, r io.Reader) (map[string]any, error) {
 			// x-nullable is Swagger v2, nullable is Swagger v3
 			delete(m, "nullable")
 			return
+		case "bm25":
+			m["x-go-type-skip-optional-pointer"] = false
 		case "id":
 			if format, ok := m["format"]; ok && format == "uuid" {
 				m["x-go-type"] = "*openapi_types.UUID"
 			}
+			return
 		}
 
 		if format, ok := m["format"]; ok {
@@ -389,10 +392,6 @@ func convertToV3(ctx context.Context, r io.Reader) (map[string]any, error) {
 		if t, ok := m["type"]; ok && t == "number" {
 			m["format"] = "float"
 		}
-
-		// if _, ok := m["$ref"]; ok {
-		// 	m["x-go-type-skip-optional-pointer"] = false
-		// }
 	})
 
 	return schema, nil

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -111,10 +111,10 @@ const (
 	DataTypeGeoCoordinates DataType = "geoCoordinates"
 	DataTypeTextArray      DataType = "text[]"
 	DataTypeBoolArray      DataType = "boolean[]"
-	DataTypeIntArray       DataType = "number[]"
-	DataTypeNumberArray    DataType = "date[]"
-	DataTypeDateArray      DataType = "object[]"
-	DataTypeObjectArray    DataType = "geoCoordinates[]"
+	DataTypeIntArray       DataType = "int[]"
+	DataTypeNumberArray    DataType = "number[]"
+	DataTypeDateArray      DataType = "date[]"
+	DataTypeObjectArray    DataType = "object[]"
 )
 
 // knownDataTypes are a set of all data types defined in the Weaviate server.

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -307,7 +307,7 @@ func (c *Collection) MarshalJSON() ([]byte, error) {
 		}
 
 		if c.InvertedIndex.BM25 != nil {
-			out.InvertedIndexConfig.Bm25 = rest.BM25Config{
+			out.InvertedIndexConfig.Bm25 = &rest.BM25Config{
 				B:  c.InvertedIndex.BM25.B,
 				K1: c.InvertedIndex.BM25.K1,
 			}

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -360,7 +360,7 @@ func TestRESTRequests(t *testing.T) {
 					IndexTimestamps:        true,
 					UsingBlockMaxWAND:      true,
 					CleanupIntervalSeconds: 92,
-					Bm25: rest.BM25Config{
+					Bm25: &rest.BM25Config{
 						B:  25,
 						K1: 1,
 					},
@@ -1439,7 +1439,7 @@ func TestRESTResponses(t *testing.T) {
 					IndexTimestamps:        true,
 					UsingBlockMaxWAND:      true,
 					CleanupIntervalSeconds: 92,
-					Bm25: rest.BM25Config{
+					Bm25: &rest.BM25Config{
 						B:  25,
 						K1: 1,
 					},

--- a/internal/api/endpoint_test.go
+++ b/internal/api/endpoint_test.go
@@ -855,31 +855,31 @@ func TestRESTRequests(t *testing.T) {
 					{
 						"action": "create_users",
 						"users": map[string]any{
-							"user": "john_doe",
+							"users": "john_doe",
 						},
 					},
 					{
 						"action": "read_users",
 						"users": map[string]any{
-							"user": "john_doe",
+							"users": "john_doe",
 						},
 					},
 					{
 						"action": "update_users",
 						"users": map[string]any{
-							"user": "jane_doe",
+							"users": "jane_doe",
 						},
 					},
 					{
 						"action": "delete_users",
 						"users": map[string]any{
-							"user": "jane_doe",
+							"users": "jane_doe",
 						},
 					},
 					{
 						"action": "assign_and_revoke_users",
 						"users": map[string]any{
-							"user": "jim_beam",
+							"users": "jim_beam",
 						},
 					},
 				},
@@ -1915,31 +1915,31 @@ func TestRESTResponses(t *testing.T) {
 					{
 						"action": "create_users",
 						"users": map[string]any{
-							"user": "john_doe",
+							"users": "john_doe",
 						},
 					},
 					{
 						"action": "read_users",
 						"users": map[string]any{
-							"user": "john_doe",
+							"users": "john_doe",
 						},
 					},
 					{
 						"action": "update_users",
 						"users": map[string]any{
-							"user": "jane_doe",
+							"users": "jane_doe",
 						},
 					},
 					{
 						"action": "delete_users",
 						"users": map[string]any{
-							"user": "jane_doe",
+							"users": "jane_doe",
 						},
 					},
 					{
 						"action": "assign_and_revoke_users",
 						"users": map[string]any{
-							"user": "jim_beam",
+							"users": "jim_beam",
 						},
 					},
 				},

--- a/internal/api/internal/gen/rest/models.go
+++ b/internal/api/internal/gen/rest/models.go
@@ -2493,7 +2493,7 @@ type IndexUpsertRequest struct {
 // InvertedIndexConfig Configure the inverted index built into Weaviate. See [Reference: Inverted index](https://docs.weaviate.io/weaviate/config-refs/indexing/inverted-index#inverted-index-parameters) for details.
 type InvertedIndexConfig struct {
 	// Bm25 Tuning parameters for the BM25 algorithm.
-	Bm25 BM25Config `json:"bm25,omitempty"`
+	Bm25 *BM25Config `json:"bm25,omitempty"`
 
 	// CleanupIntervalSeconds Asynchronous index clean up happens every n seconds (default: 60).
 	CleanupIntervalSeconds int32 `json:"cleanupIntervalSeconds,omitempty"`

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -818,19 +818,73 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 			},
 		},
 		{
-			name: "near text implicit target",
+			name: "near text move concepts",
 			req: &api.SearchRequest{
 				NearText: &api.NearText{
-					Concepts:   []string{"apples", "oranges"},
-					Similarity: api.VectorSimilarity{Distance: testkit.Ptr(.92)},
 					MoveTo: &api.Move{
 						Force:    0.58,
 						Concepts: []string{"computers"},
 					},
 					MoveAway: &api.Move{
-						Force:   0.22,
+						Force:    0.22,
+						Concepts: []string{"meatloaf"},
+					},
+				},
+			},
+			want: &proto.SearchRequest{
+				NearText: &proto.NearTextSearch{
+					MoveTo: &proto.NearTextSearch_Move{
+						Force:    0.58,
+						Concepts: []string{"computers"},
+					},
+					MoveAway: &proto.NearTextSearch_Move{
+						Force:    0.22,
+						Concepts: []string{"meatloaf"},
+					},
+				},
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+			},
+		},
+		{
+			name: "near text move objects",
+			req: &api.SearchRequest{
+				NearText: &api.NearText{
+					MoveTo: &api.Move{
+						Force:   0.58,
 						Objects: []uuid.UUID{uuid.Nil, uuid.Max},
 					},
+					MoveAway: &api.Move{
+						Force:   0.22,
+						Objects: []uuid.UUID{testkit.UUID},
+					},
+				},
+			},
+			want: &proto.SearchRequest{
+				NearText: &proto.NearTextSearch{
+					MoveTo: &proto.NearTextSearch_Move{
+						Force: 0.58,
+						Uuids: []string{uuid.Nil.String(), uuid.Max.String()},
+					},
+					MoveAway: &proto.NearTextSearch_Move{
+						Force: 0.22,
+						Uuids: []string{testkit.UUID.String()},
+					},
+				},
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+			},
+		},
+		{
+			name: "near text implicit target",
+			req: &api.SearchRequest{
+				NearText: &api.NearText{
+					Concepts:   []string{"apples", "oranges"},
+					Similarity: api.VectorSimilarity{Distance: testkit.Ptr(.92)},
 					Selection: api.Selection{
 						MMR: &api.SelectionMMR{Limit: int32(3)},
 					},
@@ -840,14 +894,6 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 				NearText: &proto.NearTextSearch{
 					Query:    []string{"apples", "oranges"},
 					Distance: testkit.Ptr(.92),
-					MoveTo: &proto.NearTextSearch_Move{
-						Force:    0.58,
-						Concepts: []string{"computers"},
-					},
-					MoveAway: &proto.NearTextSearch_Move{
-						Force: 0.22,
-						Uuids: []string{uuid.Nil.String(), uuid.Max.String()},
-					},
 					Selection: &proto.Selection{
 						Selection: &proto.Selection_Mmr{
 							Mmr: &proto.Selection_MMR{

--- a/internal/api/rbac.go
+++ b/internal/api/rbac.go
@@ -126,7 +126,7 @@ type (
 		Delete bool `json:"-"`
 	}
 	UserPermission struct {
-		UserID string `json:"user,omitempty"`
+		UserID string `json:"users,omitempty"`
 
 		Create          bool `json:"-"`
 		Read            bool `json:"-"`

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"slices"
 	"strings"
 	"time"
 
@@ -591,12 +590,8 @@ func marshalNearText(req *NearText) (*proto.NearTextSearch, error) {
 		Certainty: req.Similarity.Certainty,
 	}
 
-	// We keep MoveTo and MoveAway marshaling inline to
-	// 1) avoid breeding functions; these params are only needed here
-	// 2) re-use the uuids slice if possible (minor benefit, but still).
-	var uuids []string
 	if m := req.MoveTo; m != nil {
-		uuids = slices.Grow(uuids, len(m.Objects))
+		var uuids []string
 		for _, u := range m.Objects {
 			uuids = append(uuids, u.String())
 		}
@@ -608,7 +603,7 @@ func marshalNearText(req *NearText) (*proto.NearTextSearch, error) {
 	}
 
 	if m := req.MoveAway; m != nil {
-		uuids = slices.Grow(uuids[:0], len(m.Objects))
+		var uuids []string
 		for _, u := range m.Objects {
 			uuids = append(uuids, u.String())
 		}

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -319,9 +319,6 @@ func marshalFilter(f FilterExpr) *proto.Filters {
 		// Marshaling it would've been as simple as [structpb.NewValue].
 		switch v := f.Value.(type) {
 		case nil:
-			if f.Operator != FilterOperatorIsNull {
-				return nil // Null-ness should be checked via IsNull operator.
-			}
 		case string:
 			pf.TestValue = &proto.Filters_ValueText{ValueText: v}
 		case []string:

--- a/internal/api/ssb/protocol.go
+++ b/internal/api/ssb/protocol.go
@@ -3,6 +3,7 @@ package ssb
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"iter"
 	"maps"
@@ -55,9 +56,15 @@ func NewClient(conf ClientConfig) *Client {
 }
 
 // Add creates a new task and puts it on the work queue.
+// A stream can only have a single task in progress for each object or reference,
+// and an error is returned if the task with the same ID hasn't completed yet.
 // If [Client.Context] expires, Add returns [context.Canceled],
 // otherwise the error is nil. Calling Add after closing the batch panics.
 func (c *Client) Add(ctx context.Context, d Data) (*Task, error) {
+	if id := d.ID(); c.wip.contains(id) {
+		return nil, fmt.Errorf("task for %q is still in progress", id)
+	}
+
 	t := &Task{
 		data: d,
 		done: make(chan struct{}),
@@ -645,6 +652,13 @@ func (c *cache) put(t *Task) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.m[t.ID()] = t
+}
+
+func (c *cache) contains(k string) (ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok = c.m[k]
+	return
 }
 
 // walk calls f for every cache entry in keys.


### PR DESCRIPTION
This PR contains another round of bugfixes:

- Omit BM25 config from request entirely if not provided by the user
- Send data for user permissions under key `"users"` and not `"user"`
- Remove client-side validation for a filter with nil value to let the server resolve it
- Fix names for array data types
- Prevent `MoveAway.Objects` from overwriting `MoveTo.Objects`
- Prevent users from creating multiple batch tasks for the same object/reference