### PR TITLE
v6: return insert errors as an error value

### DIFF
--- a/data/client.go
+++ b/data/client.go
@@ -53,8 +53,15 @@ type Object struct {
 }
 
 type InsertResult struct {
-	Took   time.Duration
+	Took time.Duration
+}
+
+type InsertError struct {
 	Errors map[uuid.UUID]string
+}
+
+func (ie InsertError) Error() string {
+	return fmt.Sprintf("insert failed for %d objects", len(ie.Errors))
 }
 
 // Insert new objects into the collection.
@@ -77,18 +84,20 @@ func (c *Client) Insert(ctx context.Context, objects ...*Object) (*InsertResult,
 		return nil, fmt.Errorf("insert objects: %w", err)
 	}
 
-	dev.Assert(len(resp.Positions) == len(resp.Errors), "indices and errors not aligned")
+	r := &InsertResult{Took: resp.Took}
+	if len(resp.Errors) == 0 {
+		return r, nil
+	}
 
-	r := &InsertResult{
-		Took:   resp.Took,
+	dev.Assert(len(resp.Positions) == len(resp.Errors), "indices and errors not aligned")
+	err := InsertError{
 		Errors: internal.MakeMap[uuid.UUID, string](len(resp.Positions)),
 	}
-
 	for i, pos := range resp.Positions {
-		r.Errors[batch[pos].UUID] = resp.Errors[i]
+		err.Errors[batch[pos].UUID] = resp.Errors[i]
 	}
 
-	return r, nil
+	return r, err
 }
 
 // Replace object in the collection. The [Object.UUID] must be non-nil,

--- a/data/client_test.go
+++ b/data/client_test.go
@@ -106,9 +106,13 @@ func TestClient_Insert(t *testing.T) {
 			}},
 			want: &data.InsertResult{
 				Took: 92 * time.Second,
-				Errors: map[uuid.UUID]string{
-					testkit.UUID: "Whaam!",
-				},
+			},
+			err: func(tt assert.TestingT, err error, a ...any) bool {
+				var got data.InsertError
+				return assert.ErrorAs(t, err, &got) &&
+					assert.Equal(t, map[uuid.UUID]string{
+						testkit.UUID: "Whaam!",
+					}, got.Errors)
 			},
 		},
 		{


### PR DESCRIPTION
Something I felt the need for while migrating server's e2e tests to v6.
This makes error handling for insert that much more ergonomic and idiomatic.

I remember there being a issue in either Go client or the Java client repo (can't find it right now) saying how it's easy to forget to handle partial failure, because checking `err != nil` is not sufficient.

```go
r, err := songs.Data.Insert(Standoff, BlastFurnace)
if err != nil {
  // Handle transport error
}
if len(r.Errors) > 0 {
  // Handle insert errors
}
```

With this refactor the returned err is non-nil if an insert failed for any of the objects in the batch. The user can narrow the error to `data.InsertError` to get the error messages.

```go
r, err := songs.Data.Insert(Standoff, BlashFurnace)
if err != nil {
    var partial data.InsertError
    if errors.As(err, &partial) {
        for id, err := range partial.Errors {
            retryLater(id) // for example
        }
    }
    return err
}
// batch succeeded!
```