### PR TITLE
fix(graphql): correct panic error message typo in hybrid and nearvector builders

### DIFF
--- a/weaviate/graphql/bm25builder.go
+++ b/weaviate/graphql/bm25builder.go
@@ -40,7 +40,7 @@ func (b *BM25ArgumentBuilder) build() string {
 	if len(b.properties) > 0 {
 		propStr, err := json.Marshal(b.properties)
 		if err != nil {
-			panic(fmt.Errorf("failed to unmarshal bm25 properties: %s", err))
+			panic(fmt.Errorf("failed to marshal bm25 properties: %s", err))
 		}
 		clause = append(clause, fmt.Sprintf("properties: %v", string(propStr)))
 	}

--- a/weaviate/graphql/hybridbuilder.go
+++ b/weaviate/graphql/hybridbuilder.go
@@ -104,7 +104,7 @@ func (h *HybridArgumentBuilder) build() string {
 	if !h.isVectorEmpty(h.vector) {
 		vectorB, err := json.Marshal(h.vector)
 		if err != nil {
-			panic(fmt.Errorf("failed to unmarshal hybrid search vector: %s", err))
+			panic(fmt.Errorf("failed to marshal hybrid search vector: %s", err))
 		}
 		clause = append(clause, fmt.Sprintf("vector: %s", string(vectorB)))
 	}
@@ -118,7 +118,7 @@ func (h *HybridArgumentBuilder) build() string {
 	if len(h.properties) > 0 {
 		props, err := json.Marshal(h.properties)
 		if err != nil {
-			panic(fmt.Errorf("failed to unmarshal hybrid properties: %s", err))
+			panic(fmt.Errorf("failed to marshal hybrid properties: %s", err))
 		}
 		clause = append(clause, fmt.Sprintf("properties: %v", string(props)))
 	}

--- a/weaviate/graphql/nearvectorbuilder.go
+++ b/weaviate/graphql/nearvectorbuilder.go
@@ -102,7 +102,7 @@ func (b *NearVectorArgumentBuilder) build() string {
 	if !b.isVectorEmpty(b.vector) && len(b.vectorsPerTarget) == 0 {
 		vectorB, err := json.Marshal(b.vector)
 		if err != nil {
-			panic(fmt.Errorf("failed to unmarshal nearVector search vector: %s", err))
+			panic(fmt.Errorf("failed to marshal nearVector search vector: %s", err))
 		}
 		clause = append(clause, fmt.Sprintf("vector: %s", string(vectorB)))
 	}


### PR DESCRIPTION
This PR fixes a minor error message typo where panics produced during JSON encoding in HybridArgumentBuilder and NearVectorArgumentBuilder state failed to unmarshal instead of failed to marshal.