### PR TITLE
v6: Implement review feedback

### DIFF
--- a/collections/client_test.go
+++ b/collections/client_test.go
@@ -157,6 +157,9 @@ func TestClient_Create(t *testing.T) {
 						},
 					},
 					"audio_vec": {SkipDefaultCompression: true},
+					"cover_vec": {
+						Index: vectorindex.HFresh{},
+					},
 				},
 				Sharding: &collections.ShardingConfig{
 					DesiredCount:        3,
@@ -268,6 +271,12 @@ func TestClient_Create(t *testing.T) {
 									},
 								},
 								"audio_vec": {SkipDefaultCompression: true},
+								"cover_vec": {
+									Index: &api.Module{
+										Name: "hfresh",
+										Conf: map[string]any{},
+									},
+								},
 							},
 							Sharding: &api.ShardingConfig{
 								DesiredCount:        3,

--- a/collections/vectorindex/index.go
+++ b/collections/vectorindex/index.go
@@ -16,10 +16,10 @@ type Type string
 var _ internal.Module[Type] = (*HFresh)(nil)
 
 type HFresh struct {
-	Distance         Distance `json:"distance"`
-	MaxPostingSizeKB int      `json:"maxPostingSizeKB"`
-	ReplicaCount     int      `json:"replicas"`
-	SearchProbe      int      `json:"searchProbe"`
+	Distance         Distance `json:"distance,omitempty"`
+	MaxPostingSizeKB int      `json:"maxPostingSizeKB,omitempty"`
+	ReplicaCount     int      `json:"replicas,omitempty"`
+	SearchProbe      int      `json:"searchProbe,omitempty"`
 }
 
 func (HFresh) Name() Type { return "hfresh" }

--- a/internal/api/message_test.go
+++ b/internal/api/message_test.go
@@ -1091,6 +1091,17 @@ func TestSearchRequest_MarshalMessage(t *testing.T) {
 			},
 		},
 		{
+			name: "near media missing",
+			req: &api.SearchRequest{
+				NearMedia: &api.NearMedia{
+					Similarity: api.VectorSimilarity{
+						Distance: testkit.Ptr(.245),
+					},
+				},
+			},
+			err: testkit.ExpectError,
+		},
+		{
 			name: "near object",
 			req: &api.SearchRequest{
 				NearObject: &api.NearObject{

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -873,7 +873,7 @@ func marshalNearMedia(req *NearMedia) (any, error) {
 			Imu:       req.Media,
 		}, nil
 	}
-	return nil, nil
+	return nil, errors.New("missing media")
 }
 
 func marshalBM25(req *BM25) (*proto.BM25, error) {

--- a/internal/api/transport/transport.go
+++ b/internal/api/transport/transport.go
@@ -388,6 +388,15 @@ type KeepAlive struct {
 	//
 	// [gRPC connections]: https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md#basic-keepalive
 	Retry int
+
+	// If true, client sends keepalive pings even with no active RPCs. If false,
+	// when there are no active RPCs, Retry and Interval will be ignored and no
+	// keepalive pings will be sent.
+	//
+	// This setting is only relevant to gRPC connections and must be coordinated with the server.
+	// Unless it too has [keepalive.EnforcementPolicy.PermitWithoutStream] enabled, setting it to true
+	// in the client will result in server breaking the connection with GOAWAY via.
+	PermitWithoutStream bool
 }
 
 // If k is not nil, dialOptions returns non-nil configuration for
@@ -406,7 +415,7 @@ func (k *KeepAlive) dialOptions() (*net.KeepAliveConfig, *keepalive.ClientParame
 			Interval: interval,
 			Count:    retry,
 		}, &keepalive.ClientParameters{
-			PermitWithoutStream: true,
+			PermitWithoutStream: k.PermitWithoutStream,
 			Time:                idle,
 			Timeout:             interval * time.Duration(retry),
 		}

--- a/internal/api/transport/transport.go
+++ b/internal/api/transport/transport.go
@@ -330,9 +330,10 @@ func tokenKeepalive(ctx context.Context, src oauth2.TokenSource, tickFunc func(t
 		return
 	}
 
-	// When Expiry is zero, oauth2 will never refresh the token,
-	// so pre-empting it like this is not useful.
-	for t, err := src.Token(); err == nil && t != nil && !t.Expiry.IsZero(); t, err = src.Token() {
+	// When ExpiresIn is zero, oauth2 will never refresh the token,
+	// so pre-empting it like this is not useful. Expiry is an optional value
+	// and might not always be populated.
+	for t, err := src.Token(); err == nil && t != nil && t.ExpiresIn > 0; t, err = src.Token() {
 		select {
 		case <-ctx.Done():
 			return

--- a/internal/api/transport/transport_test.go
+++ b/internal/api/transport/transport_test.go
@@ -484,7 +484,7 @@ func TestKeepAlive(t *testing.T) {
 				Count:    minRetry,
 			},
 			gRPC: &keepalive.ClientParameters{
-				PermitWithoutStream: true,
+				PermitWithoutStream: false,
 				Time:                minIdle,
 				Timeout:             minInterval * time.Duration(minRetry),
 			},
@@ -503,7 +503,7 @@ func TestKeepAlive(t *testing.T) {
 				Count:    5,
 			},
 			gRPC: &keepalive.ClientParameters{
-				PermitWithoutStream: true,
+				PermitWithoutStream: false,
 				Time:                5 * time.Minute,
 				Timeout:             5 * 30 * time.Second,
 			},

--- a/modules/model2vec/module.go
+++ b/modules/model2vec/module.go
@@ -9,8 +9,8 @@ func init() {
 // Text2Vec is a vectorizer for text properties
 // based on the text2vec-model2vec module.
 type Text2Vec struct {
-	URL        string   `json:"inferenceURL"`
-	Properties []string `json:"properties"`
+	URL        string   `json:"inferenceURL,omitempty"`
+	Properties []string `json:"properties,omitempty"`
 }
 
 func (Text2Vec) Name() string { return "text2vec-model2vec" }

--- a/modules/register_test.go
+++ b/modules/register_test.go
@@ -36,6 +36,11 @@ func TestModules(t *testing.T) {
 			},
 		},
 		{
+			name:   "text2vec-model2vec",
+			module: model2vec.Text2Vec{},
+			conf:   map[string]any{},
+		},
+		{
 			name: "text2vec-weaviate",
 			module: weaviate.Text2Vec{
 				URL:        "example.com",
@@ -49,6 +54,11 @@ func TestModules(t *testing.T) {
 				"model":      "Snowflake/snowflake-arctic-embed-m-v1.5",
 				"dimensions": 92,
 			},
+		},
+		{
+			name:   "text2vec-weaviate",
+			module: weaviate.Text2Vec{},
+			conf:   map[string]any{},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/modules/weaviate/module.go
+++ b/modules/weaviate/module.go
@@ -9,10 +9,10 @@ func init() {
 // Text2Vec is a vectorizer for text properties
 // based on the text2vec-weaviate module.
 type Text2Vec struct {
-	URL        string   `json:"baseURL"`
-	Properties []string `json:"properties"`
-	Model      string   `json:"model"`
-	Dimensions int      `json:"dimensions"`
+	URL        string   `json:"baseURL,omitempty"`
+	Properties []string `json:"properties,omitempty"`
+	Model      string   `json:"model,omitempty"`
+	Dimensions int      `json:"dimensions,omitempty"`
 }
 
 func (Text2Vec) Name() string { return "text2vec-weaviate" }

--- a/query/boost/boost.go
+++ b/query/boost/boost.go
@@ -21,7 +21,6 @@ var _ Expr = (*Cond)(nil)
 
 func (c Cond) Expr() api.BoostExpr {
 	return api.BoostExpr{
-		Weight: c.Weight,
 		Conds: []api.BoostCond{
 			{
 				Func:   c.Func.Func(),

--- a/query/boost/boost_test.go
+++ b/query/boost/boost_test.go
@@ -34,7 +34,6 @@ func TestCond(t *testing.T) {
 				},
 			},
 			expr: api.BoostExpr{
-				Weight: 3,
 				Conds: []api.BoostCond{
 					{
 						Weight: 3,
@@ -66,7 +65,6 @@ func TestCond(t *testing.T) {
 				},
 			},
 			expr: api.BoostExpr{
-				Weight: 3,
 				Conds: []api.BoostCond{
 					{
 						Weight: 3,
@@ -94,7 +92,6 @@ func TestCond(t *testing.T) {
 				},
 			},
 			expr: api.BoostExpr{
-				Weight: 3,
 				Conds: []api.BoostCond{
 					{
 						Weight: 3,
@@ -121,7 +118,6 @@ func TestCond(t *testing.T) {
 				},
 			},
 			expr: api.BoostExpr{
-				Weight: 3,
 				Conds: []api.BoostCond{
 					{
 						Weight: 3,


### PR DESCRIPTION
This PR fixes some things found in the recent review of `beta.2`:

- `boost.Cond` no longer populates top-level "weight" parameter, which has different semantics and is meant to be used for blending.
- Fields in `internal.Module`-like structs now have `omitempty` directive in their JSON tag. (HFresh configuration, `model2vec` and `weaviate` vectorizers)
- Keepalive configuration exposes `PermitWithoutStream` parameter to avoid overloading gRPC servers which do not expect to be pinged in the idle state
- Avoid background refreshes for tokens which do not have `ExpiresIn` set, because it causes the goroutine to spin.