### PR TITLE
v6: Near Media queries

### DIFF
--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -983,6 +983,114 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 			},
 		},
 		{
+			name: "near image",
+			req: &api.SearchRequest{
+				NearMedia: &api.NearMedia{
+					Kind:  api.MediaImage,
+					Media: "base64-media",
+				},
+			},
+			want: &proto.SearchRequest{
+				NearImage: &proto.NearImageSearch{
+					Image: "base64-media",
+				},
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+			},
+		},
+		{
+			name: "near audio",
+			req: &api.SearchRequest{
+				NearMedia: &api.NearMedia{
+					Kind:  api.MediaAudio,
+					Media: "base64-media",
+				},
+			},
+			want: &proto.SearchRequest{
+				NearAudio: &proto.NearAudioSearch{
+					Audio: "base64-media",
+				},
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+			},
+		},
+		{
+			name: "near video",
+			req: &api.SearchRequest{
+				NearMedia: &api.NearMedia{
+					Kind:  api.MediaVideo,
+					Media: "base64-media",
+				},
+			},
+			want: &proto.SearchRequest{
+				NearVideo: &proto.NearVideoSearch{
+					Video: "base64-media",
+				},
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+			},
+		},
+		{
+			name: "near depth",
+			req: &api.SearchRequest{
+				NearMedia: &api.NearMedia{
+					Kind:  api.MediaDepth,
+					Media: "base64-media",
+				},
+			},
+			want: &proto.SearchRequest{
+				NearDepth: &proto.NearDepthSearch{
+					Depth: "base64-media",
+				},
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+			},
+		},
+		{
+			name: "near thermal",
+			req: &api.SearchRequest{
+				NearMedia: &api.NearMedia{
+					Kind:  api.MediaThermal,
+					Media: "base64-media",
+				},
+			},
+			want: &proto.SearchRequest{
+				NearThermal: &proto.NearThermalSearch{
+					Thermal: "base64-media",
+				},
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+			},
+		},
+		{
+			name: "near imu",
+			req: &api.SearchRequest{
+				NearMedia: &api.NearMedia{
+					Kind:  api.MediaIMU,
+					Media: "base64-media",
+				},
+			},
+			want: &proto.SearchRequest{
+				NearImu: &proto.NearIMUSearch{
+					Imu: "base64-media",
+				},
+				Metadata: &proto.MetadataRequest{Uuid: true},
+				Properties: &proto.PropertiesRequest{
+					ReturnAllNonrefProperties: true,
+				},
+			},
+		},
+		{
 			name: "near text move concepts",
 			req: &api.SearchRequest{
 				NearText: &api.NearText{

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -31,6 +31,7 @@ type SearchRequest struct {
 
 	NearVector *NearVector
 	NearText   *NearText
+	NearMedia  *NearMedia
 	BM25       *BM25
 	Hybrid     *Hybrid
 }
@@ -89,6 +90,12 @@ type (
 		Weight *float32
 	}
 	NearVector struct {
+		Target     SearchTarget
+		Similarity VectorSimilarity
+	}
+	NearMedia struct {
+		Media      string
+		Kind       MediaKind
 		Target     SearchTarget
 		Similarity VectorSimilarity
 	}
@@ -258,6 +265,17 @@ const (
 	HybridFusionRelativeScore = HybridFusion(proto.Hybrid_FUSION_TYPE_UNSPECIFIED)
 )
 
+type MediaKind int
+
+const (
+	MediaImage = iota
+	MediaVideo
+	MediaAudio
+	MediaDepth
+	MediaThermal
+	MediaIMU
+)
+
 func (r *SearchRequest) MarshalMessage() (*proto.SearchRequest, error) {
 	dev.AssertNotNil(r, "r")
 
@@ -305,6 +323,24 @@ func (r *SearchRequest) MarshalMessage() (*proto.SearchRequest, error) {
 		req.NearVector, err = marshalNearVector(r.NearVector)
 	case r.NearText != nil:
 		req.NearText, err = marshalNearText(r.NearText)
+	case r.NearMedia != nil:
+		var media any
+		media, err = marshalNearMedia(r.NearMedia)
+		switch media := media.(type) {
+		case nil:
+		case *proto.NearImageSearch:
+			req.NearImage = media
+		case *proto.NearAudioSearch:
+			req.NearAudio = media
+		case *proto.NearVideoSearch:
+			req.NearVideo = media
+		case *proto.NearDepthSearch:
+			req.NearDepth = media
+		case *proto.NearThermalSearch:
+			req.NearThermal = media
+		case *proto.NearIMUSearch:
+			req.NearImu = media
+		}
 	case r.BM25 != nil:
 		req.Bm25Search, err = marshalBM25(r.BM25)
 	case r.Hybrid != nil:
@@ -703,6 +739,7 @@ func marshalNearText(req *NearText) (*proto.NearTextSearch, error) {
 		Query:     req.Concepts,
 		Distance:  req.Similarity.Distance,
 		Certainty: req.Similarity.Certainty,
+		Targets:   marshalSearchTarget(req.Target),
 	}
 
 	if m := req.MoveTo; m != nil {
@@ -729,26 +766,6 @@ func marshalNearText(req *NearText) (*proto.NearTextSearch, error) {
 		}
 	}
 
-	if len(req.Target.Vectors) > 0 {
-		// Pre-allocate slices for targets. Do not allocate WeightsForTarget,
-		// as targets may have no weights.
-		nt.Targets = &proto.Targets{
-			TargetVectors: make([]string, len(req.Target.Vectors)),
-			Combination:   proto.CombinationMethod(req.Target.CombinationMethod),
-		}
-
-		for i, tv := range req.Target.Vectors {
-			nt.Targets.TargetVectors[i] = tv.Name
-			if tv.Weight != nil {
-				nt.Targets.WeightsForTargets = append(nt.Targets.WeightsForTargets,
-					&proto.WeightsForTarget{
-						Target: tv.Name,
-						Weight: *tv.Weight,
-					})
-			}
-		}
-	}
-
 	switch {
 	case req.Selection.MMR != nil:
 		mmr := req.Selection.MMR
@@ -763,6 +780,80 @@ func marshalNearText(req *NearText) (*proto.NearTextSearch, error) {
 	}
 
 	return nt, nil
+}
+
+func marshalSearchTarget(st SearchTarget) *proto.Targets {
+	if len(st.Vectors) == 0 {
+		return nil
+	}
+
+	// Pre-allocate slices for targets. Do not allocate WeightsForTarget,
+	// as targets may have no weights.
+	ts := &proto.Targets{
+		TargetVectors: make([]string, len(st.Vectors)),
+		Combination:   proto.CombinationMethod(st.CombinationMethod),
+	}
+
+	for i, tv := range st.Vectors {
+		ts.TargetVectors[i] = tv.Name
+		if tv.Weight != nil {
+			ts.WeightsForTargets = append(ts.WeightsForTargets,
+				&proto.WeightsForTarget{
+					Target: tv.Name,
+					Weight: *tv.Weight,
+				})
+		}
+	}
+	return ts
+}
+
+func marshalNearMedia(req *NearMedia) (any, error) {
+	dev.AssertNotNil(req, "req")
+	switch req.Kind {
+	case MediaImage:
+		return &proto.NearImageSearch{
+			Certainty: req.Similarity.Certainty,
+			Distance:  req.Similarity.Distance,
+			Targets:   marshalSearchTarget(req.Target),
+			Image:     req.Media,
+		}, nil
+	case MediaVideo:
+		return &proto.NearVideoSearch{
+			Certainty: req.Similarity.Certainty,
+			Distance:  req.Similarity.Distance,
+			Targets:   marshalSearchTarget(req.Target),
+			Video:     req.Media,
+		}, nil
+	case MediaAudio:
+		return &proto.NearAudioSearch{
+			Certainty: req.Similarity.Certainty,
+			Distance:  req.Similarity.Distance,
+			Targets:   marshalSearchTarget(req.Target),
+			Audio:     req.Media,
+		}, nil
+	case MediaDepth:
+		return &proto.NearDepthSearch{
+			Certainty: req.Similarity.Certainty,
+			Distance:  req.Similarity.Distance,
+			Targets:   marshalSearchTarget(req.Target),
+			Depth:     req.Media,
+		}, nil
+	case MediaThermal:
+		return &proto.NearThermalSearch{
+			Certainty: req.Similarity.Certainty,
+			Distance:  req.Similarity.Distance,
+			Targets:   marshalSearchTarget(req.Target),
+			Thermal:   req.Media,
+		}, nil
+	case MediaIMU:
+		return &proto.NearIMUSearch{
+			Certainty: req.Similarity.Certainty,
+			Distance:  req.Similarity.Distance,
+			Targets:   marshalSearchTarget(req.Target),
+			Imu:       req.Media,
+		}, nil
+	}
+	return nil, nil
 }
 
 func marshalBM25(req *BM25) (*proto.BM25, error) {

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -268,7 +268,8 @@ const (
 type MediaKind int
 
 const (
-	MediaImage = iota
+	_ = iota // none selected, to avoid confusing zero value with MediaImage
+	MediaImage
 	MediaVideo
 	MediaAudio
 	MediaDepth

--- a/query/client.go
+++ b/query/client.go
@@ -23,6 +23,7 @@ func NewClient(t internal.Transport, rd api.RequestDefaults) *Client {
 		defaults:   rd,
 		OverAll:    overAllFunc(t, rd),
 		NearVector: nearVectorFunc(t, rd),
+		NearMedia:  nearMediaFunc(t, rd),
 		NearText:   nearTextFunc(t, rd),
 		Hybrid:     hybridFunc(t, rd),
 		BM25:       bm25Func(t, rd),
@@ -35,6 +36,7 @@ type Client struct {
 
 	OverAll    OverAllFunc
 	NearVector NearVectorFunc
+	NearMedia  NearMediaFunc
 	NearText   NearTextFunc
 	Hybrid     HybridFunc
 	BM25       BM25Func

--- a/query/near_media.go
+++ b/query/near_media.go
@@ -95,19 +95,24 @@ func nearMediaFunc(t internal.Transport, rd api.RequestDefaults) NearMediaFunc {
 
 // nearMedia convers [NearMedia] to [api.NearMedia].
 func nearMedia(nm *NearMedia) *api.NearMedia {
-	if nm == nil || nm.Target == nil {
+	if nm == nil {
 		return nil
 	}
 
-	return &api.NearMedia{
-		Kind:   nm.Media.Kind(),
-		Media:  nm.Media.Data(),
-		Target: marshalSearchTarget(nm.Target),
+	out := &api.NearMedia{
+		Kind:  nm.Media.Kind(),
+		Media: nm.Media.Data(),
 		Similarity: api.VectorSimilarity{
 			Distance:  nm.Similarity.Distance(),
 			Certainty: nm.Similarity.Certainty(),
 		},
 	}
+
+	if nm.Target != nil {
+		out.Target = marshalSearchTarget(nm.Target)
+	}
+
+	return out
 }
 
 // GroupBy runs near vector search with a GroupBy clause.

--- a/query/near_media.go
+++ b/query/near_media.go
@@ -1,0 +1,116 @@
+package query
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/weaviate/weaviate-go-client/v6/internal"
+	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/query/filter"
+)
+
+type NearMedia struct {
+	Limit                  int              // Limit the number of results returned for the query.
+	Offset                 int              // Skip the first N objects in the collection.
+	AutoLimit              int              // Return objects in the first N similarity clusters.
+	After                  uuid.UUID        // Skip all objects before the one with this ID.
+	Filter                 filter.Expr      // Filter results based on their properties.
+	ReturnMetadata         ReturnMetadata   // Select query and object metadata to return for each object.
+	ReturnVectors          []string         // List vectors to return for each object in the result set.
+	ReturnReferences       []Reference      // Select reference properties to return.
+	ReturnNestedProperties []NestedProperty // Return object properties and a subset of their nested properties.
+
+	// Select a subset of properties to return. By default, all properties are returned.
+	// To not return any properties, initialize this value to an empty slice explicitly.
+	ReturnProperties []string
+
+	// Media is represented as a base64 string.
+	Media Media
+
+	// Target vector or a combination of multiple vector targets.
+	// By default, the resulting vectors are compared against the "default"
+	// vector, or the _only_ vector, if the collection only has a single vector index.
+	// See [MultiVectorTarget] for examples of providing multiple targets.
+	Target VectorTarget
+
+	// Similarity specifies a cutoff point for query results.
+	// Prefer expressing similarity in terms of vector distance, as that is a more conventional metric.
+	Similarity VectorSimilarity
+
+	// groupBy can only be set by [NearMediaFunc.GroupBy], as it changes the shape of the response.
+	groupBy *GroupBy
+}
+
+type Media struct {
+	data string
+	kind api.MediaKind
+}
+
+func (m Media) Kind() api.MediaKind { return m.kind }
+func (m Media) Data() string        { return m.data }
+
+// Image returns near image query target. The value must be a base64-encoded string.
+func Image(s string) Media { return Media{kind: api.MediaImage, data: s} }
+
+// Audio returns near audio query target. The value must be a base64-encoded string.
+func Audio(s string) Media { return Media{kind: api.MediaAudio, data: s} }
+
+// Video returns near video query target. The value must be a base64-encoded string.
+func Video(s string) Media { return Media{kind: api.MediaVideo, data: s} }
+
+// Depth returns near depth query target. The value must be a base64-encoded string.
+func Depth(s string) Media { return Media{kind: api.MediaDepth, data: s} }
+
+// Thermal returns near thermal query target. The value must be a base64-encoded string.
+func Thermal(s string) Media { return Media{kind: api.MediaThermal, data: s} }
+
+// IMU returns near IMU query target. The value must be a base64-encoded string.
+func IMU(s string) Media { return Media{kind: api.MediaIMU, data: s} }
+
+// NearMediaFunc runs plain near vector search.
+type NearMediaFunc func(context.Context, NearMedia) (*Result, error)
+
+// nearMediaFunc makes internal.Transport available to [query] via a closure.
+func nearMediaFunc(t internal.Transport, rd api.RequestDefaults) NearMediaFunc {
+	return func(ctx context.Context, nm NearMedia) (*Result, error) {
+		return query(ctx, t, request{
+			RequestDefaults:        rd,
+			Limit:                  int32(nm.Limit),
+			AutoLimit:              int32(nm.AutoLimit),
+			Offset:                 int32(nm.Offset),
+			After:                  nm.After,
+			Filter:                 nm.Filter,
+			ReturnVectors:          nm.ReturnVectors,
+			ReturnMetadata:         nm.ReturnMetadata,
+			ReturnProperties:       nm.ReturnProperties,
+			ReturnNestedProperties: nm.ReturnNestedProperties,
+			ReturnReferences:       nm.ReturnReferences,
+			GroupBy:                nm.groupBy,
+		}, func(req *api.SearchRequest) { req.NearMedia = nearMedia(&nm) })
+	}
+}
+
+// nearMedia convers [NearMedia] to [api.NearMedia].
+func nearMedia(nm *NearMedia) *api.NearMedia {
+	if nm == nil || nm.Target == nil {
+		return nil
+	}
+
+	return &api.NearMedia{
+		Kind:   nm.Media.Kind(),
+		Media:  nm.Media.Data(),
+		Target: marshalSearchTarget(nm.Target),
+		Similarity: api.VectorSimilarity{
+			Distance:  nm.Similarity.Distance(),
+			Certainty: nm.Similarity.Certainty(),
+		},
+	}
+}
+
+// GroupBy runs near vector search with a GroupBy clause.
+func (nmf NearMediaFunc) GroupBy(ctx context.Context, nv NearMedia, groupBy GroupBy) (*GroupByResult, error) {
+	nv.groupBy = &groupBy
+	return queryGroupBy(ctx, nmf, nv)
+}
+
+func (nm NearMedia) Search() *api.NearMedia { return nearMedia(&nm) }

--- a/query/near_media.go
+++ b/query/near_media.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate-go-client/v6/internal"
 	"github.com/weaviate/weaviate-go-client/v6/internal/api"
+	"github.com/weaviate/weaviate-go-client/v6/query/boost"
 	"github.com/weaviate/weaviate-go-client/v6/query/filter"
 )
 
@@ -15,6 +16,7 @@ type NearMedia struct {
 	AutoLimit              int              // Return objects in the first N similarity clusters.
 	After                  uuid.UUID        // Skip all objects before the one with this ID.
 	Filter                 filter.Expr      // Filter results based on their properties.
+	Boost                  boost.Expr       // Rerank search results using a decay function.
 	ReturnMetadata         ReturnMetadata   // Select query and object metadata to return for each object.
 	ReturnVectors          []string         // List vectors to return for each object in the result set.
 	ReturnReferences       []Reference      // Select reference properties to return.
@@ -80,6 +82,7 @@ func nearMediaFunc(t internal.Transport, rd api.RequestDefaults) NearMediaFunc {
 			Offset:                 int32(nm.Offset),
 			After:                  nm.After,
 			Filter:                 nm.Filter,
+			Boost:                  nm.Boost,
 			ReturnVectors:          nm.ReturnVectors,
 			ReturnMetadata:         nm.ReturnMetadata,
 			ReturnProperties:       nm.ReturnProperties,

--- a/query/near_media_test.go
+++ b/query/near_media_test.go
@@ -12,24 +12,30 @@ import (
 	"github.com/weaviate/weaviate-go-client/v6/types"
 )
 
-func TestKeywordSimilarity(t *testing.T) {
-	t.Run("all tokens match", func(t *testing.T) {
-		assert.True(t, query.AllTokensMatch.AllTokensMatch(), "all tokens match")
-		assert.Nil(t, query.AllTokensMatch.MinimumTokensMatch(), "minimum tokens match")
-	})
-	t.Run("all tokens match cross property", func(t *testing.T) {
-		assert.True(t, query.AllTokensMatchCross.AllTokensMatch(), "all tokens match")
-		assert.True(t, query.AllTokensMatchCross.CrossProperty(), "cross property")
-		assert.Nil(t, query.AllTokensMatchCross.MinimumTokensMatch(), "minimum tokens match")
-	})
-	t.Run("minimum tokens match", func(t *testing.T) {
-		similarity := query.MinimumTokensMatch(5)
-		assert.False(t, similarity.AllTokensMatch(), "all tokens match")
-		assert.NotNil(t, similarity.MinimumTokensMatch(), "minimum tokens match")
-	})
+func TestMedia(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		make func(string) query.Media
+		kind api.MediaKind
+	}{
+		{name: "image", make: query.Image, kind: api.MediaImage},
+		{name: "audio", make: query.Audio, kind: api.MediaAudio},
+		{name: "video", make: query.Video, kind: api.MediaVideo},
+		{name: "depth", make: query.Depth, kind: api.MediaDepth},
+		{name: "thermal", make: query.Thermal, kind: api.MediaThermal},
+		{name: "imu", make: query.IMU, kind: api.MediaIMU},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotNil(t, tt.make, "bad test: no make function")
+
+			media := tt.make("abc")
+			assert.Equal(t, tt.kind, media.Kind(), "media kind")
+			assert.Equal(t, "abc", media.Data(), "media data")
+		})
+	}
 }
 
-func TestBM25(t *testing.T) {
+func TestNearMedia(t *testing.T) {
 	rd := api.RequestDefaults{
 		CollectionName:   "Songs",
 		Tenant:           "john_doe",
@@ -40,28 +46,27 @@ func TestBM25(t *testing.T) {
 		testkit.Only
 
 		name  string
-		bm25  query.BM25
+		nm    query.NearMedia
 		stubs []testkit.Stub[api.SearchRequest, api.SearchResponse]
 		want  *query.Result // Expected return value.
 		err   testkit.Error
 	}{
 		{
 			name: "ok",
-			bm25: query.BM25{
-				Query:             "yellow submarine",
-				QueryProperties:   []string{"title", "lyrics"},
-				KeywordSimilarity: query.MinimumTokensMatch(3),
+			nm: query.NearMedia{
+				Media:  query.Image("hounds-mid-race=="),
+				Target: query.VectorName("album_cover_vec"),
 			},
 			stubs: []testkit.Stub[api.SearchRequest, api.SearchResponse]{
 				{
 					Request: &api.SearchRequest{
 						RequestDefaults: rd,
-						BM25: &api.BM25{
-							Query:           "yellow submarine",
-							QueryProperties: []string{"title", "lyrics"},
-							KeywordSimilarity: api.KeywordSimilarity{
-								MinimumTokensMatch: testkit.Ptr[int32](3),
-							},
+						NearMedia: &api.NearMedia{
+							Kind:  api.MediaImage,
+							Media: "hounds-mid-race==",
+							Target: api.SearchTarget{Vectors: []api.TargetVector{
+								{Vector: api.Vector{Name: "album_cover_vec"}},
+							}},
 						},
 					},
 					Response: api.SearchResponse{
@@ -71,10 +76,6 @@ func TestBM25(t *testing.T) {
 								Collection: "Songs",
 								Metadata: api.ObjectMetadata{
 									UUID: testkit.UUID,
-								},
-								Properties: map[string]any{
-									"title":        "Yellow Submarine",
-									"duration_sec": 160,
 								},
 							},
 						},
@@ -88,10 +89,6 @@ func TestBM25(t *testing.T) {
 						Object: types.Object[map[string]any]{
 							Collection: "Songs",
 							UUID:       testkit.UUID,
-							Properties: map[string]any{
-								"title":        "Yellow Submarine",
-								"duration_sec": 160,
-							},
 						},
 					},
 				},
@@ -111,8 +108,8 @@ func TestBM25(t *testing.T) {
 			c := query.NewClient(transport, rd)
 			require.NotNil(t, c, "client")
 
-			got, err := c.BM25(t.Context(), tt.bm25)
-			tt.err.Require(t, err, "bm25 query")
+			got, err := c.NearMedia(t.Context(), tt.nm)
+			tt.err.Require(t, err, "near media query")
 			require.EqualExportedValues(t, tt.want, got, "query result")
 		})
 	}

--- a/query/near_media_test.go
+++ b/query/near_media_test.go
@@ -52,7 +52,46 @@ func TestNearMedia(t *testing.T) {
 		err   testkit.Error
 	}{
 		{
-			name: "ok",
+			name: "default target",
+			nm: query.NearMedia{
+				Media: query.Image("hounds-mid-race=="),
+			},
+			stubs: []testkit.Stub[api.SearchRequest, api.SearchResponse]{
+				{
+					Request: &api.SearchRequest{
+						RequestDefaults: rd,
+						NearMedia: &api.NearMedia{
+							Kind:  api.MediaImage,
+							Media: "hounds-mid-race==",
+						},
+					},
+					Response: api.SearchResponse{
+						Took: 92 * time.Second,
+						Results: []api.Object{
+							{
+								Collection: "Songs",
+								Metadata: api.ObjectMetadata{
+									UUID: testkit.UUID,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &query.Result{
+				Took: 92 * time.Second,
+				Objects: []query.Object[map[string]any]{
+					{
+						Object: types.Object[map[string]any]{
+							Collection: "Songs",
+							UUID:       testkit.UUID,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "explicit target",
 			nm: query.NearMedia{
 				Media:  query.Image("hounds-mid-race=="),
 				Target: query.VectorName("album_cover_vec"),


### PR DESCRIPTION
This PR adds NearMedia queries for all supported media types: image, audio, video, depth, thermal, and IMU.

The API is intentionally minimal and simple, most notably lacking any helpers for converting `[]byte` or `io.Reader` into a base64-encoded string. Because:

1. The standard `encoding/base64` is already simple, accessible, and well-known.
2. We shouldn't provide an interface which _always base64-encodes the input_ as the user may way to search with an image property it just retrieved in a query.
3. We shouldn't proliferate trivial functions unnecessarily. `*`

Also, unlike other clients, Go client avoids declaring separate methods for each media type and provides dedicated "media" constructors with descriptive names.

```go
r, err := songs.Query.NearMedia(ctx, query.NearMedia{
  Media:  query.Image("base64-encoded-album-cover"),
  Target: query.VectorName("album_cover_vec"),
})
```

`*` - it's possible that `query.Image()` and co. are already excessive, let me know if you think that.